### PR TITLE
chore: expand operation coverage

### DIFF
--- a/src/services/accessanalyzer/index.ts
+++ b/src/services/accessanalyzer/index.ts
@@ -302,6 +302,118 @@ export declare class AccessAnalyzer extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createAnalyzer(
+    input: CreateAnalyzerRequest,
+  ): Effect.Effect<
+    CreateAnalyzerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createArchiveRule(
+    input: CreateArchiveRuleRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAnalyzer(
+    input: DeleteAnalyzerRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteArchiveRule(
+    input: DeleteArchiveRuleRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAnalyzer(
+    input: GetAnalyzerRequest,
+  ): Effect.Effect<
+    GetAnalyzerResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getArchiveRule(
+    input: GetArchiveRuleRequest,
+  ): Effect.Effect<
+    GetArchiveRuleResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAnalyzers(
+    input: ListAnalyzersRequest,
+  ): Effect.Effect<
+    ListAnalyzersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listArchiveRules(
+    input: ListArchiveRulesRequest,
+  ): Effect.Effect<
+    ListArchiveRulesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAnalyzer(
+    input: UpdateAnalyzerRequest,
+  ): Effect.Effect<
+    UpdateAnalyzerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateArchiveRule(
+    input: UpdateArchiveRuleRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Accessanalyzer extends AccessAnalyzer {}
@@ -1788,6 +1900,128 @@ export declare namespace ValidatePolicy {
   export type Error =
     | AccessDeniedException
     | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAnalyzer {
+  export type Input = CreateAnalyzerRequest;
+  export type Output = CreateAnalyzerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateArchiveRule {
+  export type Input = CreateArchiveRuleRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAnalyzer {
+  export type Input = DeleteAnalyzerRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteArchiveRule {
+  export type Input = DeleteArchiveRuleRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAnalyzer {
+  export type Input = GetAnalyzerRequest;
+  export type Output = GetAnalyzerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetArchiveRule {
+  export type Input = GetArchiveRuleRequest;
+  export type Output = GetArchiveRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAnalyzers {
+  export type Input = ListAnalyzersRequest;
+  export type Output = ListAnalyzersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListArchiveRules {
+  export type Input = ListArchiveRulesRequest;
+  export type Output = ListArchiveRulesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAnalyzer {
+  export type Input = UpdateAnalyzerRequest;
+  export type Output = UpdateAnalyzerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateArchiveRule {
+  export type Input = UpdateArchiveRuleRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/aiops/index.ts
+++ b/src/services/aiops/index.ts
@@ -39,6 +39,94 @@ export declare class AIOps extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createInvestigationGroup(
+    input: CreateInvestigationGroupInput,
+  ): Effect.Effect<
+    CreateInvestigationGroupOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteInvestigationGroup(
+    input: DeleteInvestigationGroupRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteInvestigationGroupPolicy(
+    input: DeleteInvestigationGroupPolicyRequest,
+  ): Effect.Effect<
+    DeleteInvestigationGroupPolicyOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getInvestigationGroup(
+    input: GetInvestigationGroupRequest,
+  ): Effect.Effect<
+    GetInvestigationGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getInvestigationGroupPolicy(
+    input: GetInvestigationGroupPolicyRequest,
+  ): Effect.Effect<
+    GetInvestigationGroupPolicyResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listInvestigationGroups(
+    input: ListInvestigationGroupsInput,
+  ): Effect.Effect<
+    ListInvestigationGroupsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  putInvestigationGroupPolicy(
+    input: PutInvestigationGroupPolicyRequest,
+  ): Effect.Effect<
+    PutInvestigationGroupPolicyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateInvestigationGroup(
+    input: UpdateInvestigationGroupRequest,
+  ): Effect.Effect<
+    UpdateInvestigationGroupOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Aiops extends AIOps {}
@@ -250,6 +338,102 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateInvestigationGroup {
+  export type Input = CreateInvestigationGroupInput;
+  export type Output = CreateInvestigationGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteInvestigationGroup {
+  export type Input = DeleteInvestigationGroupRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteInvestigationGroupPolicy {
+  export type Input = DeleteInvestigationGroupPolicyRequest;
+  export type Output = DeleteInvestigationGroupPolicyOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetInvestigationGroup {
+  export type Input = GetInvestigationGroupRequest;
+  export type Output = GetInvestigationGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetInvestigationGroupPolicy {
+  export type Input = GetInvestigationGroupPolicyRequest;
+  export type Output = GetInvestigationGroupPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListInvestigationGroups {
+  export type Input = ListInvestigationGroupsInput;
+  export type Output = ListInvestigationGroupsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace PutInvestigationGroupPolicy {
+  export type Input = PutInvestigationGroupPolicyRequest;
+  export type Output = PutInvestigationGroupPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateInvestigationGroup {
+  export type Input = UpdateInvestigationGroupRequest;
+  export type Output = UpdateInvestigationGroupOutput;
   export type Error =
     | AccessDeniedException
     | ConflictException

--- a/src/services/amp/index.ts
+++ b/src/services/amp/index.ts
@@ -45,6 +45,340 @@ export declare class amp extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createAlertManagerDefinition(
+    input: CreateAlertManagerDefinitionRequest,
+  ): Effect.Effect<
+    CreateAlertManagerDefinitionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createLoggingConfiguration(
+    input: CreateLoggingConfigurationRequest,
+  ): Effect.Effect<
+    CreateLoggingConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createQueryLoggingConfiguration(
+    input: CreateQueryLoggingConfigurationRequest,
+  ): Effect.Effect<
+    CreateQueryLoggingConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRuleGroupsNamespace(
+    input: CreateRuleGroupsNamespaceRequest,
+  ): Effect.Effect<
+    CreateRuleGroupsNamespaceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createScraper(
+    input: CreateScraperRequest,
+  ): Effect.Effect<
+    CreateScraperResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkspace(
+    input: CreateWorkspaceRequest,
+  ): Effect.Effect<
+    CreateWorkspaceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAlertManagerDefinition(
+    input: DeleteAlertManagerDefinitionRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteLoggingConfiguration(
+    input: DeleteLoggingConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteQueryLoggingConfiguration(
+    input: DeleteQueryLoggingConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRuleGroupsNamespace(
+    input: DeleteRuleGroupsNamespaceRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteScraper(
+    input: DeleteScraperRequest,
+  ): Effect.Effect<
+    DeleteScraperResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkspace(
+    input: DeleteWorkspaceRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeAlertManagerDefinition(
+    input: DescribeAlertManagerDefinitionRequest,
+  ): Effect.Effect<
+    DescribeAlertManagerDefinitionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeLoggingConfiguration(
+    input: DescribeLoggingConfigurationRequest,
+  ): Effect.Effect<
+    DescribeLoggingConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeQueryLoggingConfiguration(
+    input: DescribeQueryLoggingConfigurationRequest,
+  ): Effect.Effect<
+    DescribeQueryLoggingConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeRuleGroupsNamespace(
+    input: DescribeRuleGroupsNamespaceRequest,
+  ): Effect.Effect<
+    DescribeRuleGroupsNamespaceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeScraper(
+    input: DescribeScraperRequest,
+  ): Effect.Effect<
+    DescribeScraperResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeWorkspace(
+    input: DescribeWorkspaceRequest,
+  ): Effect.Effect<
+    DescribeWorkspaceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeWorkspaceConfiguration(
+    input: DescribeWorkspaceConfigurationRequest,
+  ): Effect.Effect<
+    DescribeWorkspaceConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRuleGroupsNamespaces(
+    input: ListRuleGroupsNamespacesRequest,
+  ): Effect.Effect<
+    ListRuleGroupsNamespacesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listScrapers(
+    input: ListScrapersRequest,
+  ): Effect.Effect<
+    ListScrapersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkspaces(
+    input: ListWorkspacesRequest,
+  ): Effect.Effect<
+    ListWorkspacesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putAlertManagerDefinition(
+    input: PutAlertManagerDefinitionRequest,
+  ): Effect.Effect<
+    PutAlertManagerDefinitionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putRuleGroupsNamespace(
+    input: PutRuleGroupsNamespaceRequest,
+  ): Effect.Effect<
+    PutRuleGroupsNamespaceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLoggingConfiguration(
+    input: UpdateLoggingConfigurationRequest,
+  ): Effect.Effect<
+    UpdateLoggingConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateQueryLoggingConfiguration(
+    input: UpdateQueryLoggingConfigurationRequest,
+  ): Effect.Effect<
+    UpdateQueryLoggingConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateScraper(
+    input: UpdateScraperRequest,
+  ): Effect.Effect<
+    UpdateScraperResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkspaceAlias(
+    input: UpdateWorkspaceAliasRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkspaceConfiguration(
+    input: UpdateWorkspaceConfigurationRequest,
+  ): Effect.Effect<
+    UpdateWorkspaceConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Amp extends amp {}
@@ -635,6 +969,369 @@ export declare namespace UntagResource {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAlertManagerDefinition {
+  export type Input = CreateAlertManagerDefinitionRequest;
+  export type Output = CreateAlertManagerDefinitionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateLoggingConfiguration {
+  export type Input = CreateLoggingConfigurationRequest;
+  export type Output = CreateLoggingConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateQueryLoggingConfiguration {
+  export type Input = CreateQueryLoggingConfigurationRequest;
+  export type Output = CreateQueryLoggingConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRuleGroupsNamespace {
+  export type Input = CreateRuleGroupsNamespaceRequest;
+  export type Output = CreateRuleGroupsNamespaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateScraper {
+  export type Input = CreateScraperRequest;
+  export type Output = CreateScraperResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkspace {
+  export type Input = CreateWorkspaceRequest;
+  export type Output = CreateWorkspaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAlertManagerDefinition {
+  export type Input = DeleteAlertManagerDefinitionRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLoggingConfiguration {
+  export type Input = DeleteLoggingConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteQueryLoggingConfiguration {
+  export type Input = DeleteQueryLoggingConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRuleGroupsNamespace {
+  export type Input = DeleteRuleGroupsNamespaceRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteScraper {
+  export type Input = DeleteScraperRequest;
+  export type Output = DeleteScraperResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkspace {
+  export type Input = DeleteWorkspaceRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeAlertManagerDefinition {
+  export type Input = DescribeAlertManagerDefinitionRequest;
+  export type Output = DescribeAlertManagerDefinitionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeLoggingConfiguration {
+  export type Input = DescribeLoggingConfigurationRequest;
+  export type Output = DescribeLoggingConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeQueryLoggingConfiguration {
+  export type Input = DescribeQueryLoggingConfigurationRequest;
+  export type Output = DescribeQueryLoggingConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeRuleGroupsNamespace {
+  export type Input = DescribeRuleGroupsNamespaceRequest;
+  export type Output = DescribeRuleGroupsNamespaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeScraper {
+  export type Input = DescribeScraperRequest;
+  export type Output = DescribeScraperResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeWorkspace {
+  export type Input = DescribeWorkspaceRequest;
+  export type Output = DescribeWorkspaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeWorkspaceConfiguration {
+  export type Input = DescribeWorkspaceConfigurationRequest;
+  export type Output = DescribeWorkspaceConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRuleGroupsNamespaces {
+  export type Input = ListRuleGroupsNamespacesRequest;
+  export type Output = ListRuleGroupsNamespacesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListScrapers {
+  export type Input = ListScrapersRequest;
+  export type Output = ListScrapersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkspaces {
+  export type Input = ListWorkspacesRequest;
+  export type Output = ListWorkspacesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutAlertManagerDefinition {
+  export type Input = PutAlertManagerDefinitionRequest;
+  export type Output = PutAlertManagerDefinitionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutRuleGroupsNamespace {
+  export type Input = PutRuleGroupsNamespaceRequest;
+  export type Output = PutRuleGroupsNamespaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLoggingConfiguration {
+  export type Input = UpdateLoggingConfigurationRequest;
+  export type Output = UpdateLoggingConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateQueryLoggingConfiguration {
+  export type Input = UpdateQueryLoggingConfigurationRequest;
+  export type Output = UpdateQueryLoggingConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateScraper {
+  export type Input = UpdateScraperRequest;
+  export type Output = UpdateScraperResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkspaceAlias {
+  export type Input = UpdateWorkspaceAliasRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkspaceConfiguration {
+  export type Input = UpdateWorkspaceConfigurationRequest;
+  export type Output = UpdateWorkspaceConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/amplifyuibuilder/index.ts
+++ b/src/services/amplifyuibuilder/index.ts
@@ -60,6 +60,181 @@ export declare class AmplifyUIBuilder extends AWSServiceClient {
     | UnauthorizedException
     | CommonAwsError
   >;
+  createComponent(
+    input: CreateComponentRequest,
+  ): Effect.Effect<
+    CreateComponentResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  createForm(
+    input: CreateFormRequest,
+  ): Effect.Effect<
+    CreateFormResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  createTheme(
+    input: CreateThemeRequest,
+  ): Effect.Effect<
+    CreateThemeResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  deleteComponent(
+    input: DeleteComponentRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  deleteForm(
+    input: DeleteFormRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  deleteTheme(
+    input: DeleteThemeRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  exportComponents(
+    input: ExportComponentsRequest,
+  ): Effect.Effect<
+    ExportComponentsResponse,
+    InternalServerException | InvalidParameterException | CommonAwsError
+  >;
+  exportForms(
+    input: ExportFormsRequest,
+  ): Effect.Effect<
+    ExportFormsResponse,
+    InternalServerException | InvalidParameterException | CommonAwsError
+  >;
+  exportThemes(
+    input: ExportThemesRequest,
+  ): Effect.Effect<
+    ExportThemesResponse,
+    InternalServerException | InvalidParameterException | CommonAwsError
+  >;
+  getCodegenJob(
+    input: GetCodegenJobRequest,
+  ): Effect.Effect<
+    GetCodegenJobResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getComponent(
+    input: GetComponentRequest,
+  ): Effect.Effect<
+    GetComponentResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  getForm(
+    input: GetFormRequest,
+  ): Effect.Effect<
+    GetFormResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  getTheme(
+    input: GetThemeRequest,
+  ): Effect.Effect<
+    GetThemeResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  listCodegenJobs(
+    input: ListCodegenJobsRequest,
+  ): Effect.Effect<
+    ListCodegenJobsResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  listComponents(
+    input: ListComponentsRequest,
+  ): Effect.Effect<
+    ListComponentsResponse,
+    InternalServerException | InvalidParameterException | CommonAwsError
+  >;
+  listForms(
+    input: ListFormsRequest,
+  ): Effect.Effect<
+    ListFormsResponse,
+    InternalServerException | InvalidParameterException | CommonAwsError
+  >;
+  listThemes(
+    input: ListThemesRequest,
+  ): Effect.Effect<
+    ListThemesResponse,
+    InternalServerException | InvalidParameterException | CommonAwsError
+  >;
+  startCodegenJob(
+    input: StartCodegenJobRequest,
+  ): Effect.Effect<
+    StartCodegenJobResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateComponent(
+    input: UpdateComponentRequest,
+  ): Effect.Effect<
+    UpdateComponentResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | CommonAwsError
+  >;
+  updateForm(
+    input: UpdateFormRequest,
+  ): Effect.Effect<
+    UpdateFormResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | CommonAwsError
+  >;
+  updateTheme(
+    input: UpdateThemeRequest,
+  ): Effect.Effect<
+    UpdateThemeResponse,
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | CommonAwsError
+  >;
 }
 
 export declare class Amplifyuibuilder extends AmplifyUIBuilder {}
@@ -978,5 +1153,213 @@ export declare namespace UntagResource {
     | ResourceNotFoundException
     | ThrottlingException
     | UnauthorizedException
+    | CommonAwsError;
+}
+
+export declare namespace CreateComponent {
+  export type Input = CreateComponentRequest;
+  export type Output = CreateComponentResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace CreateForm {
+  export type Input = CreateFormRequest;
+  export type Output = CreateFormResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTheme {
+  export type Input = CreateThemeRequest;
+  export type Output = CreateThemeResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteComponent {
+  export type Input = DeleteComponentRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteForm {
+  export type Input = DeleteFormRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTheme {
+  export type Input = DeleteThemeRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ExportComponents {
+  export type Input = ExportComponentsRequest;
+  export type Output = ExportComponentsResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | CommonAwsError;
+}
+
+export declare namespace ExportForms {
+  export type Input = ExportFormsRequest;
+  export type Output = ExportFormsResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | CommonAwsError;
+}
+
+export declare namespace ExportThemes {
+  export type Input = ExportThemesRequest;
+  export type Output = ExportThemesResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | CommonAwsError;
+}
+
+export declare namespace GetCodegenJob {
+  export type Input = GetCodegenJobRequest;
+  export type Output = GetCodegenJobResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetComponent {
+  export type Input = GetComponentRequest;
+  export type Output = GetComponentResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetForm {
+  export type Input = GetFormRequest;
+  export type Output = GetFormResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetTheme {
+  export type Input = GetThemeRequest;
+  export type Output = GetThemeResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListCodegenJobs {
+  export type Input = ListCodegenJobsRequest;
+  export type Output = ListCodegenJobsResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace ListComponents {
+  export type Input = ListComponentsRequest;
+  export type Output = ListComponentsResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | CommonAwsError;
+}
+
+export declare namespace ListForms {
+  export type Input = ListFormsRequest;
+  export type Output = ListFormsResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | CommonAwsError;
+}
+
+export declare namespace ListThemes {
+  export type Input = ListThemesRequest;
+  export type Output = ListThemesResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | CommonAwsError;
+}
+
+export declare namespace StartCodegenJob {
+  export type Input = StartCodegenJobRequest;
+  export type Output = StartCodegenJobResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateComponent {
+  export type Input = UpdateComponentRequest;
+  export type Output = UpdateComponentResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateForm {
+  export type Input = UpdateFormRequest;
+  export type Output = UpdateFormResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTheme {
+  export type Input = UpdateThemeRequest;
+  export type Output = UpdateThemeResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidParameterException
+    | ResourceConflictException
     | CommonAwsError;
 }

--- a/src/services/app-mesh/index.ts
+++ b/src/services/app-mesh/index.ts
@@ -40,6 +40,460 @@ export declare class AppMesh extends AWSServiceClient {
     | TooManyRequestsException
     | CommonAwsError
   >;
+  createGatewayRoute(
+    input: CreateGatewayRouteInput,
+  ): Effect.Effect<
+    CreateGatewayRouteOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createMesh(
+    input: CreateMeshInput,
+  ): Effect.Effect<
+    CreateMeshOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createRoute(
+    input: CreateRouteInput,
+  ): Effect.Effect<
+    CreateRouteOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createVirtualGateway(
+    input: CreateVirtualGatewayInput,
+  ): Effect.Effect<
+    CreateVirtualGatewayOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createVirtualNode(
+    input: CreateVirtualNodeInput,
+  ): Effect.Effect<
+    CreateVirtualNodeOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createVirtualRouter(
+    input: CreateVirtualRouterInput,
+  ): Effect.Effect<
+    CreateVirtualRouterOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createVirtualService(
+    input: CreateVirtualServiceInput,
+  ): Effect.Effect<
+    CreateVirtualServiceOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteGatewayRoute(
+    input: DeleteGatewayRouteInput,
+  ): Effect.Effect<
+    DeleteGatewayRouteOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteMesh(
+    input: DeleteMeshInput,
+  ): Effect.Effect<
+    DeleteMeshOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteRoute(
+    input: DeleteRouteInput,
+  ): Effect.Effect<
+    DeleteRouteOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteVirtualGateway(
+    input: DeleteVirtualGatewayInput,
+  ): Effect.Effect<
+    DeleteVirtualGatewayOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteVirtualNode(
+    input: DeleteVirtualNodeInput,
+  ): Effect.Effect<
+    DeleteVirtualNodeOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteVirtualRouter(
+    input: DeleteVirtualRouterInput,
+  ): Effect.Effect<
+    DeleteVirtualRouterOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteVirtualService(
+    input: DeleteVirtualServiceInput,
+  ): Effect.Effect<
+    DeleteVirtualServiceOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeGatewayRoute(
+    input: DescribeGatewayRouteInput,
+  ): Effect.Effect<
+    DescribeGatewayRouteOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeMesh(
+    input: DescribeMeshInput,
+  ): Effect.Effect<
+    DescribeMeshOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeRoute(
+    input: DescribeRouteInput,
+  ): Effect.Effect<
+    DescribeRouteOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeVirtualGateway(
+    input: DescribeVirtualGatewayInput,
+  ): Effect.Effect<
+    DescribeVirtualGatewayOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeVirtualNode(
+    input: DescribeVirtualNodeInput,
+  ): Effect.Effect<
+    DescribeVirtualNodeOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeVirtualRouter(
+    input: DescribeVirtualRouterInput,
+  ): Effect.Effect<
+    DescribeVirtualRouterOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeVirtualService(
+    input: DescribeVirtualServiceInput,
+  ): Effect.Effect<
+    DescribeVirtualServiceOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listGatewayRoutes(
+    input: ListGatewayRoutesInput,
+  ): Effect.Effect<
+    ListGatewayRoutesOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listMeshes(
+    input: ListMeshesInput,
+  ): Effect.Effect<
+    ListMeshesOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listRoutes(
+    input: ListRoutesInput,
+  ): Effect.Effect<
+    ListRoutesOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listVirtualGateways(
+    input: ListVirtualGatewaysInput,
+  ): Effect.Effect<
+    ListVirtualGatewaysOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listVirtualNodes(
+    input: ListVirtualNodesInput,
+  ): Effect.Effect<
+    ListVirtualNodesOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listVirtualRouters(
+    input: ListVirtualRoutersInput,
+  ): Effect.Effect<
+    ListVirtualRoutersOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listVirtualServices(
+    input: ListVirtualServicesInput,
+  ): Effect.Effect<
+    ListVirtualServicesOutput,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateGatewayRoute(
+    input: UpdateGatewayRouteInput,
+  ): Effect.Effect<
+    UpdateGatewayRouteOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateMesh(
+    input: UpdateMeshInput,
+  ): Effect.Effect<
+    UpdateMeshOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateRoute(
+    input: UpdateRouteInput,
+  ): Effect.Effect<
+    UpdateRouteOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateVirtualGateway(
+    input: UpdateVirtualGatewayInput,
+  ): Effect.Effect<
+    UpdateVirtualGatewayOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateVirtualNode(
+    input: UpdateVirtualNodeInput,
+  ): Effect.Effect<
+    UpdateVirtualNodeOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateVirtualRouter(
+    input: UpdateVirtualRouterInput,
+  ): Effect.Effect<
+    UpdateVirtualRouterOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateVirtualService(
+    input: UpdateVirtualServiceInput,
+  ): Effect.Effect<
+    UpdateVirtualServiceOutput,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
 }
 
 interface _AccessLog {
@@ -1443,6 +1897,495 @@ export declare namespace UntagResource {
     | BadRequestException
     | ForbiddenException
     | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGatewayRoute {
+  export type Input = CreateGatewayRouteInput;
+  export type Output = CreateGatewayRouteOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMesh {
+  export type Input = CreateMeshInput;
+  export type Output = CreateMeshOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRoute {
+  export type Input = CreateRouteInput;
+  export type Output = CreateRouteOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateVirtualGateway {
+  export type Input = CreateVirtualGatewayInput;
+  export type Output = CreateVirtualGatewayOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateVirtualNode {
+  export type Input = CreateVirtualNodeInput;
+  export type Output = CreateVirtualNodeOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateVirtualRouter {
+  export type Input = CreateVirtualRouterInput;
+  export type Output = CreateVirtualRouterOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateVirtualService {
+  export type Input = CreateVirtualServiceInput;
+  export type Output = CreateVirtualServiceOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGatewayRoute {
+  export type Input = DeleteGatewayRouteInput;
+  export type Output = DeleteGatewayRouteOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMesh {
+  export type Input = DeleteMeshInput;
+  export type Output = DeleteMeshOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRoute {
+  export type Input = DeleteRouteInput;
+  export type Output = DeleteRouteOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVirtualGateway {
+  export type Input = DeleteVirtualGatewayInput;
+  export type Output = DeleteVirtualGatewayOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVirtualNode {
+  export type Input = DeleteVirtualNodeInput;
+  export type Output = DeleteVirtualNodeOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVirtualRouter {
+  export type Input = DeleteVirtualRouterInput;
+  export type Output = DeleteVirtualRouterOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVirtualService {
+  export type Input = DeleteVirtualServiceInput;
+  export type Output = DeleteVirtualServiceOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ResourceInUseException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeGatewayRoute {
+  export type Input = DescribeGatewayRouteInput;
+  export type Output = DescribeGatewayRouteOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeMesh {
+  export type Input = DescribeMeshInput;
+  export type Output = DescribeMeshOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeRoute {
+  export type Input = DescribeRouteInput;
+  export type Output = DescribeRouteOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeVirtualGateway {
+  export type Input = DescribeVirtualGatewayInput;
+  export type Output = DescribeVirtualGatewayOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeVirtualNode {
+  export type Input = DescribeVirtualNodeInput;
+  export type Output = DescribeVirtualNodeOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeVirtualRouter {
+  export type Input = DescribeVirtualRouterInput;
+  export type Output = DescribeVirtualRouterOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeVirtualService {
+  export type Input = DescribeVirtualServiceInput;
+  export type Output = DescribeVirtualServiceOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListGatewayRoutes {
+  export type Input = ListGatewayRoutesInput;
+  export type Output = ListGatewayRoutesOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListMeshes {
+  export type Input = ListMeshesInput;
+  export type Output = ListMeshesOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListRoutes {
+  export type Input = ListRoutesInput;
+  export type Output = ListRoutesOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListVirtualGateways {
+  export type Input = ListVirtualGatewaysInput;
+  export type Output = ListVirtualGatewaysOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListVirtualNodes {
+  export type Input = ListVirtualNodesInput;
+  export type Output = ListVirtualNodesOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListVirtualRouters {
+  export type Input = ListVirtualRoutersInput;
+  export type Output = ListVirtualRoutersOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListVirtualServices {
+  export type Input = ListVirtualServicesInput;
+  export type Output = ListVirtualServicesOutput;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGatewayRoute {
+  export type Input = UpdateGatewayRouteInput;
+  export type Output = UpdateGatewayRouteOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMesh {
+  export type Input = UpdateMeshInput;
+  export type Output = UpdateMeshOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRoute {
+  export type Input = UpdateRouteInput;
+  export type Output = UpdateRouteOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateVirtualGateway {
+  export type Input = UpdateVirtualGatewayInput;
+  export type Output = UpdateVirtualGatewayOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateVirtualNode {
+  export type Input = UpdateVirtualNodeInput;
+  export type Output = UpdateVirtualNodeOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateVirtualRouter {
+  export type Input = UpdateVirtualRouterInput;
+  export type Output = UpdateVirtualRouterOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateVirtualService {
+  export type Input = UpdateVirtualServiceInput;
+  export type Output = UpdateVirtualServiceOutput;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | LimitExceededException
     | NotFoundException
     | ServiceUnavailableException
     | TooManyRequestsException

--- a/src/services/appconfigdata/index.ts
+++ b/src/services/appconfigdata/index.ts
@@ -13,6 +13,16 @@ export declare class AppConfigData extends AWSServiceClient {
     | ThrottlingException
     | CommonAwsError
   >;
+  startConfigurationSession(
+    input: StartConfigurationSessionRequest,
+  ): Effect.Effect<
+    StartConfigurationSessionResponse,
+    | BadRequestException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
 }
 
 export declare class Appconfigdata extends AppConfigData {}
@@ -95,6 +105,17 @@ export type Token = string;
 export declare namespace GetLatestConfiguration {
   export type Input = GetLatestConfigurationRequest;
   export type Output = GetLatestConfigurationResponse;
+  export type Error =
+    | BadRequestException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace StartConfigurationSession {
+  export type Input = StartConfigurationSessionRequest;
+  export type Output = StartConfigurationSessionResponse;
   export type Error =
     | BadRequestException
     | InternalServerException

--- a/src/services/application-signals/index.ts
+++ b/src/services/application-signals/index.ts
@@ -87,6 +87,50 @@ export declare class ApplicationSignals extends AWSServiceClient {
     UntagResourceResponse,
     ResourceNotFoundException | ThrottlingException | CommonAwsError
   >;
+  createServiceLevelObjective(
+    input: CreateServiceLevelObjectiveInput,
+  ): Effect.Effect<
+    CreateServiceLevelObjectiveOutput,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServiceLevelObjective(
+    input: DeleteServiceLevelObjectiveInput,
+  ): Effect.Effect<
+    DeleteServiceLevelObjectiveOutput,
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceLevelObjective(
+    input: GetServiceLevelObjectiveInput,
+  ): Effect.Effect<
+    GetServiceLevelObjectiveOutput,
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceLevelObjectives(
+    input: ListServiceLevelObjectivesInput,
+  ): Effect.Effect<
+    ListServiceLevelObjectivesOutput,
+    ThrottlingException | ValidationException | CommonAwsError
+  >;
+  updateServiceLevelObjective(
+    input: UpdateServiceLevelObjectiveInput,
+  ): Effect.Effect<
+    UpdateServiceLevelObjectiveOutput,
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -782,5 +826,56 @@ export declare namespace UntagResource {
   export type Error =
     | ResourceNotFoundException
     | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceLevelObjective {
+  export type Input = CreateServiceLevelObjectiveInput;
+  export type Output = CreateServiceLevelObjectiveOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServiceLevelObjective {
+  export type Input = DeleteServiceLevelObjectiveInput;
+  export type Output = DeleteServiceLevelObjectiveOutput;
+  export type Error =
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceLevelObjective {
+  export type Input = GetServiceLevelObjectiveInput;
+  export type Output = GetServiceLevelObjectiveOutput;
+  export type Error =
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceLevelObjectives {
+  export type Input = ListServiceLevelObjectivesInput;
+  export type Output = ListServiceLevelObjectivesOutput;
+  export type Error =
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServiceLevelObjective {
+  export type Input = UpdateServiceLevelObjectiveInput;
+  export type Output = UpdateServiceLevelObjectiveOutput;
+  export type Error =
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
     | CommonAwsError;
 }

--- a/src/services/apptest/index.ts
+++ b/src/services/apptest/index.ts
@@ -37,6 +37,248 @@ export declare class AppTest extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createTestCase(
+    input: CreateTestCaseRequest,
+  ): Effect.Effect<
+    CreateTestCaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTestConfiguration(
+    input: CreateTestConfigurationRequest,
+  ): Effect.Effect<
+    CreateTestConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTestSuite(
+    input: CreateTestSuiteRequest,
+  ): Effect.Effect<
+    CreateTestSuiteResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTestCase(
+    input: DeleteTestCaseRequest,
+  ): Effect.Effect<
+    DeleteTestCaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTestConfiguration(
+    input: DeleteTestConfigurationRequest,
+  ): Effect.Effect<
+    DeleteTestConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTestRun(
+    input: DeleteTestRunRequest,
+  ): Effect.Effect<
+    DeleteTestRunResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTestSuite(
+    input: DeleteTestSuiteRequest,
+  ): Effect.Effect<
+    DeleteTestSuiteResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTestCase(
+    input: GetTestCaseRequest,
+  ): Effect.Effect<
+    GetTestCaseResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTestConfiguration(
+    input: GetTestConfigurationRequest,
+  ): Effect.Effect<
+    GetTestConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTestRunStep(
+    input: GetTestRunStepRequest,
+  ): Effect.Effect<
+    GetTestRunStepResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTestSuite(
+    input: GetTestSuiteRequest,
+  ): Effect.Effect<
+    GetTestSuiteResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTestCases(
+    input: ListTestCasesRequest,
+  ): Effect.Effect<
+    ListTestCasesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTestConfigurations(
+    input: ListTestConfigurationsRequest,
+  ): Effect.Effect<
+    ListTestConfigurationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTestRunSteps(
+    input: ListTestRunStepsRequest,
+  ): Effect.Effect<
+    ListTestRunStepsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTestRunTestCases(
+    input: ListTestRunTestCasesRequest,
+  ): Effect.Effect<
+    ListTestRunTestCasesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTestRuns(
+    input: ListTestRunsRequest,
+  ): Effect.Effect<
+    ListTestRunsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTestSuites(
+    input: ListTestSuitesRequest,
+  ): Effect.Effect<
+    ListTestSuitesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startTestRun(
+    input: StartTestRunRequest,
+  ): Effect.Effect<
+    StartTestRunResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTestCase(
+    input: UpdateTestCaseRequest,
+  ): Effect.Effect<
+    UpdateTestCaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTestConfiguration(
+    input: UpdateTestConfigurationRequest,
+  ): Effect.Effect<
+    UpdateTestConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTestSuite(
+    input: UpdateTestSuiteRequest,
+  ): Effect.Effect<
+    UpdateTestSuiteResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Apptest extends AppTest {}
@@ -883,6 +1125,269 @@ export declare namespace UntagResource {
   export type Output = UntagResourceResponse;
   export type Error =
     | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTestCase {
+  export type Input = CreateTestCaseRequest;
+  export type Output = CreateTestCaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTestConfiguration {
+  export type Input = CreateTestConfigurationRequest;
+  export type Output = CreateTestConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTestSuite {
+  export type Input = CreateTestSuiteRequest;
+  export type Output = CreateTestSuiteResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTestCase {
+  export type Input = DeleteTestCaseRequest;
+  export type Output = DeleteTestCaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTestConfiguration {
+  export type Input = DeleteTestConfigurationRequest;
+  export type Output = DeleteTestConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTestRun {
+  export type Input = DeleteTestRunRequest;
+  export type Output = DeleteTestRunResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTestSuite {
+  export type Input = DeleteTestSuiteRequest;
+  export type Output = DeleteTestSuiteResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTestCase {
+  export type Input = GetTestCaseRequest;
+  export type Output = GetTestCaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTestConfiguration {
+  export type Input = GetTestConfigurationRequest;
+  export type Output = GetTestConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTestRunStep {
+  export type Input = GetTestRunStepRequest;
+  export type Output = GetTestRunStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTestSuite {
+  export type Input = GetTestSuiteRequest;
+  export type Output = GetTestSuiteResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTestCases {
+  export type Input = ListTestCasesRequest;
+  export type Output = ListTestCasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTestConfigurations {
+  export type Input = ListTestConfigurationsRequest;
+  export type Output = ListTestConfigurationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTestRunSteps {
+  export type Input = ListTestRunStepsRequest;
+  export type Output = ListTestRunStepsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTestRunTestCases {
+  export type Input = ListTestRunTestCasesRequest;
+  export type Output = ListTestRunTestCasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTestRuns {
+  export type Input = ListTestRunsRequest;
+  export type Output = ListTestRunsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTestSuites {
+  export type Input = ListTestSuitesRequest;
+  export type Output = ListTestSuitesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartTestRun {
+  export type Input = StartTestRunRequest;
+  export type Output = StartTestRunResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTestCase {
+  export type Input = UpdateTestCaseRequest;
+  export type Output = UpdateTestCaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTestConfiguration {
+  export type Input = UpdateTestConfigurationRequest;
+  export type Output = UpdateTestConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTestSuite {
+  export type Input = UpdateTestSuiteRequest;
+  export type Output = UpdateTestSuiteResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/arc-region-switch/index.ts
+++ b/src/services/arc-region-switch/index.ts
@@ -85,6 +85,45 @@ export declare class ARCRegionswitch extends AWSServiceClient {
     UpdatePlanExecutionStepResponse,
     AccessDeniedException | ResourceNotFoundException | CommonAwsError
   >;
+  createPlan(
+    input: CreatePlanRequest,
+  ): Effect.Effect<CreatePlanResponse, CommonAwsError>;
+  deletePlan(
+    input: DeletePlanRequest,
+  ): Effect.Effect<
+    DeletePlanResponse,
+    IllegalStateException | ResourceNotFoundException | CommonAwsError
+  >;
+  getPlan(
+    input: GetPlanRequest,
+  ): Effect.Effect<GetPlanResponse, ResourceNotFoundException | CommonAwsError>;
+  listPlans(
+    input: ListPlansRequest,
+  ): Effect.Effect<ListPlansResponse, CommonAwsError>;
+  listTagsForResource(
+    input: ListTagsForResourceRequest,
+  ): Effect.Effect<
+    ListTagsForResourceResponse,
+    InternalServerException | ResourceNotFoundException | CommonAwsError
+  >;
+  tagResource(
+    input: TagResourceRequest,
+  ): Effect.Effect<
+    TagResourceResponse,
+    InternalServerException | ResourceNotFoundException | CommonAwsError
+  >;
+  untagResource(
+    input: UntagResourceRequest,
+  ): Effect.Effect<
+    UntagResourceResponse,
+    InternalServerException | ResourceNotFoundException | CommonAwsError
+  >;
+  updatePlan(
+    input: UpdatePlanRequest,
+  ): Effect.Effect<
+    UpdatePlanResponse,
+    ResourceNotFoundException | CommonAwsError
+  >;
 }
 
 export interface AbbreviatedExecution {
@@ -866,4 +905,64 @@ export declare namespace UpdatePlanExecutionStep {
     | AccessDeniedException
     | ResourceNotFoundException
     | CommonAwsError;
+}
+
+export declare namespace CreatePlan {
+  export type Input = CreatePlanRequest;
+  export type Output = CreatePlanResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeletePlan {
+  export type Input = DeletePlanRequest;
+  export type Output = DeletePlanResponse;
+  export type Error =
+    | IllegalStateException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetPlan {
+  export type Input = GetPlanRequest;
+  export type Output = GetPlanResponse;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace ListPlans {
+  export type Input = ListPlansRequest;
+  export type Output = ListPlansResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListTagsForResource {
+  export type Input = ListTagsForResourceRequest;
+  export type Output = ListTagsForResourceResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace TagResource {
+  export type Input = TagResourceRequest;
+  export type Output = TagResourceResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UntagResource {
+  export type Input = UntagResourceRequest;
+  export type Output = UntagResourceResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePlan {
+  export type Input = UpdatePlanRequest;
+  export type Output = UpdatePlanResponse;
+  export type Error = ResourceNotFoundException | CommonAwsError;
 }

--- a/src/services/b2bi/index.ts
+++ b/src/services/b2bi/index.ts
@@ -107,6 +107,243 @@ export declare class b2bi extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createCapability(
+    input: CreateCapabilityRequest,
+  ): Effect.Effect<
+    CreateCapabilityResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPartnership(
+    input: CreatePartnershipRequest,
+  ): Effect.Effect<
+    CreatePartnershipResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createProfile(
+    input: CreateProfileRequest,
+  ): Effect.Effect<
+    CreateProfileResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTransformer(
+    input: CreateTransformerRequest,
+  ): Effect.Effect<
+    CreateTransformerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCapability(
+    input: DeleteCapabilityRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePartnership(
+    input: DeletePartnershipRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteProfile(
+    input: DeleteProfileRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTransformer(
+    input: DeleteTransformerRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCapability(
+    input: GetCapabilityRequest,
+  ): Effect.Effect<
+    GetCapabilityResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getPartnership(
+    input: GetPartnershipRequest,
+  ): Effect.Effect<
+    GetPartnershipResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getProfile(
+    input: GetProfileRequest,
+  ): Effect.Effect<
+    GetProfileResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTransformer(
+    input: GetTransformerRequest,
+  ): Effect.Effect<
+    GetTransformerResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCapabilities(
+    input: ListCapabilitiesRequest,
+  ): Effect.Effect<
+    ListCapabilitiesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPartnerships(
+    input: ListPartnershipsRequest,
+  ): Effect.Effect<
+    ListPartnershipsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listProfiles(
+    input: ListProfilesRequest,
+  ): Effect.Effect<
+    ListProfilesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTransformers(
+    input: ListTransformersRequest,
+  ): Effect.Effect<
+    ListTransformersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCapability(
+    input: UpdateCapabilityRequest,
+  ): Effect.Effect<
+    UpdateCapabilityResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updatePartnership(
+    input: UpdatePartnershipRequest,
+  ): Effect.Effect<
+    UpdatePartnershipResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateProfile(
+    input: UpdateProfileRequest,
+  ): Effect.Effect<
+    UpdateProfileResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTransformer(
+    input: UpdateTransformerRequest,
+  ): Effect.Effect<
+    UpdateTransformerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class B2bi extends b2bi {}
@@ -1294,6 +1531,263 @@ export declare namespace UntagResource {
   export type Error =
     | InternalServerException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCapability {
+  export type Input = CreateCapabilityRequest;
+  export type Output = CreateCapabilityResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePartnership {
+  export type Input = CreatePartnershipRequest;
+  export type Output = CreatePartnershipResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateProfile {
+  export type Input = CreateProfileRequest;
+  export type Output = CreateProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTransformer {
+  export type Input = CreateTransformerRequest;
+  export type Output = CreateTransformerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCapability {
+  export type Input = DeleteCapabilityRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePartnership {
+  export type Input = DeletePartnershipRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteProfile {
+  export type Input = DeleteProfileRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTransformer {
+  export type Input = DeleteTransformerRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCapability {
+  export type Input = GetCapabilityRequest;
+  export type Output = GetCapabilityResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetPartnership {
+  export type Input = GetPartnershipRequest;
+  export type Output = GetPartnershipResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetProfile {
+  export type Input = GetProfileRequest;
+  export type Output = GetProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTransformer {
+  export type Input = GetTransformerRequest;
+  export type Output = GetTransformerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCapabilities {
+  export type Input = ListCapabilitiesRequest;
+  export type Output = ListCapabilitiesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPartnerships {
+  export type Input = ListPartnershipsRequest;
+  export type Output = ListPartnershipsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListProfiles {
+  export type Input = ListProfilesRequest;
+  export type Output = ListProfilesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTransformers {
+  export type Input = ListTransformersRequest;
+  export type Output = ListTransformersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCapability {
+  export type Input = UpdateCapabilityRequest;
+  export type Output = UpdateCapabilityResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePartnership {
+  export type Input = UpdatePartnershipRequest;
+  export type Output = UpdatePartnershipResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProfile {
+  export type Input = UpdateProfileRequest;
+  export type Output = UpdateProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTransformer {
+  export type Input = UpdateTransformerRequest;
+  export type Output = UpdateTransformerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/backup-gateway/index.ts
+++ b/src/services/backup-gateway/index.ts
@@ -21,6 +21,135 @@ export declare class BackupGateway extends AWSServiceClient {
     UntagResourceOutput,
     ResourceNotFoundException | CommonAwsError
   >;
+  associateGatewayToServer(
+    input: AssociateGatewayToServerInput,
+  ): Effect.Effect<
+    AssociateGatewayToServerOutput,
+    ConflictException | CommonAwsError
+  >;
+  createGateway(
+    input: CreateGatewayInput,
+  ): Effect.Effect<CreateGatewayOutput, CommonAwsError>;
+  deleteGateway(
+    input: DeleteGatewayInput,
+  ): Effect.Effect<
+    DeleteGatewayOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  deleteHypervisor(
+    input: DeleteHypervisorInput,
+  ): Effect.Effect<
+    DeleteHypervisorOutput,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  disassociateGatewayFromServer(
+    input: DisassociateGatewayFromServerInput,
+  ): Effect.Effect<
+    DisassociateGatewayFromServerOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  getBandwidthRateLimitSchedule(
+    input: GetBandwidthRateLimitScheduleInput,
+  ): Effect.Effect<
+    GetBandwidthRateLimitScheduleOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getGateway(
+    input: GetGatewayInput,
+  ): Effect.Effect<
+    GetGatewayOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getHypervisor(
+    input: GetHypervisorInput,
+  ): Effect.Effect<
+    GetHypervisorOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getHypervisorPropertyMappings(
+    input: GetHypervisorPropertyMappingsInput,
+  ): Effect.Effect<
+    GetHypervisorPropertyMappingsOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getVirtualMachine(
+    input: GetVirtualMachineInput,
+  ): Effect.Effect<
+    GetVirtualMachineOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  importHypervisorConfiguration(
+    input: ImportHypervisorConfigurationInput,
+  ): Effect.Effect<
+    ImportHypervisorConfigurationOutput,
+    AccessDeniedException | ConflictException | CommonAwsError
+  >;
+  listGateways(
+    input: ListGatewaysInput,
+  ): Effect.Effect<ListGatewaysOutput, CommonAwsError>;
+  listHypervisors(
+    input: ListHypervisorsInput,
+  ): Effect.Effect<ListHypervisorsOutput, CommonAwsError>;
+  listVirtualMachines(
+    input: ListVirtualMachinesInput,
+  ): Effect.Effect<ListVirtualMachinesOutput, CommonAwsError>;
+  putBandwidthRateLimitSchedule(
+    input: PutBandwidthRateLimitScheduleInput,
+  ): Effect.Effect<
+    PutBandwidthRateLimitScheduleOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  putHypervisorPropertyMappings(
+    input: PutHypervisorPropertyMappingsInput,
+  ): Effect.Effect<
+    PutHypervisorPropertyMappingsOutput,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  putMaintenanceStartTime(
+    input: PutMaintenanceStartTimeInput,
+  ): Effect.Effect<
+    PutMaintenanceStartTimeOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  startVirtualMachinesMetadataSync(
+    input: StartVirtualMachinesMetadataSyncInput,
+  ): Effect.Effect<
+    StartVirtualMachinesMetadataSyncOutput,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  testHypervisorConfiguration(
+    input: TestHypervisorConfigurationInput,
+  ): Effect.Effect<
+    TestHypervisorConfigurationOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  updateGatewayInformation(
+    input: UpdateGatewayInformationInput,
+  ): Effect.Effect<
+    UpdateGatewayInformationOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  updateGatewaySoftwareNow(
+    input: UpdateGatewaySoftwareNowInput,
+  ): Effect.Effect<
+    UpdateGatewaySoftwareNowOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  updateHypervisor(
+    input: UpdateHypervisorInput,
+  ): Effect.Effect<
+    UpdateHypervisorOutput,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -411,4 +540,166 @@ export declare namespace UntagResource {
   export type Input = UntagResourceInput;
   export type Output = UntagResourceOutput;
   export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace AssociateGatewayToServer {
+  export type Input = AssociateGatewayToServerInput;
+  export type Output = AssociateGatewayToServerOutput;
+  export type Error = ConflictException | CommonAwsError;
+}
+
+export declare namespace CreateGateway {
+  export type Input = CreateGatewayInput;
+  export type Output = CreateGatewayOutput;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteGateway {
+  export type Input = DeleteGatewayInput;
+  export type Output = DeleteGatewayOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace DeleteHypervisor {
+  export type Input = DeleteHypervisorInput;
+  export type Output = DeleteHypervisorOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateGatewayFromServer {
+  export type Input = DisassociateGatewayFromServerInput;
+  export type Output = DisassociateGatewayFromServerOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetBandwidthRateLimitSchedule {
+  export type Input = GetBandwidthRateLimitScheduleInput;
+  export type Output = GetBandwidthRateLimitScheduleOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetGateway {
+  export type Input = GetGatewayInput;
+  export type Output = GetGatewayOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetHypervisor {
+  export type Input = GetHypervisorInput;
+  export type Output = GetHypervisorOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetHypervisorPropertyMappings {
+  export type Input = GetHypervisorPropertyMappingsInput;
+  export type Output = GetHypervisorPropertyMappingsOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetVirtualMachine {
+  export type Input = GetVirtualMachineInput;
+  export type Output = GetVirtualMachineOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace ImportHypervisorConfiguration {
+  export type Input = ImportHypervisorConfigurationInput;
+  export type Output = ImportHypervisorConfigurationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | CommonAwsError;
+}
+
+export declare namespace ListGateways {
+  export type Input = ListGatewaysInput;
+  export type Output = ListGatewaysOutput;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListHypervisors {
+  export type Input = ListHypervisorsInput;
+  export type Output = ListHypervisorsOutput;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListVirtualMachines {
+  export type Input = ListVirtualMachinesInput;
+  export type Output = ListVirtualMachinesOutput;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace PutBandwidthRateLimitSchedule {
+  export type Input = PutBandwidthRateLimitScheduleInput;
+  export type Output = PutBandwidthRateLimitScheduleOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace PutHypervisorPropertyMappings {
+  export type Input = PutHypervisorPropertyMappingsInput;
+  export type Output = PutHypervisorPropertyMappingsOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace PutMaintenanceStartTime {
+  export type Input = PutMaintenanceStartTimeInput;
+  export type Output = PutMaintenanceStartTimeOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace StartVirtualMachinesMetadataSync {
+  export type Input = StartVirtualMachinesMetadataSyncInput;
+  export type Output = StartVirtualMachinesMetadataSyncOutput;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace TestHypervisorConfiguration {
+  export type Input = TestHypervisorConfigurationInput;
+  export type Output = TestHypervisorConfigurationOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGatewayInformation {
+  export type Input = UpdateGatewayInformationInput;
+  export type Output = UpdateGatewayInformationOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGatewaySoftwareNow {
+  export type Input = UpdateGatewaySoftwareNowInput;
+  export type Output = UpdateGatewaySoftwareNowOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace UpdateHypervisor {
+  export type Input = UpdateHypervisorInput;
+  export type Output = UpdateHypervisorOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
 }

--- a/src/services/backupsearch/index.ts
+++ b/src/services/backupsearch/index.ts
@@ -33,6 +33,48 @@ export declare class BackupSearch extends AWSServiceClient {
     UntagResourceResponse,
     ResourceNotFoundException | CommonAwsError
   >;
+  getSearchJob(
+    input: GetSearchJobInput,
+  ): Effect.Effect<
+    GetSearchJobOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getSearchResultExportJob(
+    input: GetSearchResultExportJobInput,
+  ): Effect.Effect<
+    GetSearchResultExportJobOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  listSearchJobs(
+    input: ListSearchJobsInput,
+  ): Effect.Effect<ListSearchJobsOutput, CommonAwsError>;
+  listSearchResultExportJobs(
+    input: ListSearchResultExportJobsInput,
+  ): Effect.Effect<
+    ListSearchResultExportJobsOutput,
+    ResourceNotFoundException | ServiceQuotaExceededException | CommonAwsError
+  >;
+  startSearchJob(
+    input: StartSearchJobInput,
+  ): Effect.Effect<
+    StartSearchJobOutput,
+    ConflictException | ServiceQuotaExceededException | CommonAwsError
+  >;
+  startSearchResultExportJob(
+    input: StartSearchResultExportJobInput,
+  ): Effect.Effect<
+    StartSearchResultExportJobOutput,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  stopSearchJob(
+    input: StopSearchJobInput,
+  ): Effect.Effect<
+    StopSearchJobOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
 }
 
 export declare class Backupsearch extends BackupSearch {}
@@ -396,4 +438,59 @@ export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
   export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetSearchJob {
+  export type Input = GetSearchJobInput;
+  export type Output = GetSearchJobOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetSearchResultExportJob {
+  export type Input = GetSearchResultExportJobInput;
+  export type Output = GetSearchResultExportJobOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace ListSearchJobs {
+  export type Input = ListSearchJobsInput;
+  export type Output = ListSearchJobsOutput;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListSearchResultExportJobs {
+  export type Input = ListSearchResultExportJobsInput;
+  export type Output = ListSearchResultExportJobsOutput;
+  export type Error =
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace StartSearchJob {
+  export type Input = StartSearchJobInput;
+  export type Output = StartSearchJobOutput;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace StartSearchResultExportJob {
+  export type Input = StartSearchResultExportJobInput;
+  export type Output = StartSearchResultExportJobOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace StopSearchJob {
+  export type Input = StopSearchJobInput;
+  export type Output = StopSearchJobOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
 }

--- a/src/services/bcm-pricing-calculator/index.ts
+++ b/src/services/bcm-pricing-calculator/index.ts
@@ -33,6 +33,241 @@ export declare class BCMPricingCalculator extends AWSServiceClient {
     UpdatePreferencesResponse,
     DataUnavailableException | ServiceQuotaExceededException | CommonAwsError
   >;
+  batchCreateBillScenarioCommitmentModification(
+    input: BatchCreateBillScenarioCommitmentModificationRequest,
+  ): Effect.Effect<
+    BatchCreateBillScenarioCommitmentModificationResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  batchCreateBillScenarioUsageModification(
+    input: BatchCreateBillScenarioUsageModificationRequest,
+  ): Effect.Effect<
+    BatchCreateBillScenarioUsageModificationResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  batchCreateWorkloadEstimateUsage(
+    input: BatchCreateWorkloadEstimateUsageRequest,
+  ): Effect.Effect<
+    BatchCreateWorkloadEstimateUsageResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  batchDeleteBillScenarioCommitmentModification(
+    input: BatchDeleteBillScenarioCommitmentModificationRequest,
+  ): Effect.Effect<
+    BatchDeleteBillScenarioCommitmentModificationResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  batchDeleteBillScenarioUsageModification(
+    input: BatchDeleteBillScenarioUsageModificationRequest,
+  ): Effect.Effect<
+    BatchDeleteBillScenarioUsageModificationResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  batchDeleteWorkloadEstimateUsage(
+    input: BatchDeleteWorkloadEstimateUsageRequest,
+  ): Effect.Effect<
+    BatchDeleteWorkloadEstimateUsageResponse,
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  batchUpdateBillScenarioCommitmentModification(
+    input: BatchUpdateBillScenarioCommitmentModificationRequest,
+  ): Effect.Effect<
+    BatchUpdateBillScenarioCommitmentModificationResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  batchUpdateBillScenarioUsageModification(
+    input: BatchUpdateBillScenarioUsageModificationRequest,
+  ): Effect.Effect<
+    BatchUpdateBillScenarioUsageModificationResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  batchUpdateWorkloadEstimateUsage(
+    input: BatchUpdateWorkloadEstimateUsageRequest,
+  ): Effect.Effect<
+    BatchUpdateWorkloadEstimateUsageResponse,
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  createBillEstimate(
+    input: CreateBillEstimateRequest,
+  ): Effect.Effect<
+    CreateBillEstimateResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  createBillScenario(
+    input: CreateBillScenarioRequest,
+  ): Effect.Effect<
+    CreateBillScenarioResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  createWorkloadEstimate(
+    input: CreateWorkloadEstimateRequest,
+  ): Effect.Effect<
+    CreateWorkloadEstimateResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  deleteBillEstimate(
+    input: DeleteBillEstimateRequest,
+  ): Effect.Effect<
+    DeleteBillEstimateResponse,
+    ConflictException | DataUnavailableException | CommonAwsError
+  >;
+  deleteBillScenario(
+    input: DeleteBillScenarioRequest,
+  ): Effect.Effect<
+    DeleteBillScenarioResponse,
+    ConflictException | DataUnavailableException | CommonAwsError
+  >;
+  deleteWorkloadEstimate(
+    input: DeleteWorkloadEstimateRequest,
+  ): Effect.Effect<
+    DeleteWorkloadEstimateResponse,
+    DataUnavailableException | CommonAwsError
+  >;
+  getBillEstimate(
+    input: GetBillEstimateRequest,
+  ): Effect.Effect<
+    GetBillEstimateResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  getBillScenario(
+    input: GetBillScenarioRequest,
+  ): Effect.Effect<
+    GetBillScenarioResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  getWorkloadEstimate(
+    input: GetWorkloadEstimateRequest,
+  ): Effect.Effect<
+    GetWorkloadEstimateResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  listBillEstimateCommitments(
+    input: ListBillEstimateCommitmentsRequest,
+  ): Effect.Effect<
+    ListBillEstimateCommitmentsResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  listBillEstimateInputCommitmentModifications(
+    input: ListBillEstimateInputCommitmentModificationsRequest,
+  ): Effect.Effect<
+    ListBillEstimateInputCommitmentModificationsResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  listBillEstimateInputUsageModifications(
+    input: ListBillEstimateInputUsageModificationsRequest,
+  ): Effect.Effect<
+    ListBillEstimateInputUsageModificationsResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  listBillEstimateLineItems(
+    input: ListBillEstimateLineItemsRequest,
+  ): Effect.Effect<
+    ListBillEstimateLineItemsResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  listBillEstimates(
+    input: ListBillEstimatesRequest,
+  ): Effect.Effect<
+    ListBillEstimatesResponse,
+    DataUnavailableException | CommonAwsError
+  >;
+  listBillScenarioCommitmentModifications(
+    input: ListBillScenarioCommitmentModificationsRequest,
+  ): Effect.Effect<
+    ListBillScenarioCommitmentModificationsResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  listBillScenarioUsageModifications(
+    input: ListBillScenarioUsageModificationsRequest,
+  ): Effect.Effect<
+    ListBillScenarioUsageModificationsResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  listBillScenarios(
+    input: ListBillScenariosRequest,
+  ): Effect.Effect<
+    ListBillScenariosResponse,
+    DataUnavailableException | CommonAwsError
+  >;
+  listWorkloadEstimateUsage(
+    input: ListWorkloadEstimateUsageRequest,
+  ): Effect.Effect<
+    ListWorkloadEstimateUsageResponse,
+    DataUnavailableException | ResourceNotFoundException | CommonAwsError
+  >;
+  listWorkloadEstimates(
+    input: ListWorkloadEstimatesRequest,
+  ): Effect.Effect<
+    ListWorkloadEstimatesResponse,
+    DataUnavailableException | CommonAwsError
+  >;
+  updateBillEstimate(
+    input: UpdateBillEstimateRequest,
+  ): Effect.Effect<
+    UpdateBillEstimateResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  updateBillScenario(
+    input: UpdateBillScenarioRequest,
+  ): Effect.Effect<
+    UpdateBillScenarioResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  updateWorkloadEstimate(
+    input: UpdateWorkloadEstimateRequest,
+  ): Effect.Effect<
+    UpdateWorkloadEstimateResponse,
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
 }
 
 export declare class BcmPricingCalculator extends BCMPricingCalculator {}
@@ -1027,5 +1262,291 @@ export declare namespace UpdatePreferences {
   export type Error =
     | DataUnavailableException
     | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace BatchCreateBillScenarioCommitmentModification {
+  export type Input = BatchCreateBillScenarioCommitmentModificationRequest;
+  export type Output = BatchCreateBillScenarioCommitmentModificationResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace BatchCreateBillScenarioUsageModification {
+  export type Input = BatchCreateBillScenarioUsageModificationRequest;
+  export type Output = BatchCreateBillScenarioUsageModificationResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace BatchCreateWorkloadEstimateUsage {
+  export type Input = BatchCreateWorkloadEstimateUsageRequest;
+  export type Output = BatchCreateWorkloadEstimateUsageResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace BatchDeleteBillScenarioCommitmentModification {
+  export type Input = BatchDeleteBillScenarioCommitmentModificationRequest;
+  export type Output = BatchDeleteBillScenarioCommitmentModificationResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace BatchDeleteBillScenarioUsageModification {
+  export type Input = BatchDeleteBillScenarioUsageModificationRequest;
+  export type Output = BatchDeleteBillScenarioUsageModificationResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace BatchDeleteWorkloadEstimateUsage {
+  export type Input = BatchDeleteWorkloadEstimateUsageRequest;
+  export type Output = BatchDeleteWorkloadEstimateUsageResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace BatchUpdateBillScenarioCommitmentModification {
+  export type Input = BatchUpdateBillScenarioCommitmentModificationRequest;
+  export type Output = BatchUpdateBillScenarioCommitmentModificationResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace BatchUpdateBillScenarioUsageModification {
+  export type Input = BatchUpdateBillScenarioUsageModificationRequest;
+  export type Output = BatchUpdateBillScenarioUsageModificationResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace BatchUpdateWorkloadEstimateUsage {
+  export type Input = BatchUpdateWorkloadEstimateUsageRequest;
+  export type Output = BatchUpdateWorkloadEstimateUsageResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBillEstimate {
+  export type Input = CreateBillEstimateRequest;
+  export type Output = CreateBillEstimateResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBillScenario {
+  export type Input = CreateBillScenarioRequest;
+  export type Output = CreateBillScenarioResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkloadEstimate {
+  export type Input = CreateWorkloadEstimateRequest;
+  export type Output = CreateWorkloadEstimateResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteBillEstimate {
+  export type Input = DeleteBillEstimateRequest;
+  export type Output = DeleteBillEstimateResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteBillScenario {
+  export type Input = DeleteBillScenarioRequest;
+  export type Output = DeleteBillScenarioResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkloadEstimate {
+  export type Input = DeleteWorkloadEstimateRequest;
+  export type Output = DeleteWorkloadEstimateResponse;
+  export type Error = DataUnavailableException | CommonAwsError;
+}
+
+export declare namespace GetBillEstimate {
+  export type Input = GetBillEstimateRequest;
+  export type Output = GetBillEstimateResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetBillScenario {
+  export type Input = GetBillScenarioRequest;
+  export type Output = GetBillScenarioResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkloadEstimate {
+  export type Input = GetWorkloadEstimateRequest;
+  export type Output = GetWorkloadEstimateResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListBillEstimateCommitments {
+  export type Input = ListBillEstimateCommitmentsRequest;
+  export type Output = ListBillEstimateCommitmentsResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListBillEstimateInputCommitmentModifications {
+  export type Input = ListBillEstimateInputCommitmentModificationsRequest;
+  export type Output = ListBillEstimateInputCommitmentModificationsResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListBillEstimateInputUsageModifications {
+  export type Input = ListBillEstimateInputUsageModificationsRequest;
+  export type Output = ListBillEstimateInputUsageModificationsResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListBillEstimateLineItems {
+  export type Input = ListBillEstimateLineItemsRequest;
+  export type Output = ListBillEstimateLineItemsResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListBillEstimates {
+  export type Input = ListBillEstimatesRequest;
+  export type Output = ListBillEstimatesResponse;
+  export type Error = DataUnavailableException | CommonAwsError;
+}
+
+export declare namespace ListBillScenarioCommitmentModifications {
+  export type Input = ListBillScenarioCommitmentModificationsRequest;
+  export type Output = ListBillScenarioCommitmentModificationsResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListBillScenarioUsageModifications {
+  export type Input = ListBillScenarioUsageModificationsRequest;
+  export type Output = ListBillScenarioUsageModificationsResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListBillScenarios {
+  export type Input = ListBillScenariosRequest;
+  export type Output = ListBillScenariosResponse;
+  export type Error = DataUnavailableException | CommonAwsError;
+}
+
+export declare namespace ListWorkloadEstimateUsage {
+  export type Input = ListWorkloadEstimateUsageRequest;
+  export type Output = ListWorkloadEstimateUsageResponse;
+  export type Error =
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkloadEstimates {
+  export type Input = ListWorkloadEstimatesRequest;
+  export type Output = ListWorkloadEstimatesResponse;
+  export type Error = DataUnavailableException | CommonAwsError;
+}
+
+export declare namespace UpdateBillEstimate {
+  export type Input = UpdateBillEstimateRequest;
+  export type Output = UpdateBillEstimateResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBillScenario {
+  export type Input = UpdateBillScenarioRequest;
+  export type Output = UpdateBillScenarioResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkloadEstimate {
+  export type Input = UpdateWorkloadEstimateRequest;
+  export type Output = UpdateWorkloadEstimateResponse;
+  export type Error =
+    | ConflictException
+    | DataUnavailableException
+    | ResourceNotFoundException
     | CommonAwsError;
 }

--- a/src/services/bedrock-agent/index.ts
+++ b/src/services/bedrock-agent/index.ts
@@ -13,6 +13,844 @@ export declare class BedrockAgent extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateAgentCollaborator(
+    input: AssociateAgentCollaboratorRequest,
+  ): Effect.Effect<
+    AssociateAgentCollaboratorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateAgentKnowledgeBase(
+    input: AssociateAgentKnowledgeBaseRequest,
+  ): Effect.Effect<
+    AssociateAgentKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAgent(
+    input: CreateAgentRequest,
+  ): Effect.Effect<
+    CreateAgentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAgentActionGroup(
+    input: CreateAgentActionGroupRequest,
+  ): Effect.Effect<
+    CreateAgentActionGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAgentAlias(
+    input: CreateAgentAliasRequest,
+  ): Effect.Effect<
+    CreateAgentAliasResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataSource(
+    input: CreateDataSourceRequest,
+  ): Effect.Effect<
+    CreateDataSourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createFlow(
+    input: CreateFlowRequest,
+  ): Effect.Effect<
+    CreateFlowResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createFlowAlias(
+    input: CreateFlowAliasRequest,
+  ): Effect.Effect<
+    CreateFlowAliasResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createFlowVersion(
+    input: CreateFlowVersionRequest,
+  ): Effect.Effect<
+    CreateFlowVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createKnowledgeBase(
+    input: CreateKnowledgeBaseRequest,
+  ): Effect.Effect<
+    CreateKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPrompt(
+    input: CreatePromptRequest,
+  ): Effect.Effect<
+    CreatePromptResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPromptVersion(
+    input: CreatePromptVersionRequest,
+  ): Effect.Effect<
+    CreatePromptVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAgent(
+    input: DeleteAgentRequest,
+  ): Effect.Effect<
+    DeleteAgentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAgentActionGroup(
+    input: DeleteAgentActionGroupRequest,
+  ): Effect.Effect<
+    DeleteAgentActionGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAgentAlias(
+    input: DeleteAgentAliasRequest,
+  ): Effect.Effect<
+    DeleteAgentAliasResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAgentVersion(
+    input: DeleteAgentVersionRequest,
+  ): Effect.Effect<
+    DeleteAgentVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataSource(
+    input: DeleteDataSourceRequest,
+  ): Effect.Effect<
+    DeleteDataSourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteFlow(
+    input: DeleteFlowRequest,
+  ): Effect.Effect<
+    DeleteFlowResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteFlowAlias(
+    input: DeleteFlowAliasRequest,
+  ): Effect.Effect<
+    DeleteFlowAliasResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteFlowVersion(
+    input: DeleteFlowVersionRequest,
+  ): Effect.Effect<
+    DeleteFlowVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteKnowledgeBase(
+    input: DeleteKnowledgeBaseRequest,
+  ): Effect.Effect<
+    DeleteKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteKnowledgeBaseDocuments(
+    input: DeleteKnowledgeBaseDocumentsRequest,
+  ): Effect.Effect<
+    DeleteKnowledgeBaseDocumentsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePrompt(
+    input: DeletePromptRequest,
+  ): Effect.Effect<
+    DeletePromptResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateAgentCollaborator(
+    input: DisassociateAgentCollaboratorRequest,
+  ): Effect.Effect<
+    DisassociateAgentCollaboratorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateAgentKnowledgeBase(
+    input: DisassociateAgentKnowledgeBaseRequest,
+  ): Effect.Effect<
+    DisassociateAgentKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAgent(
+    input: GetAgentRequest,
+  ): Effect.Effect<
+    GetAgentResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAgentActionGroup(
+    input: GetAgentActionGroupRequest,
+  ): Effect.Effect<
+    GetAgentActionGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAgentAlias(
+    input: GetAgentAliasRequest,
+  ): Effect.Effect<
+    GetAgentAliasResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAgentCollaborator(
+    input: GetAgentCollaboratorRequest,
+  ): Effect.Effect<
+    GetAgentCollaboratorResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAgentKnowledgeBase(
+    input: GetAgentKnowledgeBaseRequest,
+  ): Effect.Effect<
+    GetAgentKnowledgeBaseResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAgentVersion(
+    input: GetAgentVersionRequest,
+  ): Effect.Effect<
+    GetAgentVersionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataSource(
+    input: GetDataSourceRequest,
+  ): Effect.Effect<
+    GetDataSourceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFlow(
+    input: GetFlowRequest,
+  ): Effect.Effect<
+    GetFlowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFlowAlias(
+    input: GetFlowAliasRequest,
+  ): Effect.Effect<
+    GetFlowAliasResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFlowVersion(
+    input: GetFlowVersionRequest,
+  ): Effect.Effect<
+    GetFlowVersionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getIngestionJob(
+    input: GetIngestionJobRequest,
+  ): Effect.Effect<
+    GetIngestionJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getKnowledgeBase(
+    input: GetKnowledgeBaseRequest,
+  ): Effect.Effect<
+    GetKnowledgeBaseResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getKnowledgeBaseDocuments(
+    input: GetKnowledgeBaseDocumentsRequest,
+  ): Effect.Effect<
+    GetKnowledgeBaseDocumentsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getPrompt(
+    input: GetPromptRequest,
+  ): Effect.Effect<
+    GetPromptResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  ingestKnowledgeBaseDocuments(
+    input: IngestKnowledgeBaseDocumentsRequest,
+  ): Effect.Effect<
+    IngestKnowledgeBaseDocumentsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgentActionGroups(
+    input: ListAgentActionGroupsRequest,
+  ): Effect.Effect<
+    ListAgentActionGroupsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgentAliases(
+    input: ListAgentAliasesRequest,
+  ): Effect.Effect<
+    ListAgentAliasesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgentCollaborators(
+    input: ListAgentCollaboratorsRequest,
+  ): Effect.Effect<
+    ListAgentCollaboratorsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgentKnowledgeBases(
+    input: ListAgentKnowledgeBasesRequest,
+  ): Effect.Effect<
+    ListAgentKnowledgeBasesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgentVersions(
+    input: ListAgentVersionsRequest,
+  ): Effect.Effect<
+    ListAgentVersionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgents(
+    input: ListAgentsRequest,
+  ): Effect.Effect<
+    ListAgentsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataSources(
+    input: ListDataSourcesRequest,
+  ): Effect.Effect<
+    ListDataSourcesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFlowAliases(
+    input: ListFlowAliasesRequest,
+  ): Effect.Effect<
+    ListFlowAliasesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFlowVersions(
+    input: ListFlowVersionsRequest,
+  ): Effect.Effect<
+    ListFlowVersionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFlows(
+    input: ListFlowsRequest,
+  ): Effect.Effect<
+    ListFlowsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIngestionJobs(
+    input: ListIngestionJobsRequest,
+  ): Effect.Effect<
+    ListIngestionJobsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listKnowledgeBaseDocuments(
+    input: ListKnowledgeBaseDocumentsRequest,
+  ): Effect.Effect<
+    ListKnowledgeBaseDocumentsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listKnowledgeBases(
+    input: ListKnowledgeBasesRequest,
+  ): Effect.Effect<
+    ListKnowledgeBasesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPrompts(
+    input: ListPromptsRequest,
+  ): Effect.Effect<
+    ListPromptsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTagsForResource(
+    input: ListTagsForResourceRequest,
+  ): Effect.Effect<
+    ListTagsForResourceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  prepareAgent(
+    input: PrepareAgentRequest,
+  ): Effect.Effect<
+    PrepareAgentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  prepareFlow(
+    input: PrepareFlowRequest,
+  ): Effect.Effect<
+    PrepareFlowResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startIngestionJob(
+    input: StartIngestionJobRequest,
+  ): Effect.Effect<
+    StartIngestionJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopIngestionJob(
+    input: StopIngestionJobRequest,
+  ): Effect.Effect<
+    StopIngestionJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  tagResource(
+    input: TagResourceRequest,
+  ): Effect.Effect<
+    TagResourceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  untagResource(
+    input: UntagResourceRequest,
+  ): Effect.Effect<
+    UntagResourceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAgent(
+    input: UpdateAgentRequest,
+  ): Effect.Effect<
+    UpdateAgentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAgentActionGroup(
+    input: UpdateAgentActionGroupRequest,
+  ): Effect.Effect<
+    UpdateAgentActionGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAgentAlias(
+    input: UpdateAgentAliasRequest,
+  ): Effect.Effect<
+    UpdateAgentAliasResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAgentCollaborator(
+    input: UpdateAgentCollaboratorRequest,
+  ): Effect.Effect<
+    UpdateAgentCollaboratorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAgentKnowledgeBase(
+    input: UpdateAgentKnowledgeBaseRequest,
+  ): Effect.Effect<
+    UpdateAgentKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataSource(
+    input: UpdateDataSourceRequest,
+  ): Effect.Effect<
+    UpdateDataSourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateFlow(
+    input: UpdateFlowRequest,
+  ): Effect.Effect<
+    UpdateFlowResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateFlowAlias(
+    input: UpdateFlowAliasRequest,
+  ): Effect.Effect<
+    UpdateFlowAliasResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateKnowledgeBase(
+    input: UpdateKnowledgeBaseRequest,
+  ): Effect.Effect<
+    UpdateKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updatePrompt(
+    input: UpdatePromptRequest,
+  ): Effect.Effect<
+    UpdatePromptResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -2780,6 +3618,915 @@ export declare namespace ValidateFlowDefinition {
   export type Error =
     | AccessDeniedException
     | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateAgentCollaborator {
+  export type Input = AssociateAgentCollaboratorRequest;
+  export type Output = AssociateAgentCollaboratorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateAgentKnowledgeBase {
+  export type Input = AssociateAgentKnowledgeBaseRequest;
+  export type Output = AssociateAgentKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAgent {
+  export type Input = CreateAgentRequest;
+  export type Output = CreateAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAgentActionGroup {
+  export type Input = CreateAgentActionGroupRequest;
+  export type Output = CreateAgentActionGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAgentAlias {
+  export type Input = CreateAgentAliasRequest;
+  export type Output = CreateAgentAliasResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataSource {
+  export type Input = CreateDataSourceRequest;
+  export type Output = CreateDataSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFlow {
+  export type Input = CreateFlowRequest;
+  export type Output = CreateFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFlowAlias {
+  export type Input = CreateFlowAliasRequest;
+  export type Output = CreateFlowAliasResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFlowVersion {
+  export type Input = CreateFlowVersionRequest;
+  export type Output = CreateFlowVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateKnowledgeBase {
+  export type Input = CreateKnowledgeBaseRequest;
+  export type Output = CreateKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePrompt {
+  export type Input = CreatePromptRequest;
+  export type Output = CreatePromptResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePromptVersion {
+  export type Input = CreatePromptVersionRequest;
+  export type Output = CreatePromptVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAgent {
+  export type Input = DeleteAgentRequest;
+  export type Output = DeleteAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAgentActionGroup {
+  export type Input = DeleteAgentActionGroupRequest;
+  export type Output = DeleteAgentActionGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAgentAlias {
+  export type Input = DeleteAgentAliasRequest;
+  export type Output = DeleteAgentAliasResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAgentVersion {
+  export type Input = DeleteAgentVersionRequest;
+  export type Output = DeleteAgentVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataSource {
+  export type Input = DeleteDataSourceRequest;
+  export type Output = DeleteDataSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFlow {
+  export type Input = DeleteFlowRequest;
+  export type Output = DeleteFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFlowAlias {
+  export type Input = DeleteFlowAliasRequest;
+  export type Output = DeleteFlowAliasResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFlowVersion {
+  export type Input = DeleteFlowVersionRequest;
+  export type Output = DeleteFlowVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteKnowledgeBase {
+  export type Input = DeleteKnowledgeBaseRequest;
+  export type Output = DeleteKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteKnowledgeBaseDocuments {
+  export type Input = DeleteKnowledgeBaseDocumentsRequest;
+  export type Output = DeleteKnowledgeBaseDocumentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePrompt {
+  export type Input = DeletePromptRequest;
+  export type Output = DeletePromptResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateAgentCollaborator {
+  export type Input = DisassociateAgentCollaboratorRequest;
+  export type Output = DisassociateAgentCollaboratorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateAgentKnowledgeBase {
+  export type Input = DisassociateAgentKnowledgeBaseRequest;
+  export type Output = DisassociateAgentKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgent {
+  export type Input = GetAgentRequest;
+  export type Output = GetAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgentActionGroup {
+  export type Input = GetAgentActionGroupRequest;
+  export type Output = GetAgentActionGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgentAlias {
+  export type Input = GetAgentAliasRequest;
+  export type Output = GetAgentAliasResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgentCollaborator {
+  export type Input = GetAgentCollaboratorRequest;
+  export type Output = GetAgentCollaboratorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgentKnowledgeBase {
+  export type Input = GetAgentKnowledgeBaseRequest;
+  export type Output = GetAgentKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgentVersion {
+  export type Input = GetAgentVersionRequest;
+  export type Output = GetAgentVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataSource {
+  export type Input = GetDataSourceRequest;
+  export type Output = GetDataSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFlow {
+  export type Input = GetFlowRequest;
+  export type Output = GetFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFlowAlias {
+  export type Input = GetFlowAliasRequest;
+  export type Output = GetFlowAliasResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFlowVersion {
+  export type Input = GetFlowVersionRequest;
+  export type Output = GetFlowVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetIngestionJob {
+  export type Input = GetIngestionJobRequest;
+  export type Output = GetIngestionJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetKnowledgeBase {
+  export type Input = GetKnowledgeBaseRequest;
+  export type Output = GetKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetKnowledgeBaseDocuments {
+  export type Input = GetKnowledgeBaseDocumentsRequest;
+  export type Output = GetKnowledgeBaseDocumentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetPrompt {
+  export type Input = GetPromptRequest;
+  export type Output = GetPromptResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace IngestKnowledgeBaseDocuments {
+  export type Input = IngestKnowledgeBaseDocumentsRequest;
+  export type Output = IngestKnowledgeBaseDocumentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgentActionGroups {
+  export type Input = ListAgentActionGroupsRequest;
+  export type Output = ListAgentActionGroupsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgentAliases {
+  export type Input = ListAgentAliasesRequest;
+  export type Output = ListAgentAliasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgentCollaborators {
+  export type Input = ListAgentCollaboratorsRequest;
+  export type Output = ListAgentCollaboratorsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgentKnowledgeBases {
+  export type Input = ListAgentKnowledgeBasesRequest;
+  export type Output = ListAgentKnowledgeBasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgentVersions {
+  export type Input = ListAgentVersionsRequest;
+  export type Output = ListAgentVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgents {
+  export type Input = ListAgentsRequest;
+  export type Output = ListAgentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataSources {
+  export type Input = ListDataSourcesRequest;
+  export type Output = ListDataSourcesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFlowAliases {
+  export type Input = ListFlowAliasesRequest;
+  export type Output = ListFlowAliasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFlowVersions {
+  export type Input = ListFlowVersionsRequest;
+  export type Output = ListFlowVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFlows {
+  export type Input = ListFlowsRequest;
+  export type Output = ListFlowsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIngestionJobs {
+  export type Input = ListIngestionJobsRequest;
+  export type Output = ListIngestionJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListKnowledgeBaseDocuments {
+  export type Input = ListKnowledgeBaseDocumentsRequest;
+  export type Output = ListKnowledgeBaseDocumentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListKnowledgeBases {
+  export type Input = ListKnowledgeBasesRequest;
+  export type Output = ListKnowledgeBasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPrompts {
+  export type Input = ListPromptsRequest;
+  export type Output = ListPromptsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTagsForResource {
+  export type Input = ListTagsForResourceRequest;
+  export type Output = ListTagsForResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PrepareAgent {
+  export type Input = PrepareAgentRequest;
+  export type Output = PrepareAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PrepareFlow {
+  export type Input = PrepareFlowRequest;
+  export type Output = PrepareFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartIngestionJob {
+  export type Input = StartIngestionJobRequest;
+  export type Output = StartIngestionJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopIngestionJob {
+  export type Input = StopIngestionJobRequest;
+  export type Output = StopIngestionJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace TagResource {
+  export type Input = TagResourceRequest;
+  export type Output = TagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UntagResource {
+  export type Input = UntagResourceRequest;
+  export type Output = UntagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgent {
+  export type Input = UpdateAgentRequest;
+  export type Output = UpdateAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgentActionGroup {
+  export type Input = UpdateAgentActionGroupRequest;
+  export type Output = UpdateAgentActionGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgentAlias {
+  export type Input = UpdateAgentAliasRequest;
+  export type Output = UpdateAgentAliasResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgentCollaborator {
+  export type Input = UpdateAgentCollaboratorRequest;
+  export type Output = UpdateAgentCollaboratorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgentKnowledgeBase {
+  export type Input = UpdateAgentKnowledgeBaseRequest;
+  export type Output = UpdateAgentKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataSource {
+  export type Input = UpdateDataSourceRequest;
+  export type Output = UpdateDataSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFlow {
+  export type Input = UpdateFlowRequest;
+  export type Output = UpdateFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFlowAlias {
+  export type Input = UpdateFlowAliasRequest;
+  export type Output = UpdateFlowAliasResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateKnowledgeBase {
+  export type Input = UpdateKnowledgeBaseRequest;
+  export type Output = UpdateKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePrompt {
+  export type Input = UpdatePromptRequest;
+  export type Output = UpdatePromptResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/bedrock-agentcore-control/index.ts
+++ b/src/services/bedrock-agentcore-control/index.ts
@@ -28,6 +28,600 @@ export declare class BedrockAgentCoreControl extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createAgentRuntime(
+    input: CreateAgentRuntimeRequest,
+  ): Effect.Effect<
+    CreateAgentRuntimeResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAgentRuntimeEndpoint(
+    input: CreateAgentRuntimeEndpointRequest,
+  ): Effect.Effect<
+    CreateAgentRuntimeEndpointResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createApiKeyCredentialProvider(
+    input: CreateApiKeyCredentialProviderRequest,
+  ): Effect.Effect<
+    CreateApiKeyCredentialProviderResponse,
+    | AccessDeniedException
+    | ConflictException
+    | DecryptionFailure
+    | EncryptionFailure
+    | InternalServerException
+    | ResourceLimitExceededException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createBrowser(
+    input: CreateBrowserRequest,
+  ): Effect.Effect<
+    CreateBrowserResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCodeInterpreter(
+    input: CreateCodeInterpreterRequest,
+  ): Effect.Effect<
+    CreateCodeInterpreterResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createGateway(
+    input: CreateGatewayRequest,
+  ): Effect.Effect<
+    CreateGatewayResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createGatewayTarget(
+    input: CreateGatewayTargetRequest,
+  ): Effect.Effect<
+    CreateGatewayTargetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createMemory(
+    input: CreateMemoryInput,
+  ): Effect.Effect<
+    CreateMemoryOutput,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createOauth2CredentialProvider(
+    input: CreateOauth2CredentialProviderRequest,
+  ): Effect.Effect<
+    CreateOauth2CredentialProviderResponse,
+    | AccessDeniedException
+    | ConflictException
+    | DecryptionFailure
+    | EncryptionFailure
+    | InternalServerException
+    | ResourceLimitExceededException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkloadIdentity(
+    input: CreateWorkloadIdentityRequest,
+  ): Effect.Effect<
+    CreateWorkloadIdentityResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAgentRuntime(
+    input: DeleteAgentRuntimeRequest,
+  ): Effect.Effect<
+    DeleteAgentRuntimeResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteAgentRuntimeEndpoint(
+    input: DeleteAgentRuntimeEndpointRequest,
+  ): Effect.Effect<
+    DeleteAgentRuntimeEndpointResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteApiKeyCredentialProvider(
+    input: DeleteApiKeyCredentialProviderRequest,
+  ): Effect.Effect<
+    DeleteApiKeyCredentialProviderResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteBrowser(
+    input: DeleteBrowserRequest,
+  ): Effect.Effect<
+    DeleteBrowserResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCodeInterpreter(
+    input: DeleteCodeInterpreterRequest,
+  ): Effect.Effect<
+    DeleteCodeInterpreterResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteGateway(
+    input: DeleteGatewayRequest,
+  ): Effect.Effect<
+    DeleteGatewayResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteGatewayTarget(
+    input: DeleteGatewayTargetRequest,
+  ): Effect.Effect<
+    DeleteGatewayTargetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMemory(
+    input: DeleteMemoryInput,
+  ): Effect.Effect<
+    DeleteMemoryOutput,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ServiceException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteOauth2CredentialProvider(
+    input: DeleteOauth2CredentialProviderRequest,
+  ): Effect.Effect<
+    DeleteOauth2CredentialProviderResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkloadIdentity(
+    input: DeleteWorkloadIdentityRequest,
+  ): Effect.Effect<
+    DeleteWorkloadIdentityResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAgentRuntime(
+    input: GetAgentRuntimeRequest,
+  ): Effect.Effect<
+    GetAgentRuntimeResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAgentRuntimeEndpoint(
+    input: GetAgentRuntimeEndpointRequest,
+  ): Effect.Effect<
+    GetAgentRuntimeEndpointResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApiKeyCredentialProvider(
+    input: GetApiKeyCredentialProviderRequest,
+  ): Effect.Effect<
+    GetApiKeyCredentialProviderResponse,
+    | AccessDeniedException
+    | DecryptionFailure
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBrowser(
+    input: GetBrowserRequest,
+  ): Effect.Effect<
+    GetBrowserResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getCodeInterpreter(
+    input: GetCodeInterpreterRequest,
+  ): Effect.Effect<
+    GetCodeInterpreterResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getGateway(
+    input: GetGatewayRequest,
+  ): Effect.Effect<
+    GetGatewayResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getGatewayTarget(
+    input: GetGatewayTargetRequest,
+  ): Effect.Effect<
+    GetGatewayTargetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMemory(
+    input: GetMemoryInput,
+  ): Effect.Effect<
+    GetMemoryOutput,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ServiceException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getOauth2CredentialProvider(
+    input: GetOauth2CredentialProviderRequest,
+  ): Effect.Effect<
+    GetOauth2CredentialProviderResponse,
+    | AccessDeniedException
+    | DecryptionFailure
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorkloadIdentity(
+    input: GetWorkloadIdentityRequest,
+  ): Effect.Effect<
+    GetWorkloadIdentityResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgentRuntimeEndpoints(
+    input: ListAgentRuntimeEndpointsRequest,
+  ): Effect.Effect<
+    ListAgentRuntimeEndpointsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgentRuntimeVersions(
+    input: ListAgentRuntimeVersionsRequest,
+  ): Effect.Effect<
+    ListAgentRuntimeVersionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAgentRuntimes(
+    input: ListAgentRuntimesRequest,
+  ): Effect.Effect<
+    ListAgentRuntimesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApiKeyCredentialProviders(
+    input: ListApiKeyCredentialProvidersRequest,
+  ): Effect.Effect<
+    ListApiKeyCredentialProvidersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBrowsers(
+    input: ListBrowsersRequest,
+  ): Effect.Effect<
+    ListBrowsersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCodeInterpreters(
+    input: ListCodeInterpretersRequest,
+  ): Effect.Effect<
+    ListCodeInterpretersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listGatewayTargets(
+    input: ListGatewayTargetsRequest,
+  ): Effect.Effect<
+    ListGatewayTargetsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listGateways(
+    input: ListGatewaysRequest,
+  ): Effect.Effect<
+    ListGatewaysResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMemories(
+    input: ListMemoriesInput,
+  ): Effect.Effect<
+    ListMemoriesOutput,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ServiceException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listOauth2CredentialProviders(
+    input: ListOauth2CredentialProvidersRequest,
+  ): Effect.Effect<
+    ListOauth2CredentialProvidersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkloadIdentities(
+    input: ListWorkloadIdentitiesRequest,
+  ): Effect.Effect<
+    ListWorkloadIdentitiesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAgentRuntime(
+    input: UpdateAgentRuntimeRequest,
+  ): Effect.Effect<
+    UpdateAgentRuntimeResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAgentRuntimeEndpoint(
+    input: UpdateAgentRuntimeEndpointRequest,
+  ): Effect.Effect<
+    UpdateAgentRuntimeEndpointResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateApiKeyCredentialProvider(
+    input: UpdateApiKeyCredentialProviderRequest,
+  ): Effect.Effect<
+    UpdateApiKeyCredentialProviderResponse,
+    | AccessDeniedException
+    | ConflictException
+    | DecryptionFailure
+    | EncryptionFailure
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateGateway(
+    input: UpdateGatewayRequest,
+  ): Effect.Effect<
+    UpdateGatewayResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateGatewayTarget(
+    input: UpdateGatewayTargetRequest,
+  ): Effect.Effect<
+    UpdateGatewayTargetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateMemory(
+    input: UpdateMemoryInput,
+  ): Effect.Effect<
+    UpdateMemoryOutput,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateOauth2CredentialProvider(
+    input: UpdateOauth2CredentialProviderRequest,
+  ): Effect.Effect<
+    UpdateOauth2CredentialProviderResponse,
+    | AccessDeniedException
+    | ConflictException
+    | DecryptionFailure
+    | EncryptionFailure
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkloadIdentity(
+    input: UpdateWorkloadIdentityRequest,
+  ): Effect.Effect<
+    UpdateWorkloadIdentityResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class BedrockAgentcoreControl extends BedrockAgentCoreControl {}
@@ -1592,6 +2186,649 @@ export declare namespace SetTokenVaultCMK {
   export type Error =
     | AccessDeniedException
     | ConcurrentModificationException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAgentRuntime {
+  export type Input = CreateAgentRuntimeRequest;
+  export type Output = CreateAgentRuntimeResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAgentRuntimeEndpoint {
+  export type Input = CreateAgentRuntimeEndpointRequest;
+  export type Output = CreateAgentRuntimeEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateApiKeyCredentialProvider {
+  export type Input = CreateApiKeyCredentialProviderRequest;
+  export type Output = CreateApiKeyCredentialProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | DecryptionFailure
+    | EncryptionFailure
+    | InternalServerException
+    | ResourceLimitExceededException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBrowser {
+  export type Input = CreateBrowserRequest;
+  export type Output = CreateBrowserResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCodeInterpreter {
+  export type Input = CreateCodeInterpreterRequest;
+  export type Output = CreateCodeInterpreterResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGateway {
+  export type Input = CreateGatewayRequest;
+  export type Output = CreateGatewayResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGatewayTarget {
+  export type Input = CreateGatewayTargetRequest;
+  export type Output = CreateGatewayTargetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMemory {
+  export type Input = CreateMemoryInput;
+  export type Output = CreateMemoryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateOauth2CredentialProvider {
+  export type Input = CreateOauth2CredentialProviderRequest;
+  export type Output = CreateOauth2CredentialProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | DecryptionFailure
+    | EncryptionFailure
+    | InternalServerException
+    | ResourceLimitExceededException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkloadIdentity {
+  export type Input = CreateWorkloadIdentityRequest;
+  export type Output = CreateWorkloadIdentityResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAgentRuntime {
+  export type Input = DeleteAgentRuntimeRequest;
+  export type Output = DeleteAgentRuntimeResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAgentRuntimeEndpoint {
+  export type Input = DeleteAgentRuntimeEndpointRequest;
+  export type Output = DeleteAgentRuntimeEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApiKeyCredentialProvider {
+  export type Input = DeleteApiKeyCredentialProviderRequest;
+  export type Output = DeleteApiKeyCredentialProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteBrowser {
+  export type Input = DeleteBrowserRequest;
+  export type Output = DeleteBrowserResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCodeInterpreter {
+  export type Input = DeleteCodeInterpreterRequest;
+  export type Output = DeleteCodeInterpreterResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGateway {
+  export type Input = DeleteGatewayRequest;
+  export type Output = DeleteGatewayResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGatewayTarget {
+  export type Input = DeleteGatewayTargetRequest;
+  export type Output = DeleteGatewayTargetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMemory {
+  export type Input = DeleteMemoryInput;
+  export type Output = DeleteMemoryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ServiceException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteOauth2CredentialProvider {
+  export type Input = DeleteOauth2CredentialProviderRequest;
+  export type Output = DeleteOauth2CredentialProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkloadIdentity {
+  export type Input = DeleteWorkloadIdentityRequest;
+  export type Output = DeleteWorkloadIdentityResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgentRuntime {
+  export type Input = GetAgentRuntimeRequest;
+  export type Output = GetAgentRuntimeResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgentRuntimeEndpoint {
+  export type Input = GetAgentRuntimeEndpointRequest;
+  export type Output = GetAgentRuntimeEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApiKeyCredentialProvider {
+  export type Input = GetApiKeyCredentialProviderRequest;
+  export type Output = GetApiKeyCredentialProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | DecryptionFailure
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBrowser {
+  export type Input = GetBrowserRequest;
+  export type Output = GetBrowserResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetCodeInterpreter {
+  export type Input = GetCodeInterpreterRequest;
+  export type Output = GetCodeInterpreterResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetGateway {
+  export type Input = GetGatewayRequest;
+  export type Output = GetGatewayResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetGatewayTarget {
+  export type Input = GetGatewayTargetRequest;
+  export type Output = GetGatewayTargetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMemory {
+  export type Input = GetMemoryInput;
+  export type Output = GetMemoryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ServiceException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetOauth2CredentialProvider {
+  export type Input = GetOauth2CredentialProviderRequest;
+  export type Output = GetOauth2CredentialProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | DecryptionFailure
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkloadIdentity {
+  export type Input = GetWorkloadIdentityRequest;
+  export type Output = GetWorkloadIdentityResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgentRuntimeEndpoints {
+  export type Input = ListAgentRuntimeEndpointsRequest;
+  export type Output = ListAgentRuntimeEndpointsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgentRuntimeVersions {
+  export type Input = ListAgentRuntimeVersionsRequest;
+  export type Output = ListAgentRuntimeVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgentRuntimes {
+  export type Input = ListAgentRuntimesRequest;
+  export type Output = ListAgentRuntimesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApiKeyCredentialProviders {
+  export type Input = ListApiKeyCredentialProvidersRequest;
+  export type Output = ListApiKeyCredentialProvidersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBrowsers {
+  export type Input = ListBrowsersRequest;
+  export type Output = ListBrowsersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCodeInterpreters {
+  export type Input = ListCodeInterpretersRequest;
+  export type Output = ListCodeInterpretersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListGatewayTargets {
+  export type Input = ListGatewayTargetsRequest;
+  export type Output = ListGatewayTargetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListGateways {
+  export type Input = ListGatewaysRequest;
+  export type Output = ListGatewaysResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMemories {
+  export type Input = ListMemoriesInput;
+  export type Output = ListMemoriesOutput;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ServiceException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListOauth2CredentialProviders {
+  export type Input = ListOauth2CredentialProvidersRequest;
+  export type Output = ListOauth2CredentialProvidersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkloadIdentities {
+  export type Input = ListWorkloadIdentitiesRequest;
+  export type Output = ListWorkloadIdentitiesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgentRuntime {
+  export type Input = UpdateAgentRuntimeRequest;
+  export type Output = UpdateAgentRuntimeResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgentRuntimeEndpoint {
+  export type Input = UpdateAgentRuntimeEndpointRequest;
+  export type Output = UpdateAgentRuntimeEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateApiKeyCredentialProvider {
+  export type Input = UpdateApiKeyCredentialProviderRequest;
+  export type Output = UpdateApiKeyCredentialProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | DecryptionFailure
+    | EncryptionFailure
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGateway {
+  export type Input = UpdateGatewayRequest;
+  export type Output = UpdateGatewayResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGatewayTarget {
+  export type Input = UpdateGatewayTargetRequest;
+  export type Output = UpdateGatewayTargetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMemory {
+  export type Input = UpdateMemoryInput;
+  export type Output = UpdateMemoryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateOauth2CredentialProvider {
+  export type Input = UpdateOauth2CredentialProviderRequest;
+  export type Output = UpdateOauth2CredentialProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | DecryptionFailure
+    | EncryptionFailure
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkloadIdentity {
+  export type Input = UpdateWorkloadIdentityRequest;
+  export type Output = UpdateWorkloadIdentityResponse;
+  export type Error =
+    | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/bedrock-agentcore/index.ts
+++ b/src/services/bedrock-agentcore/index.ts
@@ -1,4 +1,6 @@
 import type { Effect, Stream, Data as EffectData } from "effect";
+import type { ResponseError } from "@effect/platform/HttpClientError";
+import type { Buffer } from "node:buffer";
 import type { CommonAwsError } from "../../error.ts";
 import { AWSServiceClient } from "../../client.ts";
 
@@ -67,6 +69,258 @@ export declare class BedrockAgentCore extends AWSServiceClient {
     input: InvokeCodeInterpreterRequest,
   ): Effect.Effect<
     InvokeCodeInterpreterResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEvent(
+    input: CreateEventInput,
+  ): Effect.Effect<
+    CreateEventOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEvent(
+    input: DeleteEventInput,
+  ): Effect.Effect<
+    DeleteEventOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMemoryRecord(
+    input: DeleteMemoryRecordInput,
+  ): Effect.Effect<
+    DeleteMemoryRecordOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBrowserSession(
+    input: GetBrowserSessionRequest,
+  ): Effect.Effect<
+    GetBrowserSessionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCodeInterpreterSession(
+    input: GetCodeInterpreterSessionRequest,
+  ): Effect.Effect<
+    GetCodeInterpreterSessionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEvent(
+    input: GetEventInput,
+  ): Effect.Effect<
+    GetEventOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMemoryRecord(
+    input: GetMemoryRecordInput,
+  ): Effect.Effect<
+    GetMemoryRecordOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  invokeAgentRuntime(
+    input: InvokeAgentRuntimeRequest,
+  ): Effect.Effect<
+    InvokeAgentRuntimeResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | RuntimeClientError
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listActors(
+    input: ListActorsInput,
+  ): Effect.Effect<
+    ListActorsOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBrowserSessions(
+    input: ListBrowserSessionsRequest,
+  ): Effect.Effect<
+    ListBrowserSessionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCodeInterpreterSessions(
+    input: ListCodeInterpreterSessionsRequest,
+  ): Effect.Effect<
+    ListCodeInterpreterSessionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEvents(
+    input: ListEventsInput,
+  ): Effect.Effect<
+    ListEventsOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMemoryRecords(
+    input: ListMemoryRecordsInput,
+  ): Effect.Effect<
+    ListMemoryRecordsOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSessions(
+    input: ListSessionsInput,
+  ): Effect.Effect<
+    ListSessionsOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  retrieveMemoryRecords(
+    input: RetrieveMemoryRecordsInput,
+  ): Effect.Effect<
+    RetrieveMemoryRecordsOutput,
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startBrowserSession(
+    input: StartBrowserSessionRequest,
+  ): Effect.Effect<
+    StartBrowserSessionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startCodeInterpreterSession(
+    input: StartCodeInterpreterSessionRequest,
+  ): Effect.Effect<
+    StartCodeInterpreterSessionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopBrowserSession(
+    input: StopBrowserSessionRequest,
+  ): Effect.Effect<
+    StopBrowserSessionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopCodeInterpreterSession(
+    input: StopCodeInterpreterSessionRequest,
+  ): Effect.Effect<
+    StopCodeInterpreterSessionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateBrowserStream(
+    input: UpdateBrowserStreamRequest,
+  ): Effect.Effect<
+    UpdateBrowserStreamResponse,
     | AccessDeniedException
     | ConflictException
     | InternalServerException
@@ -390,7 +644,7 @@ export interface InvokeAgentRuntimeRequest {
   baggage?: string;
   agentRuntimeArn: string;
   qualifier?: string;
-  payload: Uint8Array | string | Stream.Stream<Uint8Array>;
+  payload: Uint8Array | string | Buffer | Stream.Stream<Uint8Array>;
 }
 export interface InvokeAgentRuntimeResponse {
   runtimeSessionId?: string;
@@ -401,7 +655,7 @@ export interface InvokeAgentRuntimeResponse {
   traceState?: string;
   baggage?: string;
   contentType: string;
-  response?: Uint8Array | string | Stream.Stream<Uint8Array>;
+  response?: Stream.Stream<Uint8Array, ResponseError>;
   statusCode?: number;
 }
 export interface InvokeCodeInterpreterRequest {
@@ -817,6 +1071,278 @@ export declare namespace GetWorkloadAccessTokenForUserId {
 export declare namespace InvokeCodeInterpreter {
   export type Input = InvokeCodeInterpreterRequest;
   export type Output = InvokeCodeInterpreterResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEvent {
+  export type Input = CreateEventInput;
+  export type Output = CreateEventOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEvent {
+  export type Input = DeleteEventInput;
+  export type Output = DeleteEventOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMemoryRecord {
+  export type Input = DeleteMemoryRecordInput;
+  export type Output = DeleteMemoryRecordOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBrowserSession {
+  export type Input = GetBrowserSessionRequest;
+  export type Output = GetBrowserSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCodeInterpreterSession {
+  export type Input = GetCodeInterpreterSessionRequest;
+  export type Output = GetCodeInterpreterSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEvent {
+  export type Input = GetEventInput;
+  export type Output = GetEventOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMemoryRecord {
+  export type Input = GetMemoryRecordInput;
+  export type Output = GetMemoryRecordOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace InvokeAgentRuntime {
+  export type Input = InvokeAgentRuntimeRequest;
+  export type Output = InvokeAgentRuntimeResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | RuntimeClientError
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListActors {
+  export type Input = ListActorsInput;
+  export type Output = ListActorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBrowserSessions {
+  export type Input = ListBrowserSessionsRequest;
+  export type Output = ListBrowserSessionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCodeInterpreterSessions {
+  export type Input = ListCodeInterpreterSessionsRequest;
+  export type Output = ListCodeInterpreterSessionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEvents {
+  export type Input = ListEventsInput;
+  export type Output = ListEventsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMemoryRecords {
+  export type Input = ListMemoryRecordsInput;
+  export type Output = ListMemoryRecordsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSessions {
+  export type Input = ListSessionsInput;
+  export type Output = ListSessionsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RetrieveMemoryRecords {
+  export type Input = RetrieveMemoryRecordsInput;
+  export type Output = RetrieveMemoryRecordsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InvalidInputException
+    | ResourceNotFoundException
+    | ServiceException
+    | ServiceQuotaExceededException
+    | ThrottledException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartBrowserSession {
+  export type Input = StartBrowserSessionRequest;
+  export type Output = StartBrowserSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartCodeInterpreterSession {
+  export type Input = StartCodeInterpreterSessionRequest;
+  export type Output = StartCodeInterpreterSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopBrowserSession {
+  export type Input = StopBrowserSessionRequest;
+  export type Output = StopBrowserSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopCodeInterpreterSession {
+  export type Input = StopCodeInterpreterSessionRequest;
+  export type Output = StopCodeInterpreterSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBrowserStream {
+  export type Input = UpdateBrowserStreamRequest;
+  export type Output = UpdateBrowserStreamResponse;
   export type Error =
     | AccessDeniedException
     | ConflictException

--- a/src/services/bedrock-data-automation-runtime/index.ts
+++ b/src/services/bedrock-data-automation-runtime/index.ts
@@ -37,6 +37,28 @@ export declare class BedrockDataAutomationRuntime extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  getDataAutomationStatus(
+    input: GetDataAutomationStatusRequest,
+  ): Effect.Effect<
+    GetDataAutomationStatusResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  invokeDataAutomationAsync(
+    input: InvokeDataAutomationAsyncRequest,
+  ): Effect.Effect<
+    InvokeDataAutomationAsyncResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -227,6 +249,30 @@ export declare namespace UntagResource {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataAutomationStatus {
+  export type Input = GetDataAutomationStatusRequest;
+  export type Output = GetDataAutomationStatusResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace InvokeDataAutomationAsync {
+  export type Input = InvokeDataAutomationAsyncRequest;
+  export type Output = InvokeDataAutomationAsyncResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/bedrock-data-automation/index.ts
+++ b/src/services/bedrock-data-automation/index.ts
@@ -49,6 +49,121 @@ export declare class BedrockDataAutomation extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createBlueprint(
+    input: CreateBlueprintRequest,
+  ): Effect.Effect<
+    CreateBlueprintResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataAutomationProject(
+    input: CreateDataAutomationProjectRequest,
+  ): Effect.Effect<
+    CreateDataAutomationProjectResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteBlueprint(
+    input: DeleteBlueprintRequest,
+  ): Effect.Effect<
+    DeleteBlueprintResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataAutomationProject(
+    input: DeleteDataAutomationProjectRequest,
+  ): Effect.Effect<
+    DeleteDataAutomationProjectResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBlueprint(
+    input: GetBlueprintRequest,
+  ): Effect.Effect<
+    GetBlueprintResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataAutomationProject(
+    input: GetDataAutomationProjectRequest,
+  ): Effect.Effect<
+    GetDataAutomationProjectResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBlueprints(
+    input: ListBlueprintsRequest,
+  ): Effect.Effect<
+    ListBlueprintsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataAutomationProjects(
+    input: ListDataAutomationProjectsRequest,
+  ): Effect.Effect<
+    ListDataAutomationProjectsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateBlueprint(
+    input: UpdateBlueprintRequest,
+  ): Effect.Effect<
+    UpdateBlueprintResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataAutomationProject(
+    input: UpdateDataAutomationProjectRequest,
+  ): Effect.Effect<
+    UpdateDataAutomationProjectResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -545,6 +660,131 @@ export declare namespace UntagResource {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBlueprint {
+  export type Input = CreateBlueprintRequest;
+  export type Output = CreateBlueprintResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataAutomationProject {
+  export type Input = CreateDataAutomationProjectRequest;
+  export type Output = CreateDataAutomationProjectResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteBlueprint {
+  export type Input = DeleteBlueprintRequest;
+  export type Output = DeleteBlueprintResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataAutomationProject {
+  export type Input = DeleteDataAutomationProjectRequest;
+  export type Output = DeleteDataAutomationProjectResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBlueprint {
+  export type Input = GetBlueprintRequest;
+  export type Output = GetBlueprintResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataAutomationProject {
+  export type Input = GetDataAutomationProjectRequest;
+  export type Output = GetDataAutomationProjectResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBlueprints {
+  export type Input = ListBlueprintsRequest;
+  export type Output = ListBlueprintsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataAutomationProjects {
+  export type Input = ListDataAutomationProjectsRequest;
+  export type Output = ListDataAutomationProjectsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBlueprint {
+  export type Input = UpdateBlueprintRequest;
+  export type Output = UpdateBlueprintResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataAutomationProject {
+  export type Input = UpdateDataAutomationProjectRequest;
+  export type Output = UpdateDataAutomationProjectResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/billingconductor/index.ts
+++ b/src/services/billingconductor/index.ts
@@ -69,6 +69,305 @@ export declare class billingconductor extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateAccounts(
+    input: AssociateAccountsInput,
+  ): Effect.Effect<
+    AssociateAccountsOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associatePricingRules(
+    input: AssociatePricingRulesInput,
+  ): Effect.Effect<
+    AssociatePricingRulesOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchAssociateResourcesToCustomLineItem(
+    input: BatchAssociateResourcesToCustomLineItemInput,
+  ): Effect.Effect<
+    BatchAssociateResourcesToCustomLineItemOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchDisassociateResourcesFromCustomLineItem(
+    input: BatchDisassociateResourcesFromCustomLineItemInput,
+  ): Effect.Effect<
+    BatchDisassociateResourcesFromCustomLineItemOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createBillingGroup(
+    input: CreateBillingGroupInput,
+  ): Effect.Effect<
+    CreateBillingGroupOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCustomLineItem(
+    input: CreateCustomLineItemInput,
+  ): Effect.Effect<
+    CreateCustomLineItemOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPricingPlan(
+    input: CreatePricingPlanInput,
+  ): Effect.Effect<
+    CreatePricingPlanOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPricingRule(
+    input: CreatePricingRuleInput,
+  ): Effect.Effect<
+    CreatePricingRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteBillingGroup(
+    input: DeleteBillingGroupInput,
+  ): Effect.Effect<
+    DeleteBillingGroupOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCustomLineItem(
+    input: DeleteCustomLineItemInput,
+  ): Effect.Effect<
+    DeleteCustomLineItemOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePricingPlan(
+    input: DeletePricingPlanInput,
+  ): Effect.Effect<
+    DeletePricingPlanOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePricingRule(
+    input: DeletePricingRuleInput,
+  ): Effect.Effect<
+    DeletePricingRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateAccounts(
+    input: DisassociateAccountsInput,
+  ): Effect.Effect<
+    DisassociateAccountsOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociatePricingRules(
+    input: DisassociatePricingRulesInput,
+  ): Effect.Effect<
+    DisassociatePricingRulesOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBillingGroups(
+    input: ListBillingGroupsInput,
+  ): Effect.Effect<
+    ListBillingGroupsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCustomLineItemVersions(
+    input: ListCustomLineItemVersionsInput,
+  ): Effect.Effect<
+    ListCustomLineItemVersionsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCustomLineItems(
+    input: ListCustomLineItemsInput,
+  ): Effect.Effect<
+    ListCustomLineItemsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPricingPlans(
+    input: ListPricingPlansInput,
+  ): Effect.Effect<
+    ListPricingPlansOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPricingPlansAssociatedWithPricingRule(
+    input: ListPricingPlansAssociatedWithPricingRuleInput,
+  ): Effect.Effect<
+    ListPricingPlansAssociatedWithPricingRuleOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPricingRules(
+    input: ListPricingRulesInput,
+  ): Effect.Effect<
+    ListPricingRulesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPricingRulesAssociatedToPricingPlan(
+    input: ListPricingRulesAssociatedToPricingPlanInput,
+  ): Effect.Effect<
+    ListPricingRulesAssociatedToPricingPlanOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listResourcesAssociatedToCustomLineItem(
+    input: ListResourcesAssociatedToCustomLineItemInput,
+  ): Effect.Effect<
+    ListResourcesAssociatedToCustomLineItemOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateBillingGroup(
+    input: UpdateBillingGroupInput,
+  ): Effect.Effect<
+    UpdateBillingGroupOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCustomLineItem(
+    input: UpdateCustomLineItemInput,
+  ): Effect.Effect<
+    UpdateCustomLineItemOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updatePricingPlan(
+    input: UpdatePricingPlanInput,
+  ): Effect.Effect<
+    UpdatePricingPlanOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updatePricingRule(
+    input: UpdatePricingRuleInput,
+  ): Effect.Effect<
+    UpdatePricingRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Billingconductor extends billingconductor {}
@@ -909,6 +1208,331 @@ export declare namespace UntagResource {
   export type Output = UntagResourceResponse;
   export type Error =
     | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateAccounts {
+  export type Input = AssociateAccountsInput;
+  export type Output = AssociateAccountsOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociatePricingRules {
+  export type Input = AssociatePricingRulesInput;
+  export type Output = AssociatePricingRulesOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchAssociateResourcesToCustomLineItem {
+  export type Input = BatchAssociateResourcesToCustomLineItemInput;
+  export type Output = BatchAssociateResourcesToCustomLineItemOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchDisassociateResourcesFromCustomLineItem {
+  export type Input = BatchDisassociateResourcesFromCustomLineItemInput;
+  export type Output = BatchDisassociateResourcesFromCustomLineItemOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBillingGroup {
+  export type Input = CreateBillingGroupInput;
+  export type Output = CreateBillingGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCustomLineItem {
+  export type Input = CreateCustomLineItemInput;
+  export type Output = CreateCustomLineItemOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePricingPlan {
+  export type Input = CreatePricingPlanInput;
+  export type Output = CreatePricingPlanOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePricingRule {
+  export type Input = CreatePricingRuleInput;
+  export type Output = CreatePricingRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceLimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteBillingGroup {
+  export type Input = DeleteBillingGroupInput;
+  export type Output = DeleteBillingGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCustomLineItem {
+  export type Input = DeleteCustomLineItemInput;
+  export type Output = DeleteCustomLineItemOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePricingPlan {
+  export type Input = DeletePricingPlanInput;
+  export type Output = DeletePricingPlanOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePricingRule {
+  export type Input = DeletePricingRuleInput;
+  export type Output = DeletePricingRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateAccounts {
+  export type Input = DisassociateAccountsInput;
+  export type Output = DisassociateAccountsOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociatePricingRules {
+  export type Input = DisassociatePricingRulesInput;
+  export type Output = DisassociatePricingRulesOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBillingGroups {
+  export type Input = ListBillingGroupsInput;
+  export type Output = ListBillingGroupsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCustomLineItemVersions {
+  export type Input = ListCustomLineItemVersionsInput;
+  export type Output = ListCustomLineItemVersionsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCustomLineItems {
+  export type Input = ListCustomLineItemsInput;
+  export type Output = ListCustomLineItemsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPricingPlans {
+  export type Input = ListPricingPlansInput;
+  export type Output = ListPricingPlansOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPricingPlansAssociatedWithPricingRule {
+  export type Input = ListPricingPlansAssociatedWithPricingRuleInput;
+  export type Output = ListPricingPlansAssociatedWithPricingRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPricingRules {
+  export type Input = ListPricingRulesInput;
+  export type Output = ListPricingRulesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPricingRulesAssociatedToPricingPlan {
+  export type Input = ListPricingRulesAssociatedToPricingPlanInput;
+  export type Output = ListPricingRulesAssociatedToPricingPlanOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListResourcesAssociatedToCustomLineItem {
+  export type Input = ListResourcesAssociatedToCustomLineItemInput;
+  export type Output = ListResourcesAssociatedToCustomLineItemOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBillingGroup {
+  export type Input = UpdateBillingGroupInput;
+  export type Output = UpdateBillingGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCustomLineItem {
+  export type Input = UpdateCustomLineItemInput;
+  export type Output = UpdateCustomLineItemOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePricingPlan {
+  export type Input = UpdatePricingPlanInput;
+  export type Output = UpdatePricingPlanOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePricingRule {
+  export type Input = UpdatePricingRuleInput;
+  export type Output = UpdatePricingRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/braket/index.ts
+++ b/src/services/braket/index.ts
@@ -30,6 +30,120 @@ export declare class Braket extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  cancelJob(
+    input: CancelJobRequest,
+  ): Effect.Effect<
+    CancelJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  cancelQuantumTask(
+    input: CancelQuantumTaskRequest,
+  ): Effect.Effect<
+    CancelQuantumTaskResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createJob(
+    input: CreateJobRequest,
+  ): Effect.Effect<
+    CreateJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | DeviceOfflineException
+    | DeviceRetiredException
+    | InternalServiceException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createQuantumTask(
+    input: CreateQuantumTaskRequest,
+  ): Effect.Effect<
+    CreateQuantumTaskResponse,
+    | AccessDeniedException
+    | DeviceOfflineException
+    | DeviceRetiredException
+    | InternalServiceException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDevice(
+    input: GetDeviceRequest,
+  ): Effect.Effect<
+    GetDeviceResponse,
+    | AccessDeniedException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getJob(
+    input: GetJobRequest,
+  ): Effect.Effect<
+    GetJobResponse,
+    | AccessDeniedException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQuantumTask(
+    input: GetQuantumTaskRequest,
+  ): Effect.Effect<
+    GetQuantumTaskResponse,
+    | AccessDeniedException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchDevices(
+    input: SearchDevicesRequest,
+  ): Effect.Effect<
+    SearchDevicesResponse,
+    | AccessDeniedException
+    | InternalServiceException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchJobs(
+    input: SearchJobsRequest,
+  ): Effect.Effect<
+    SearchJobsResponse,
+    | AccessDeniedException
+    | InternalServiceException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchQuantumTasks(
+    input: SearchQuantumTasksRequest,
+  ): Effect.Effect<
+    SearchQuantumTasksResponse,
+    | AccessDeniedException
+    | InternalServiceException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -436,6 +550,130 @@ export declare namespace UntagResource {
   export type Error =
     | InternalServiceException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelJob {
+  export type Input = CancelJobRequest;
+  export type Output = CancelJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelQuantumTask {
+  export type Input = CancelQuantumTaskRequest;
+  export type Output = CancelQuantumTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateJob {
+  export type Input = CreateJobRequest;
+  export type Output = CreateJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | DeviceOfflineException
+    | DeviceRetiredException
+    | InternalServiceException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateQuantumTask {
+  export type Input = CreateQuantumTaskRequest;
+  export type Output = CreateQuantumTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | DeviceOfflineException
+    | DeviceRetiredException
+    | InternalServiceException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDevice {
+  export type Input = GetDeviceRequest;
+  export type Output = GetDeviceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetJob {
+  export type Input = GetJobRequest;
+  export type Output = GetJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQuantumTask {
+  export type Input = GetQuantumTaskRequest;
+  export type Output = GetQuantumTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchDevices {
+  export type Input = SearchDevicesRequest;
+  export type Output = SearchDevicesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchJobs {
+  export type Input = SearchJobsRequest;
+  export type Output = SearchJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchQuantumTasks {
+  export type Input = SearchQuantumTasksRequest;
+  export type Output = SearchQuantumTasksResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/chatbot/index.ts
+++ b/src/services/chatbot/index.ts
@@ -266,6 +266,56 @@ export declare class chatbot extends AWSServiceClient {
     | UpdateSlackChannelConfigurationException
     | CommonAwsError
   >;
+  createCustomAction(
+    input: CreateCustomActionRequest,
+  ): Effect.Effect<
+    CreateCustomActionResult,
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | LimitExceededException
+    | UnauthorizedException
+    | CommonAwsError
+  >;
+  deleteCustomAction(
+    input: DeleteCustomActionRequest,
+  ): Effect.Effect<
+    DeleteCustomActionResult,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | CommonAwsError
+  >;
+  getCustomAction(
+    input: GetCustomActionRequest,
+  ): Effect.Effect<
+    GetCustomActionResult,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | CommonAwsError
+  >;
+  listCustomActions(
+    input: ListCustomActionsRequest,
+  ): Effect.Effect<
+    ListCustomActionsResult,
+    | InternalServiceError
+    | InvalidRequestException
+    | UnauthorizedException
+    | CommonAwsError
+  >;
+  updateCustomAction(
+    input: UpdateCustomActionRequest,
+  ): Effect.Effect<
+    UpdateCustomActionResult,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | CommonAwsError
+  >;
 }
 
 export declare class Chatbot extends chatbot {}
@@ -1176,5 +1226,60 @@ export declare namespace UpdateSlackChannelConfiguration {
     | InvalidRequestException
     | ResourceNotFoundException
     | UpdateSlackChannelConfigurationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCustomAction {
+  export type Input = CreateCustomActionRequest;
+  export type Output = CreateCustomActionResult;
+  export type Error =
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | LimitExceededException
+    | UnauthorizedException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCustomAction {
+  export type Input = DeleteCustomActionRequest;
+  export type Output = DeleteCustomActionResult;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | CommonAwsError;
+}
+
+export declare namespace GetCustomAction {
+  export type Input = GetCustomActionRequest;
+  export type Output = GetCustomActionResult;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | CommonAwsError;
+}
+
+export declare namespace ListCustomActions {
+  export type Input = ListCustomActionsRequest;
+  export type Output = ListCustomActionsResult;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | UnauthorizedException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCustomAction {
+  export type Input = UpdateCustomActionRequest;
+  export type Output = UpdateCustomActionResult;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | UnauthorizedException
     | CommonAwsError;
 }

--- a/src/services/cleanrooms/index.ts
+++ b/src/services/cleanrooms/index.ts
@@ -21,6 +21,928 @@ export declare class CleanRooms extends AWSServiceClient {
     UntagResourceOutput,
     ResourceNotFoundException | ValidationException | CommonAwsError
   >;
+  batchGetCollaborationAnalysisTemplate(
+    input: BatchGetCollaborationAnalysisTemplateInput,
+  ): Effect.Effect<
+    BatchGetCollaborationAnalysisTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchGetSchema(
+    input: BatchGetSchemaInput,
+  ): Effect.Effect<
+    BatchGetSchemaOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchGetSchemaAnalysisRule(
+    input: BatchGetSchemaAnalysisRuleInput,
+  ): Effect.Effect<
+    BatchGetSchemaAnalysisRuleOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAnalysisTemplate(
+    input: CreateAnalysisTemplateInput,
+  ): Effect.Effect<
+    CreateAnalysisTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCollaboration(
+    input: CreateCollaborationInput,
+  ): Effect.Effect<
+    CreateCollaborationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConfiguredAudienceModelAssociation(
+    input: CreateConfiguredAudienceModelAssociationInput,
+  ): Effect.Effect<
+    CreateConfiguredAudienceModelAssociationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConfiguredTable(
+    input: CreateConfiguredTableInput,
+  ): Effect.Effect<
+    CreateConfiguredTableOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConfiguredTableAnalysisRule(
+    input: CreateConfiguredTableAnalysisRuleInput,
+  ): Effect.Effect<
+    CreateConfiguredTableAnalysisRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConfiguredTableAssociation(
+    input: CreateConfiguredTableAssociationInput,
+  ): Effect.Effect<
+    CreateConfiguredTableAssociationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConfiguredTableAssociationAnalysisRule(
+    input: CreateConfiguredTableAssociationAnalysisRuleInput,
+  ): Effect.Effect<
+    CreateConfiguredTableAssociationAnalysisRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createIdMappingTable(
+    input: CreateIdMappingTableInput,
+  ): Effect.Effect<
+    CreateIdMappingTableOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createIdNamespaceAssociation(
+    input: CreateIdNamespaceAssociationInput,
+  ): Effect.Effect<
+    CreateIdNamespaceAssociationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createMembership(
+    input: CreateMembershipInput,
+  ): Effect.Effect<
+    CreateMembershipOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPrivacyBudgetTemplate(
+    input: CreatePrivacyBudgetTemplateInput,
+  ): Effect.Effect<
+    CreatePrivacyBudgetTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAnalysisTemplate(
+    input: DeleteAnalysisTemplateInput,
+  ): Effect.Effect<
+    DeleteAnalysisTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCollaboration(
+    input: DeleteCollaborationInput,
+  ): Effect.Effect<
+    DeleteCollaborationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredAudienceModelAssociation(
+    input: DeleteConfiguredAudienceModelAssociationInput,
+  ): Effect.Effect<
+    DeleteConfiguredAudienceModelAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredTable(
+    input: DeleteConfiguredTableInput,
+  ): Effect.Effect<
+    DeleteConfiguredTableOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredTableAnalysisRule(
+    input: DeleteConfiguredTableAnalysisRuleInput,
+  ): Effect.Effect<
+    DeleteConfiguredTableAnalysisRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredTableAssociation(
+    input: DeleteConfiguredTableAssociationInput,
+  ): Effect.Effect<
+    DeleteConfiguredTableAssociationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredTableAssociationAnalysisRule(
+    input: DeleteConfiguredTableAssociationAnalysisRuleInput,
+  ): Effect.Effect<
+    DeleteConfiguredTableAssociationAnalysisRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteIdMappingTable(
+    input: DeleteIdMappingTableInput,
+  ): Effect.Effect<
+    DeleteIdMappingTableOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteIdNamespaceAssociation(
+    input: DeleteIdNamespaceAssociationInput,
+  ): Effect.Effect<
+    DeleteIdNamespaceAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMember(
+    input: DeleteMemberInput,
+  ): Effect.Effect<
+    DeleteMemberOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMembership(
+    input: DeleteMembershipInput,
+  ): Effect.Effect<
+    DeleteMembershipOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePrivacyBudgetTemplate(
+    input: DeletePrivacyBudgetTemplateInput,
+  ): Effect.Effect<
+    DeletePrivacyBudgetTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAnalysisTemplate(
+    input: GetAnalysisTemplateInput,
+  ): Effect.Effect<
+    GetAnalysisTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCollaboration(
+    input: GetCollaborationInput,
+  ): Effect.Effect<
+    GetCollaborationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCollaborationAnalysisTemplate(
+    input: GetCollaborationAnalysisTemplateInput,
+  ): Effect.Effect<
+    GetCollaborationAnalysisTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCollaborationConfiguredAudienceModelAssociation(
+    input: GetCollaborationConfiguredAudienceModelAssociationInput,
+  ): Effect.Effect<
+    GetCollaborationConfiguredAudienceModelAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCollaborationIdNamespaceAssociation(
+    input: GetCollaborationIdNamespaceAssociationInput,
+  ): Effect.Effect<
+    GetCollaborationIdNamespaceAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCollaborationPrivacyBudgetTemplate(
+    input: GetCollaborationPrivacyBudgetTemplateInput,
+  ): Effect.Effect<
+    GetCollaborationPrivacyBudgetTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredAudienceModelAssociation(
+    input: GetConfiguredAudienceModelAssociationInput,
+  ): Effect.Effect<
+    GetConfiguredAudienceModelAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredTable(
+    input: GetConfiguredTableInput,
+  ): Effect.Effect<
+    GetConfiguredTableOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredTableAnalysisRule(
+    input: GetConfiguredTableAnalysisRuleInput,
+  ): Effect.Effect<
+    GetConfiguredTableAnalysisRuleOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredTableAssociation(
+    input: GetConfiguredTableAssociationInput,
+  ): Effect.Effect<
+    GetConfiguredTableAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredTableAssociationAnalysisRule(
+    input: GetConfiguredTableAssociationAnalysisRuleInput,
+  ): Effect.Effect<
+    GetConfiguredTableAssociationAnalysisRuleOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getIdMappingTable(
+    input: GetIdMappingTableInput,
+  ): Effect.Effect<
+    GetIdMappingTableOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getIdNamespaceAssociation(
+    input: GetIdNamespaceAssociationInput,
+  ): Effect.Effect<
+    GetIdNamespaceAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMembership(
+    input: GetMembershipInput,
+  ): Effect.Effect<
+    GetMembershipOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getPrivacyBudgetTemplate(
+    input: GetPrivacyBudgetTemplateInput,
+  ): Effect.Effect<
+    GetPrivacyBudgetTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getProtectedJob(
+    input: GetProtectedJobInput,
+  ): Effect.Effect<
+    GetProtectedJobOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getProtectedQuery(
+    input: GetProtectedQueryInput,
+  ): Effect.Effect<
+    GetProtectedQueryOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSchema(
+    input: GetSchemaInput,
+  ): Effect.Effect<
+    GetSchemaOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSchemaAnalysisRule(
+    input: GetSchemaAnalysisRuleInput,
+  ): Effect.Effect<
+    GetSchemaAnalysisRuleOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAnalysisTemplates(
+    input: ListAnalysisTemplatesInput,
+  ): Effect.Effect<
+    ListAnalysisTemplatesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCollaborationAnalysisTemplates(
+    input: ListCollaborationAnalysisTemplatesInput,
+  ): Effect.Effect<
+    ListCollaborationAnalysisTemplatesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCollaborationConfiguredAudienceModelAssociations(
+    input: ListCollaborationConfiguredAudienceModelAssociationsInput,
+  ): Effect.Effect<
+    ListCollaborationConfiguredAudienceModelAssociationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCollaborationIdNamespaceAssociations(
+    input: ListCollaborationIdNamespaceAssociationsInput,
+  ): Effect.Effect<
+    ListCollaborationIdNamespaceAssociationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCollaborationPrivacyBudgetTemplates(
+    input: ListCollaborationPrivacyBudgetTemplatesInput,
+  ): Effect.Effect<
+    ListCollaborationPrivacyBudgetTemplatesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCollaborationPrivacyBudgets(
+    input: ListCollaborationPrivacyBudgetsInput,
+  ): Effect.Effect<
+    ListCollaborationPrivacyBudgetsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCollaborations(
+    input: ListCollaborationsInput,
+  ): Effect.Effect<
+    ListCollaborationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listConfiguredAudienceModelAssociations(
+    input: ListConfiguredAudienceModelAssociationsInput,
+  ): Effect.Effect<
+    ListConfiguredAudienceModelAssociationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listConfiguredTableAssociations(
+    input: ListConfiguredTableAssociationsInput,
+  ): Effect.Effect<
+    ListConfiguredTableAssociationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listConfiguredTables(
+    input: ListConfiguredTablesInput,
+  ): Effect.Effect<
+    ListConfiguredTablesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIdMappingTables(
+    input: ListIdMappingTablesInput,
+  ): Effect.Effect<
+    ListIdMappingTablesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIdNamespaceAssociations(
+    input: ListIdNamespaceAssociationsInput,
+  ): Effect.Effect<
+    ListIdNamespaceAssociationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMembers(
+    input: ListMembersInput,
+  ): Effect.Effect<
+    ListMembersOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMemberships(
+    input: ListMembershipsInput,
+  ): Effect.Effect<
+    ListMembershipsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPrivacyBudgetTemplates(
+    input: ListPrivacyBudgetTemplatesInput,
+  ): Effect.Effect<
+    ListPrivacyBudgetTemplatesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPrivacyBudgets(
+    input: ListPrivacyBudgetsInput,
+  ): Effect.Effect<
+    ListPrivacyBudgetsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listProtectedJobs(
+    input: ListProtectedJobsInput,
+  ): Effect.Effect<
+    ListProtectedJobsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listProtectedQueries(
+    input: ListProtectedQueriesInput,
+  ): Effect.Effect<
+    ListProtectedQueriesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSchemas(
+    input: ListSchemasInput,
+  ): Effect.Effect<
+    ListSchemasOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  populateIdMappingTable(
+    input: PopulateIdMappingTableInput,
+  ): Effect.Effect<
+    PopulateIdMappingTableOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  previewPrivacyImpact(
+    input: PreviewPrivacyImpactInput,
+  ): Effect.Effect<
+    PreviewPrivacyImpactOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startProtectedJob(
+    input: StartProtectedJobInput,
+  ): Effect.Effect<
+    StartProtectedJobOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startProtectedQuery(
+    input: StartProtectedQueryInput,
+  ): Effect.Effect<
+    StartProtectedQueryOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAnalysisTemplate(
+    input: UpdateAnalysisTemplateInput,
+  ): Effect.Effect<
+    UpdateAnalysisTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCollaboration(
+    input: UpdateCollaborationInput,
+  ): Effect.Effect<
+    UpdateCollaborationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateConfiguredAudienceModelAssociation(
+    input: UpdateConfiguredAudienceModelAssociationInput,
+  ): Effect.Effect<
+    UpdateConfiguredAudienceModelAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateConfiguredTable(
+    input: UpdateConfiguredTableInput,
+  ): Effect.Effect<
+    UpdateConfiguredTableOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateConfiguredTableAnalysisRule(
+    input: UpdateConfiguredTableAnalysisRuleInput,
+  ): Effect.Effect<
+    UpdateConfiguredTableAnalysisRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateConfiguredTableAssociation(
+    input: UpdateConfiguredTableAssociationInput,
+  ): Effect.Effect<
+    UpdateConfiguredTableAssociationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateConfiguredTableAssociationAnalysisRule(
+    input: UpdateConfiguredTableAssociationAnalysisRuleInput,
+  ): Effect.Effect<
+    UpdateConfiguredTableAssociationAnalysisRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateIdMappingTable(
+    input: UpdateIdMappingTableInput,
+  ): Effect.Effect<
+    UpdateIdMappingTableOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateIdNamespaceAssociation(
+    input: UpdateIdNamespaceAssociationInput,
+  ): Effect.Effect<
+    UpdateIdNamespaceAssociationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateMembership(
+    input: UpdateMembershipInput,
+  ): Effect.Effect<
+    UpdateMembershipOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updatePrivacyBudgetTemplate(
+    input: UpdatePrivacyBudgetTemplateInput,
+  ): Effect.Effect<
+    UpdatePrivacyBudgetTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateProtectedJob(
+    input: UpdateProtectedJobInput,
+  ): Effect.Effect<
+    UpdateProtectedJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateProtectedQuery(
+    input: UpdateProtectedQueryInput,
+  ): Effect.Effect<
+    UpdateProtectedQueryOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Cleanrooms extends CleanRooms {}
@@ -2312,6 +3234,1010 @@ export declare namespace UntagResource {
   export type Output = UntagResourceOutput;
   export type Error =
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetCollaborationAnalysisTemplate {
+  export type Input = BatchGetCollaborationAnalysisTemplateInput;
+  export type Output = BatchGetCollaborationAnalysisTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetSchema {
+  export type Input = BatchGetSchemaInput;
+  export type Output = BatchGetSchemaOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetSchemaAnalysisRule {
+  export type Input = BatchGetSchemaAnalysisRuleInput;
+  export type Output = BatchGetSchemaAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAnalysisTemplate {
+  export type Input = CreateAnalysisTemplateInput;
+  export type Output = CreateAnalysisTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCollaboration {
+  export type Input = CreateCollaborationInput;
+  export type Output = CreateCollaborationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfiguredAudienceModelAssociation {
+  export type Input = CreateConfiguredAudienceModelAssociationInput;
+  export type Output = CreateConfiguredAudienceModelAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfiguredTable {
+  export type Input = CreateConfiguredTableInput;
+  export type Output = CreateConfiguredTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfiguredTableAnalysisRule {
+  export type Input = CreateConfiguredTableAnalysisRuleInput;
+  export type Output = CreateConfiguredTableAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfiguredTableAssociation {
+  export type Input = CreateConfiguredTableAssociationInput;
+  export type Output = CreateConfiguredTableAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfiguredTableAssociationAnalysisRule {
+  export type Input = CreateConfiguredTableAssociationAnalysisRuleInput;
+  export type Output = CreateConfiguredTableAssociationAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateIdMappingTable {
+  export type Input = CreateIdMappingTableInput;
+  export type Output = CreateIdMappingTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateIdNamespaceAssociation {
+  export type Input = CreateIdNamespaceAssociationInput;
+  export type Output = CreateIdNamespaceAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMembership {
+  export type Input = CreateMembershipInput;
+  export type Output = CreateMembershipOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePrivacyBudgetTemplate {
+  export type Input = CreatePrivacyBudgetTemplateInput;
+  export type Output = CreatePrivacyBudgetTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAnalysisTemplate {
+  export type Input = DeleteAnalysisTemplateInput;
+  export type Output = DeleteAnalysisTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCollaboration {
+  export type Input = DeleteCollaborationInput;
+  export type Output = DeleteCollaborationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredAudienceModelAssociation {
+  export type Input = DeleteConfiguredAudienceModelAssociationInput;
+  export type Output = DeleteConfiguredAudienceModelAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredTable {
+  export type Input = DeleteConfiguredTableInput;
+  export type Output = DeleteConfiguredTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredTableAnalysisRule {
+  export type Input = DeleteConfiguredTableAnalysisRuleInput;
+  export type Output = DeleteConfiguredTableAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredTableAssociation {
+  export type Input = DeleteConfiguredTableAssociationInput;
+  export type Output = DeleteConfiguredTableAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredTableAssociationAnalysisRule {
+  export type Input = DeleteConfiguredTableAssociationAnalysisRuleInput;
+  export type Output = DeleteConfiguredTableAssociationAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIdMappingTable {
+  export type Input = DeleteIdMappingTableInput;
+  export type Output = DeleteIdMappingTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIdNamespaceAssociation {
+  export type Input = DeleteIdNamespaceAssociationInput;
+  export type Output = DeleteIdNamespaceAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMember {
+  export type Input = DeleteMemberInput;
+  export type Output = DeleteMemberOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMembership {
+  export type Input = DeleteMembershipInput;
+  export type Output = DeleteMembershipOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePrivacyBudgetTemplate {
+  export type Input = DeletePrivacyBudgetTemplateInput;
+  export type Output = DeletePrivacyBudgetTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAnalysisTemplate {
+  export type Input = GetAnalysisTemplateInput;
+  export type Output = GetAnalysisTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCollaboration {
+  export type Input = GetCollaborationInput;
+  export type Output = GetCollaborationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCollaborationAnalysisTemplate {
+  export type Input = GetCollaborationAnalysisTemplateInput;
+  export type Output = GetCollaborationAnalysisTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCollaborationConfiguredAudienceModelAssociation {
+  export type Input = GetCollaborationConfiguredAudienceModelAssociationInput;
+  export type Output = GetCollaborationConfiguredAudienceModelAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCollaborationIdNamespaceAssociation {
+  export type Input = GetCollaborationIdNamespaceAssociationInput;
+  export type Output = GetCollaborationIdNamespaceAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCollaborationPrivacyBudgetTemplate {
+  export type Input = GetCollaborationPrivacyBudgetTemplateInput;
+  export type Output = GetCollaborationPrivacyBudgetTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredAudienceModelAssociation {
+  export type Input = GetConfiguredAudienceModelAssociationInput;
+  export type Output = GetConfiguredAudienceModelAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredTable {
+  export type Input = GetConfiguredTableInput;
+  export type Output = GetConfiguredTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredTableAnalysisRule {
+  export type Input = GetConfiguredTableAnalysisRuleInput;
+  export type Output = GetConfiguredTableAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredTableAssociation {
+  export type Input = GetConfiguredTableAssociationInput;
+  export type Output = GetConfiguredTableAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredTableAssociationAnalysisRule {
+  export type Input = GetConfiguredTableAssociationAnalysisRuleInput;
+  export type Output = GetConfiguredTableAssociationAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetIdMappingTable {
+  export type Input = GetIdMappingTableInput;
+  export type Output = GetIdMappingTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetIdNamespaceAssociation {
+  export type Input = GetIdNamespaceAssociationInput;
+  export type Output = GetIdNamespaceAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMembership {
+  export type Input = GetMembershipInput;
+  export type Output = GetMembershipOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetPrivacyBudgetTemplate {
+  export type Input = GetPrivacyBudgetTemplateInput;
+  export type Output = GetPrivacyBudgetTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetProtectedJob {
+  export type Input = GetProtectedJobInput;
+  export type Output = GetProtectedJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetProtectedQuery {
+  export type Input = GetProtectedQueryInput;
+  export type Output = GetProtectedQueryOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSchema {
+  export type Input = GetSchemaInput;
+  export type Output = GetSchemaOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSchemaAnalysisRule {
+  export type Input = GetSchemaAnalysisRuleInput;
+  export type Output = GetSchemaAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAnalysisTemplates {
+  export type Input = ListAnalysisTemplatesInput;
+  export type Output = ListAnalysisTemplatesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCollaborationAnalysisTemplates {
+  export type Input = ListCollaborationAnalysisTemplatesInput;
+  export type Output = ListCollaborationAnalysisTemplatesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCollaborationConfiguredAudienceModelAssociations {
+  export type Input = ListCollaborationConfiguredAudienceModelAssociationsInput;
+  export type Output =
+    ListCollaborationConfiguredAudienceModelAssociationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCollaborationIdNamespaceAssociations {
+  export type Input = ListCollaborationIdNamespaceAssociationsInput;
+  export type Output = ListCollaborationIdNamespaceAssociationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCollaborationPrivacyBudgetTemplates {
+  export type Input = ListCollaborationPrivacyBudgetTemplatesInput;
+  export type Output = ListCollaborationPrivacyBudgetTemplatesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCollaborationPrivacyBudgets {
+  export type Input = ListCollaborationPrivacyBudgetsInput;
+  export type Output = ListCollaborationPrivacyBudgetsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCollaborations {
+  export type Input = ListCollaborationsInput;
+  export type Output = ListCollaborationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConfiguredAudienceModelAssociations {
+  export type Input = ListConfiguredAudienceModelAssociationsInput;
+  export type Output = ListConfiguredAudienceModelAssociationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConfiguredTableAssociations {
+  export type Input = ListConfiguredTableAssociationsInput;
+  export type Output = ListConfiguredTableAssociationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConfiguredTables {
+  export type Input = ListConfiguredTablesInput;
+  export type Output = ListConfiguredTablesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIdMappingTables {
+  export type Input = ListIdMappingTablesInput;
+  export type Output = ListIdMappingTablesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIdNamespaceAssociations {
+  export type Input = ListIdNamespaceAssociationsInput;
+  export type Output = ListIdNamespaceAssociationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMembers {
+  export type Input = ListMembersInput;
+  export type Output = ListMembersOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMemberships {
+  export type Input = ListMembershipsInput;
+  export type Output = ListMembershipsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPrivacyBudgetTemplates {
+  export type Input = ListPrivacyBudgetTemplatesInput;
+  export type Output = ListPrivacyBudgetTemplatesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPrivacyBudgets {
+  export type Input = ListPrivacyBudgetsInput;
+  export type Output = ListPrivacyBudgetsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListProtectedJobs {
+  export type Input = ListProtectedJobsInput;
+  export type Output = ListProtectedJobsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListProtectedQueries {
+  export type Input = ListProtectedQueriesInput;
+  export type Output = ListProtectedQueriesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSchemas {
+  export type Input = ListSchemasInput;
+  export type Output = ListSchemasOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PopulateIdMappingTable {
+  export type Input = PopulateIdMappingTableInput;
+  export type Output = PopulateIdMappingTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PreviewPrivacyImpact {
+  export type Input = PreviewPrivacyImpactInput;
+  export type Output = PreviewPrivacyImpactOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartProtectedJob {
+  export type Input = StartProtectedJobInput;
+  export type Output = StartProtectedJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartProtectedQuery {
+  export type Input = StartProtectedQueryInput;
+  export type Output = StartProtectedQueryOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAnalysisTemplate {
+  export type Input = UpdateAnalysisTemplateInput;
+  export type Output = UpdateAnalysisTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCollaboration {
+  export type Input = UpdateCollaborationInput;
+  export type Output = UpdateCollaborationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConfiguredAudienceModelAssociation {
+  export type Input = UpdateConfiguredAudienceModelAssociationInput;
+  export type Output = UpdateConfiguredAudienceModelAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConfiguredTable {
+  export type Input = UpdateConfiguredTableInput;
+  export type Output = UpdateConfiguredTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConfiguredTableAnalysisRule {
+  export type Input = UpdateConfiguredTableAnalysisRuleInput;
+  export type Output = UpdateConfiguredTableAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConfiguredTableAssociation {
+  export type Input = UpdateConfiguredTableAssociationInput;
+  export type Output = UpdateConfiguredTableAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConfiguredTableAssociationAnalysisRule {
+  export type Input = UpdateConfiguredTableAssociationAnalysisRuleInput;
+  export type Output = UpdateConfiguredTableAssociationAnalysisRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateIdMappingTable {
+  export type Input = UpdateIdMappingTableInput;
+  export type Output = UpdateIdMappingTableOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateIdNamespaceAssociation {
+  export type Input = UpdateIdNamespaceAssociationInput;
+  export type Output = UpdateIdNamespaceAssociationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMembership {
+  export type Input = UpdateMembershipInput;
+  export type Output = UpdateMembershipOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePrivacyBudgetTemplate {
+  export type Input = UpdatePrivacyBudgetTemplateInput;
+  export type Output = UpdatePrivacyBudgetTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProtectedJob {
+  export type Input = UpdateProtectedJobInput;
+  export type Output = UpdateProtectedJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProtectedQuery {
+  export type Input = UpdateProtectedQueryInput;
+  export type Output = UpdateProtectedQueryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/cleanroomsml/index.ts
+++ b/src/services/cleanroomsml/index.ts
@@ -75,6 +75,498 @@ export declare class CleanRoomsML extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  cancelTrainedModel(
+    input: CancelTrainedModelRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  cancelTrainedModelInferenceJob(
+    input: CancelTrainedModelInferenceJobRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAudienceModel(
+    input: CreateAudienceModelRequest,
+  ): Effect.Effect<
+    CreateAudienceModelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConfiguredAudienceModel(
+    input: CreateConfiguredAudienceModelRequest,
+  ): Effect.Effect<
+    CreateConfiguredAudienceModelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConfiguredModelAlgorithm(
+    input: CreateConfiguredModelAlgorithmRequest,
+  ): Effect.Effect<
+    CreateConfiguredModelAlgorithmResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConfiguredModelAlgorithmAssociation(
+    input: CreateConfiguredModelAlgorithmAssociationRequest,
+  ): Effect.Effect<
+    CreateConfiguredModelAlgorithmAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createMLInputChannel(
+    input: CreateMLInputChannelRequest,
+  ): Effect.Effect<
+    CreateMLInputChannelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTrainedModel(
+    input: CreateTrainedModelRequest,
+  ): Effect.Effect<
+    CreateTrainedModelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTrainingDataset(
+    input: CreateTrainingDatasetRequest,
+  ): Effect.Effect<
+    CreateTrainingDatasetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAudienceGenerationJob(
+    input: DeleteAudienceGenerationJobRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAudienceModel(
+    input: DeleteAudienceModelRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredAudienceModel(
+    input: DeleteConfiguredAudienceModelRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredAudienceModelPolicy(
+    input: DeleteConfiguredAudienceModelPolicyRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredModelAlgorithm(
+    input: DeleteConfiguredModelAlgorithmRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConfiguredModelAlgorithmAssociation(
+    input: DeleteConfiguredModelAlgorithmAssociationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMLConfiguration(
+    input: DeleteMLConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMLInputChannelData(
+    input: DeleteMLInputChannelDataRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTrainedModelOutput(
+    input: DeleteTrainedModelOutputRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTrainingDataset(
+    input: DeleteTrainingDatasetRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAudienceGenerationJob(
+    input: GetAudienceGenerationJobRequest,
+  ): Effect.Effect<
+    GetAudienceGenerationJobResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAudienceModel(
+    input: GetAudienceModelRequest,
+  ): Effect.Effect<
+    GetAudienceModelResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCollaborationConfiguredModelAlgorithmAssociation(
+    input: GetCollaborationConfiguredModelAlgorithmAssociationRequest,
+  ): Effect.Effect<
+    GetCollaborationConfiguredModelAlgorithmAssociationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCollaborationMLInputChannel(
+    input: GetCollaborationMLInputChannelRequest,
+  ): Effect.Effect<
+    GetCollaborationMLInputChannelResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCollaborationTrainedModel(
+    input: GetCollaborationTrainedModelRequest,
+  ): Effect.Effect<
+    GetCollaborationTrainedModelResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredAudienceModel(
+    input: GetConfiguredAudienceModelRequest,
+  ): Effect.Effect<
+    GetConfiguredAudienceModelResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredAudienceModelPolicy(
+    input: GetConfiguredAudienceModelPolicyRequest,
+  ): Effect.Effect<
+    GetConfiguredAudienceModelPolicyResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredModelAlgorithm(
+    input: GetConfiguredModelAlgorithmRequest,
+  ): Effect.Effect<
+    GetConfiguredModelAlgorithmResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConfiguredModelAlgorithmAssociation(
+    input: GetConfiguredModelAlgorithmAssociationRequest,
+  ): Effect.Effect<
+    GetConfiguredModelAlgorithmAssociationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMLConfiguration(
+    input: GetMLConfigurationRequest,
+  ): Effect.Effect<
+    GetMLConfigurationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMLInputChannel(
+    input: GetMLInputChannelRequest,
+  ): Effect.Effect<
+    GetMLInputChannelResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTrainedModel(
+    input: GetTrainedModelRequest,
+  ): Effect.Effect<
+    GetTrainedModelResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTrainedModelInferenceJob(
+    input: GetTrainedModelInferenceJobRequest,
+  ): Effect.Effect<
+    GetTrainedModelInferenceJobResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTrainingDataset(
+    input: GetTrainingDatasetRequest,
+  ): Effect.Effect<
+    GetTrainingDatasetResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAudienceExportJobs(
+    input: ListAudienceExportJobsRequest,
+  ): Effect.Effect<
+    ListAudienceExportJobsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listAudienceGenerationJobs(
+    input: ListAudienceGenerationJobsRequest,
+  ): Effect.Effect<
+    ListAudienceGenerationJobsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listAudienceModels(
+    input: ListAudienceModelsRequest,
+  ): Effect.Effect<
+    ListAudienceModelsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listConfiguredAudienceModels(
+    input: ListConfiguredAudienceModelsRequest,
+  ): Effect.Effect<
+    ListConfiguredAudienceModelsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listConfiguredModelAlgorithmAssociations(
+    input: ListConfiguredModelAlgorithmAssociationsRequest,
+  ): Effect.Effect<
+    ListConfiguredModelAlgorithmAssociationsResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listConfiguredModelAlgorithms(
+    input: ListConfiguredModelAlgorithmsRequest,
+  ): Effect.Effect<
+    ListConfiguredModelAlgorithmsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listMLInputChannels(
+    input: ListMLInputChannelsRequest,
+  ): Effect.Effect<
+    ListMLInputChannelsResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTrainedModelInferenceJobs(
+    input: ListTrainedModelInferenceJobsRequest,
+  ): Effect.Effect<
+    ListTrainedModelInferenceJobsResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTrainedModelVersions(
+    input: ListTrainedModelVersionsRequest,
+  ): Effect.Effect<
+    ListTrainedModelVersionsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTrainedModels(
+    input: ListTrainedModelsRequest,
+  ): Effect.Effect<
+    ListTrainedModelsResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTrainingDatasets(
+    input: ListTrainingDatasetsRequest,
+  ): Effect.Effect<
+    ListTrainingDatasetsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  putConfiguredAudienceModelPolicy(
+    input: PutConfiguredAudienceModelPolicyRequest,
+  ): Effect.Effect<
+    PutConfiguredAudienceModelPolicyResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putMLConfiguration(
+    input: PutMLConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startAudienceExportJob(
+    input: StartAudienceExportJobRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startAudienceGenerationJob(
+    input: StartAudienceGenerationJobRequest,
+  ): Effect.Effect<
+    StartAudienceGenerationJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startTrainedModelExportJob(
+    input: StartTrainedModelExportJobRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startTrainedModelInferenceJob(
+    input: StartTrainedModelInferenceJobRequest,
+  ): Effect.Effect<
+    StartTrainedModelInferenceJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateConfiguredAudienceModel(
+    input: UpdateConfiguredAudienceModelRequest,
+  ): Effect.Effect<
+    UpdateConfiguredAudienceModelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Cleanroomsml extends CleanRoomsML {}
@@ -1601,6 +2093,563 @@ export declare namespace UntagResource {
   export type Output = UntagResourceResponse;
   export type Error =
     | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelTrainedModel {
+  export type Input = CancelTrainedModelRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelTrainedModelInferenceJob {
+  export type Input = CancelTrainedModelInferenceJobRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAudienceModel {
+  export type Input = CreateAudienceModelRequest;
+  export type Output = CreateAudienceModelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfiguredAudienceModel {
+  export type Input = CreateConfiguredAudienceModelRequest;
+  export type Output = CreateConfiguredAudienceModelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfiguredModelAlgorithm {
+  export type Input = CreateConfiguredModelAlgorithmRequest;
+  export type Output = CreateConfiguredModelAlgorithmResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfiguredModelAlgorithmAssociation {
+  export type Input = CreateConfiguredModelAlgorithmAssociationRequest;
+  export type Output = CreateConfiguredModelAlgorithmAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMLInputChannel {
+  export type Input = CreateMLInputChannelRequest;
+  export type Output = CreateMLInputChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTrainedModel {
+  export type Input = CreateTrainedModelRequest;
+  export type Output = CreateTrainedModelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTrainingDataset {
+  export type Input = CreateTrainingDatasetRequest;
+  export type Output = CreateTrainingDatasetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAudienceGenerationJob {
+  export type Input = DeleteAudienceGenerationJobRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAudienceModel {
+  export type Input = DeleteAudienceModelRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredAudienceModel {
+  export type Input = DeleteConfiguredAudienceModelRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredAudienceModelPolicy {
+  export type Input = DeleteConfiguredAudienceModelPolicyRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredModelAlgorithm {
+  export type Input = DeleteConfiguredModelAlgorithmRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfiguredModelAlgorithmAssociation {
+  export type Input = DeleteConfiguredModelAlgorithmAssociationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMLConfiguration {
+  export type Input = DeleteMLConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMLInputChannelData {
+  export type Input = DeleteMLInputChannelDataRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTrainedModelOutput {
+  export type Input = DeleteTrainedModelOutputRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTrainingDataset {
+  export type Input = DeleteTrainingDatasetRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAudienceGenerationJob {
+  export type Input = GetAudienceGenerationJobRequest;
+  export type Output = GetAudienceGenerationJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAudienceModel {
+  export type Input = GetAudienceModelRequest;
+  export type Output = GetAudienceModelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCollaborationConfiguredModelAlgorithmAssociation {
+  export type Input =
+    GetCollaborationConfiguredModelAlgorithmAssociationRequest;
+  export type Output =
+    GetCollaborationConfiguredModelAlgorithmAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCollaborationMLInputChannel {
+  export type Input = GetCollaborationMLInputChannelRequest;
+  export type Output = GetCollaborationMLInputChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCollaborationTrainedModel {
+  export type Input = GetCollaborationTrainedModelRequest;
+  export type Output = GetCollaborationTrainedModelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredAudienceModel {
+  export type Input = GetConfiguredAudienceModelRequest;
+  export type Output = GetConfiguredAudienceModelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredAudienceModelPolicy {
+  export type Input = GetConfiguredAudienceModelPolicyRequest;
+  export type Output = GetConfiguredAudienceModelPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredModelAlgorithm {
+  export type Input = GetConfiguredModelAlgorithmRequest;
+  export type Output = GetConfiguredModelAlgorithmResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfiguredModelAlgorithmAssociation {
+  export type Input = GetConfiguredModelAlgorithmAssociationRequest;
+  export type Output = GetConfiguredModelAlgorithmAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMLConfiguration {
+  export type Input = GetMLConfigurationRequest;
+  export type Output = GetMLConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMLInputChannel {
+  export type Input = GetMLInputChannelRequest;
+  export type Output = GetMLInputChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTrainedModel {
+  export type Input = GetTrainedModelRequest;
+  export type Output = GetTrainedModelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTrainedModelInferenceJob {
+  export type Input = GetTrainedModelInferenceJobRequest;
+  export type Output = GetTrainedModelInferenceJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTrainingDataset {
+  export type Input = GetTrainingDatasetRequest;
+  export type Output = GetTrainingDatasetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAudienceExportJobs {
+  export type Input = ListAudienceExportJobsRequest;
+  export type Output = ListAudienceExportJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAudienceGenerationJobs {
+  export type Input = ListAudienceGenerationJobsRequest;
+  export type Output = ListAudienceGenerationJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAudienceModels {
+  export type Input = ListAudienceModelsRequest;
+  export type Output = ListAudienceModelsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConfiguredAudienceModels {
+  export type Input = ListConfiguredAudienceModelsRequest;
+  export type Output = ListConfiguredAudienceModelsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConfiguredModelAlgorithmAssociations {
+  export type Input = ListConfiguredModelAlgorithmAssociationsRequest;
+  export type Output = ListConfiguredModelAlgorithmAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConfiguredModelAlgorithms {
+  export type Input = ListConfiguredModelAlgorithmsRequest;
+  export type Output = ListConfiguredModelAlgorithmsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMLInputChannels {
+  export type Input = ListMLInputChannelsRequest;
+  export type Output = ListMLInputChannelsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTrainedModelInferenceJobs {
+  export type Input = ListTrainedModelInferenceJobsRequest;
+  export type Output = ListTrainedModelInferenceJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTrainedModelVersions {
+  export type Input = ListTrainedModelVersionsRequest;
+  export type Output = ListTrainedModelVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTrainedModels {
+  export type Input = ListTrainedModelsRequest;
+  export type Output = ListTrainedModelsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTrainingDatasets {
+  export type Input = ListTrainingDatasetsRequest;
+  export type Output = ListTrainingDatasetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutConfiguredAudienceModelPolicy {
+  export type Input = PutConfiguredAudienceModelPolicyRequest;
+  export type Output = PutConfiguredAudienceModelPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutMLConfiguration {
+  export type Input = PutMLConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartAudienceExportJob {
+  export type Input = StartAudienceExportJobRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartAudienceGenerationJob {
+  export type Input = StartAudienceGenerationJobRequest;
+  export type Output = StartAudienceGenerationJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartTrainedModelExportJob {
+  export type Input = StartTrainedModelExportJobRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartTrainedModelInferenceJob {
+  export type Input = StartTrainedModelInferenceJobRequest;
+  export type Output = StartTrainedModelInferenceJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConfiguredAudienceModel {
+  export type Input = UpdateConfiguredAudienceModelRequest;
+  export type Output = UpdateConfiguredAudienceModelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | ResourceNotFoundException
     | ValidationException
     | CommonAwsError;

--- a/src/services/codecatalyst/index.ts
+++ b/src/services/codecatalyst/index.ts
@@ -10,6 +10,114 @@ export declare class CodeCatalyst extends AWSServiceClient {
     VerifySessionResponse,
     CommonAwsError
   >;
+  createAccessToken(
+    input: CreateAccessTokenRequest,
+  ): Effect.Effect<CreateAccessTokenResponse, CommonAwsError>;
+  createDevEnvironment(
+    input: CreateDevEnvironmentRequest,
+  ): Effect.Effect<CreateDevEnvironmentResponse, CommonAwsError>;
+  createProject(
+    input: CreateProjectRequest,
+  ): Effect.Effect<CreateProjectResponse, CommonAwsError>;
+  createSourceRepository(
+    input: CreateSourceRepositoryRequest,
+  ): Effect.Effect<CreateSourceRepositoryResponse, CommonAwsError>;
+  createSourceRepositoryBranch(
+    input: CreateSourceRepositoryBranchRequest,
+  ): Effect.Effect<CreateSourceRepositoryBranchResponse, CommonAwsError>;
+  deleteAccessToken(
+    input: DeleteAccessTokenRequest,
+  ): Effect.Effect<DeleteAccessTokenResponse, CommonAwsError>;
+  deleteDevEnvironment(
+    input: DeleteDevEnvironmentRequest,
+  ): Effect.Effect<DeleteDevEnvironmentResponse, CommonAwsError>;
+  deleteProject(
+    input: DeleteProjectRequest,
+  ): Effect.Effect<DeleteProjectResponse, CommonAwsError>;
+  deleteSourceRepository(
+    input: DeleteSourceRepositoryRequest,
+  ): Effect.Effect<DeleteSourceRepositoryResponse, CommonAwsError>;
+  deleteSpace(
+    input: DeleteSpaceRequest,
+  ): Effect.Effect<DeleteSpaceResponse, CommonAwsError>;
+  getDevEnvironment(
+    input: GetDevEnvironmentRequest,
+  ): Effect.Effect<GetDevEnvironmentResponse, CommonAwsError>;
+  getProject(
+    input: GetProjectRequest,
+  ): Effect.Effect<GetProjectResponse, CommonAwsError>;
+  getSourceRepository(
+    input: GetSourceRepositoryRequest,
+  ): Effect.Effect<GetSourceRepositoryResponse, CommonAwsError>;
+  getSourceRepositoryCloneUrls(
+    input: GetSourceRepositoryCloneUrlsRequest,
+  ): Effect.Effect<GetSourceRepositoryCloneUrlsResponse, CommonAwsError>;
+  getSpace(
+    input: GetSpaceRequest,
+  ): Effect.Effect<GetSpaceResponse, CommonAwsError>;
+  getSubscription(
+    input: GetSubscriptionRequest,
+  ): Effect.Effect<GetSubscriptionResponse, CommonAwsError>;
+  getWorkflow(
+    input: GetWorkflowRequest,
+  ): Effect.Effect<GetWorkflowResponse, CommonAwsError>;
+  getWorkflowRun(
+    input: GetWorkflowRunRequest,
+  ): Effect.Effect<GetWorkflowRunResponse, CommonAwsError>;
+  listAccessTokens(
+    input: ListAccessTokensRequest,
+  ): Effect.Effect<ListAccessTokensResponse, CommonAwsError>;
+  listDevEnvironmentSessions(
+    input: ListDevEnvironmentSessionsRequest,
+  ): Effect.Effect<ListDevEnvironmentSessionsResponse, CommonAwsError>;
+  listDevEnvironments(
+    input: ListDevEnvironmentsRequest,
+  ): Effect.Effect<ListDevEnvironmentsResponse, CommonAwsError>;
+  listEventLogs(
+    input: ListEventLogsRequest,
+  ): Effect.Effect<ListEventLogsResponse, CommonAwsError>;
+  listProjects(
+    input: ListProjectsRequest,
+  ): Effect.Effect<ListProjectsResponse, CommonAwsError>;
+  listSourceRepositories(
+    input: ListSourceRepositoriesRequest,
+  ): Effect.Effect<ListSourceRepositoriesResponse, CommonAwsError>;
+  listSourceRepositoryBranches(
+    input: ListSourceRepositoryBranchesRequest,
+  ): Effect.Effect<ListSourceRepositoryBranchesResponse, CommonAwsError>;
+  listSpaces(
+    input: ListSpacesRequest,
+  ): Effect.Effect<ListSpacesResponse, CommonAwsError>;
+  listWorkflowRuns(
+    input: ListWorkflowRunsRequest,
+  ): Effect.Effect<ListWorkflowRunsResponse, CommonAwsError>;
+  listWorkflows(
+    input: ListWorkflowsRequest,
+  ): Effect.Effect<ListWorkflowsResponse, CommonAwsError>;
+  startDevEnvironment(
+    input: StartDevEnvironmentRequest,
+  ): Effect.Effect<StartDevEnvironmentResponse, CommonAwsError>;
+  startDevEnvironmentSession(
+    input: StartDevEnvironmentSessionRequest,
+  ): Effect.Effect<StartDevEnvironmentSessionResponse, CommonAwsError>;
+  startWorkflowRun(
+    input: StartWorkflowRunRequest,
+  ): Effect.Effect<StartWorkflowRunResponse, CommonAwsError>;
+  stopDevEnvironment(
+    input: StopDevEnvironmentRequest,
+  ): Effect.Effect<StopDevEnvironmentResponse, CommonAwsError>;
+  stopDevEnvironmentSession(
+    input: StopDevEnvironmentSessionRequest,
+  ): Effect.Effect<StopDevEnvironmentSessionResponse, CommonAwsError>;
+  updateDevEnvironment(
+    input: UpdateDevEnvironmentRequest,
+  ): Effect.Effect<UpdateDevEnvironmentResponse, CommonAwsError>;
+  updateProject(
+    input: UpdateProjectRequest,
+  ): Effect.Effect<UpdateProjectResponse, CommonAwsError>;
+  updateSpace(
+    input: UpdateSpaceRequest,
+  ): Effect.Effect<UpdateSpaceResponse, CommonAwsError>;
 }
 
 export declare class Codecatalyst extends CodeCatalyst {}
@@ -723,5 +831,221 @@ export declare namespace GetUserDetails {
 export declare namespace VerifySession {
   export type Input = {};
   export type Output = VerifySessionResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateAccessToken {
+  export type Input = CreateAccessTokenRequest;
+  export type Output = CreateAccessTokenResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateDevEnvironment {
+  export type Input = CreateDevEnvironmentRequest;
+  export type Output = CreateDevEnvironmentResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateProject {
+  export type Input = CreateProjectRequest;
+  export type Output = CreateProjectResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateSourceRepository {
+  export type Input = CreateSourceRepositoryRequest;
+  export type Output = CreateSourceRepositoryResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateSourceRepositoryBranch {
+  export type Input = CreateSourceRepositoryBranchRequest;
+  export type Output = CreateSourceRepositoryBranchResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteAccessToken {
+  export type Input = DeleteAccessTokenRequest;
+  export type Output = DeleteAccessTokenResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteDevEnvironment {
+  export type Input = DeleteDevEnvironmentRequest;
+  export type Output = DeleteDevEnvironmentResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteProject {
+  export type Input = DeleteProjectRequest;
+  export type Output = DeleteProjectResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteSourceRepository {
+  export type Input = DeleteSourceRepositoryRequest;
+  export type Output = DeleteSourceRepositoryResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteSpace {
+  export type Input = DeleteSpaceRequest;
+  export type Output = DeleteSpaceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetDevEnvironment {
+  export type Input = GetDevEnvironmentRequest;
+  export type Output = GetDevEnvironmentResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetProject {
+  export type Input = GetProjectRequest;
+  export type Output = GetProjectResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetSourceRepository {
+  export type Input = GetSourceRepositoryRequest;
+  export type Output = GetSourceRepositoryResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetSourceRepositoryCloneUrls {
+  export type Input = GetSourceRepositoryCloneUrlsRequest;
+  export type Output = GetSourceRepositoryCloneUrlsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetSpace {
+  export type Input = GetSpaceRequest;
+  export type Output = GetSpaceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetSubscription {
+  export type Input = GetSubscriptionRequest;
+  export type Output = GetSubscriptionResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetWorkflow {
+  export type Input = GetWorkflowRequest;
+  export type Output = GetWorkflowResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetWorkflowRun {
+  export type Input = GetWorkflowRunRequest;
+  export type Output = GetWorkflowRunResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListAccessTokens {
+  export type Input = ListAccessTokensRequest;
+  export type Output = ListAccessTokensResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListDevEnvironmentSessions {
+  export type Input = ListDevEnvironmentSessionsRequest;
+  export type Output = ListDevEnvironmentSessionsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListDevEnvironments {
+  export type Input = ListDevEnvironmentsRequest;
+  export type Output = ListDevEnvironmentsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListEventLogs {
+  export type Input = ListEventLogsRequest;
+  export type Output = ListEventLogsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListProjects {
+  export type Input = ListProjectsRequest;
+  export type Output = ListProjectsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListSourceRepositories {
+  export type Input = ListSourceRepositoriesRequest;
+  export type Output = ListSourceRepositoriesResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListSourceRepositoryBranches {
+  export type Input = ListSourceRepositoryBranchesRequest;
+  export type Output = ListSourceRepositoryBranchesResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListSpaces {
+  export type Input = ListSpacesRequest;
+  export type Output = ListSpacesResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListWorkflowRuns {
+  export type Input = ListWorkflowRunsRequest;
+  export type Output = ListWorkflowRunsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListWorkflows {
+  export type Input = ListWorkflowsRequest;
+  export type Output = ListWorkflowsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace StartDevEnvironment {
+  export type Input = StartDevEnvironmentRequest;
+  export type Output = StartDevEnvironmentResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace StartDevEnvironmentSession {
+  export type Input = StartDevEnvironmentSessionRequest;
+  export type Output = StartDevEnvironmentSessionResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace StartWorkflowRun {
+  export type Input = StartWorkflowRunRequest;
+  export type Output = StartWorkflowRunResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace StopDevEnvironment {
+  export type Input = StopDevEnvironmentRequest;
+  export type Output = StopDevEnvironmentResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace StopDevEnvironmentSession {
+  export type Input = StopDevEnvironmentSessionRequest;
+  export type Output = StopDevEnvironmentSessionResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateDevEnvironment {
+  export type Input = UpdateDevEnvironmentRequest;
+  export type Output = UpdateDevEnvironmentResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateProject {
+  export type Input = UpdateProjectRequest;
+  export type Output = UpdateProjectResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateSpace {
+  export type Input = UpdateSpaceRequest;
+  export type Output = UpdateSpaceResponse;
   export type Error = CommonAwsError;
 }

--- a/src/services/codeguruprofiler/index.ts
+++ b/src/services/codeguruprofiler/index.ts
@@ -39,6 +39,198 @@ export declare class CodeGuruProfiler extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  addNotificationChannels(
+    input: AddNotificationChannelsRequest,
+  ): Effect.Effect<
+    AddNotificationChannelsResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchGetFrameMetricData(
+    input: BatchGetFrameMetricDataRequest,
+  ): Effect.Effect<
+    BatchGetFrameMetricDataResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  configureAgent(
+    input: ConfigureAgentRequest,
+  ): Effect.Effect<
+    ConfigureAgentResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createProfilingGroup(
+    input: CreateProfilingGroupRequest,
+  ): Effect.Effect<
+    CreateProfilingGroupResponse,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteProfilingGroup(
+    input: DeleteProfilingGroupRequest,
+  ): Effect.Effect<
+    DeleteProfilingGroupResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeProfilingGroup(
+    input: DescribeProfilingGroupRequest,
+  ): Effect.Effect<
+    DescribeProfilingGroupResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getNotificationConfiguration(
+    input: GetNotificationConfigurationRequest,
+  ): Effect.Effect<
+    GetNotificationConfigurationResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getPolicy(
+    input: GetPolicyRequest,
+  ): Effect.Effect<
+    GetPolicyResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getProfile(
+    input: GetProfileRequest,
+  ): Effect.Effect<
+    GetProfileResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRecommendations(
+    input: GetRecommendationsRequest,
+  ): Effect.Effect<
+    GetRecommendationsResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFindingsReports(
+    input: ListFindingsReportsRequest,
+  ): Effect.Effect<
+    ListFindingsReportsResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listProfileTimes(
+    input: ListProfileTimesRequest,
+  ): Effect.Effect<
+    ListProfileTimesResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listProfilingGroups(
+    input: ListProfilingGroupsRequest,
+  ): Effect.Effect<
+    ListProfilingGroupsResponse,
+    InternalServerException | ThrottlingException | CommonAwsError
+  >;
+  postAgentProfile(
+    input: PostAgentProfileRequest,
+  ): Effect.Effect<
+    PostAgentProfileResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putPermission(
+    input: PutPermissionRequest,
+  ): Effect.Effect<
+    PutPermissionResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  removeNotificationChannel(
+    input: RemoveNotificationChannelRequest,
+  ): Effect.Effect<
+    RemoveNotificationChannelResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  removePermission(
+    input: RemovePermissionRequest,
+  ): Effect.Effect<
+    RemovePermissionResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  submitFeedback(
+    input: SubmitFeedbackRequest,
+  ): Effect.Effect<
+    SubmitFeedbackResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateProfilingGroup(
+    input: UpdateProfilingGroupRequest,
+  ): Effect.Effect<
+    UpdateProfilingGroupResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Codeguruprofiler extends CodeGuruProfiler {}
@@ -486,6 +678,219 @@ export declare namespace UntagResource {
   export type Error =
     | InternalServerException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AddNotificationChannels {
+  export type Input = AddNotificationChannelsRequest;
+  export type Output = AddNotificationChannelsResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetFrameMetricData {
+  export type Input = BatchGetFrameMetricDataRequest;
+  export type Output = BatchGetFrameMetricDataResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ConfigureAgent {
+  export type Input = ConfigureAgentRequest;
+  export type Output = ConfigureAgentResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateProfilingGroup {
+  export type Input = CreateProfilingGroupRequest;
+  export type Output = CreateProfilingGroupResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteProfilingGroup {
+  export type Input = DeleteProfilingGroupRequest;
+  export type Output = DeleteProfilingGroupResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeProfilingGroup {
+  export type Input = DescribeProfilingGroupRequest;
+  export type Output = DescribeProfilingGroupResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetNotificationConfiguration {
+  export type Input = GetNotificationConfigurationRequest;
+  export type Output = GetNotificationConfigurationResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetPolicy {
+  export type Input = GetPolicyRequest;
+  export type Output = GetPolicyResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetProfile {
+  export type Input = GetProfileRequest;
+  export type Output = GetProfileResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRecommendations {
+  export type Input = GetRecommendationsRequest;
+  export type Output = GetRecommendationsResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFindingsReports {
+  export type Input = ListFindingsReportsRequest;
+  export type Output = ListFindingsReportsResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListProfileTimes {
+  export type Input = ListProfileTimesRequest;
+  export type Output = ListProfileTimesResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListProfilingGroups {
+  export type Input = ListProfilingGroupsRequest;
+  export type Output = ListProfilingGroupsResponse;
+  export type Error =
+    | InternalServerException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace PostAgentProfile {
+  export type Input = PostAgentProfileRequest;
+  export type Output = PostAgentProfileResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutPermission {
+  export type Input = PutPermissionRequest;
+  export type Output = PutPermissionResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveNotificationChannel {
+  export type Input = RemoveNotificationChannelRequest;
+  export type Output = RemoveNotificationChannelResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RemovePermission {
+  export type Input = RemovePermissionRequest;
+  export type Output = RemovePermissionResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SubmitFeedback {
+  export type Input = SubmitFeedbackRequest;
+  export type Output = SubmitFeedbackResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProfilingGroup {
+  export type Input = UpdateProfilingGroupRequest;
+  export type Output = UpdateProfilingGroupResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/connectcases/index.ts
+++ b/src/services/connectcases/index.ts
@@ -36,6 +36,446 @@ export declare class ConnectCases extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  batchGetCaseRule(
+    input: BatchGetCaseRuleRequest,
+  ): Effect.Effect<
+    BatchGetCaseRuleResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchGetField(
+    input: BatchGetFieldRequest,
+  ): Effect.Effect<
+    BatchGetFieldResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchPutFieldOptions(
+    input: BatchPutFieldOptionsRequest,
+  ): Effect.Effect<
+    BatchPutFieldOptionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCase(
+    input: CreateCaseRequest,
+  ): Effect.Effect<
+    CreateCaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCaseRule(
+    input: CreateCaseRuleRequest,
+  ): Effect.Effect<
+    CreateCaseRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDomain(
+    input: CreateDomainRequest,
+  ): Effect.Effect<
+    CreateDomainResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createField(
+    input: CreateFieldRequest,
+  ): Effect.Effect<
+    CreateFieldResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createLayout(
+    input: CreateLayoutRequest,
+  ): Effect.Effect<
+    CreateLayoutResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRelatedItem(
+    input: CreateRelatedItemRequest,
+  ): Effect.Effect<
+    CreateRelatedItemResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTemplate(
+    input: CreateTemplateRequest,
+  ): Effect.Effect<
+    CreateTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCase(
+    input: DeleteCaseRequest,
+  ): Effect.Effect<
+    DeleteCaseResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCaseRule(
+    input: DeleteCaseRuleRequest,
+  ): Effect.Effect<
+    DeleteCaseRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteDomain(
+    input: DeleteDomainRequest,
+  ): Effect.Effect<
+    DeleteDomainResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteField(
+    input: DeleteFieldRequest,
+  ): Effect.Effect<
+    DeleteFieldResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteLayout(
+    input: DeleteLayoutRequest,
+  ): Effect.Effect<
+    DeleteLayoutResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRelatedItem(
+    input: DeleteRelatedItemRequest,
+  ): Effect.Effect<
+    DeleteRelatedItemResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTemplate(
+    input: DeleteTemplateRequest,
+  ): Effect.Effect<
+    DeleteTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCase(
+    input: GetCaseRequest,
+  ): Effect.Effect<
+    GetCaseResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCaseAuditEvents(
+    input: GetCaseAuditEventsRequest,
+  ): Effect.Effect<
+    GetCaseAuditEventsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCaseEventConfiguration(
+    input: GetCaseEventConfigurationRequest,
+  ): Effect.Effect<
+    GetCaseEventConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDomain(
+    input: GetDomainRequest,
+  ): Effect.Effect<
+    GetDomainResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getLayout(
+    input: GetLayoutRequest,
+  ): Effect.Effect<
+    GetLayoutResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTemplate(
+    input: GetTemplateRequest,
+  ): Effect.Effect<
+    GetTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCaseRules(
+    input: ListCaseRulesRequest,
+  ): Effect.Effect<
+    ListCaseRulesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCasesForContact(
+    input: ListCasesForContactRequest,
+  ): Effect.Effect<
+    ListCasesForContactResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDomains(
+    input: ListDomainsRequest,
+  ): Effect.Effect<
+    ListDomainsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFieldOptions(
+    input: ListFieldOptionsRequest,
+  ): Effect.Effect<
+    ListFieldOptionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFields(
+    input: ListFieldsRequest,
+  ): Effect.Effect<
+    ListFieldsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listLayouts(
+    input: ListLayoutsRequest,
+  ): Effect.Effect<
+    ListLayoutsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTemplates(
+    input: ListTemplatesRequest,
+  ): Effect.Effect<
+    ListTemplatesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putCaseEventConfiguration(
+    input: PutCaseEventConfigurationRequest,
+  ): Effect.Effect<
+    PutCaseEventConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchCases(
+    input: SearchCasesRequest,
+  ): Effect.Effect<
+    SearchCasesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchRelatedItems(
+    input: SearchRelatedItemsRequest,
+  ): Effect.Effect<
+    SearchRelatedItemsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCase(
+    input: UpdateCaseRequest,
+  ): Effect.Effect<
+    UpdateCaseResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCaseRule(
+    input: UpdateCaseRuleRequest,
+  ): Effect.Effect<
+    UpdateCaseRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateField(
+    input: UpdateFieldRequest,
+  ): Effect.Effect<
+    UpdateFieldResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLayout(
+    input: UpdateLayoutRequest,
+  ): Effect.Effect<
+    UpdateLayoutResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTemplate(
+    input: UpdateTemplateRequest,
+  ): Effect.Effect<
+    UpdateTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Connectcases extends ConnectCases {}
@@ -975,6 +1415,484 @@ export declare namespace UntagResource {
   export type Output = {};
   export type Error =
     | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetCaseRule {
+  export type Input = BatchGetCaseRuleRequest;
+  export type Output = BatchGetCaseRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetField {
+  export type Input = BatchGetFieldRequest;
+  export type Output = BatchGetFieldResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchPutFieldOptions {
+  export type Input = BatchPutFieldOptionsRequest;
+  export type Output = BatchPutFieldOptionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCase {
+  export type Input = CreateCaseRequest;
+  export type Output = CreateCaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCaseRule {
+  export type Input = CreateCaseRuleRequest;
+  export type Output = CreateCaseRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDomain {
+  export type Input = CreateDomainRequest;
+  export type Output = CreateDomainResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateField {
+  export type Input = CreateFieldRequest;
+  export type Output = CreateFieldResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateLayout {
+  export type Input = CreateLayoutRequest;
+  export type Output = CreateLayoutResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRelatedItem {
+  export type Input = CreateRelatedItemRequest;
+  export type Output = CreateRelatedItemResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTemplate {
+  export type Input = CreateTemplateRequest;
+  export type Output = CreateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCase {
+  export type Input = DeleteCaseRequest;
+  export type Output = DeleteCaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCaseRule {
+  export type Input = DeleteCaseRuleRequest;
+  export type Output = DeleteCaseRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDomain {
+  export type Input = DeleteDomainRequest;
+  export type Output = DeleteDomainResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteField {
+  export type Input = DeleteFieldRequest;
+  export type Output = DeleteFieldResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLayout {
+  export type Input = DeleteLayoutRequest;
+  export type Output = DeleteLayoutResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRelatedItem {
+  export type Input = DeleteRelatedItemRequest;
+  export type Output = DeleteRelatedItemResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTemplate {
+  export type Input = DeleteTemplateRequest;
+  export type Output = DeleteTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCase {
+  export type Input = GetCaseRequest;
+  export type Output = GetCaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCaseAuditEvents {
+  export type Input = GetCaseAuditEventsRequest;
+  export type Output = GetCaseAuditEventsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCaseEventConfiguration {
+  export type Input = GetCaseEventConfigurationRequest;
+  export type Output = GetCaseEventConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDomain {
+  export type Input = GetDomainRequest;
+  export type Output = GetDomainResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetLayout {
+  export type Input = GetLayoutRequest;
+  export type Output = GetLayoutResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTemplate {
+  export type Input = GetTemplateRequest;
+  export type Output = GetTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCaseRules {
+  export type Input = ListCaseRulesRequest;
+  export type Output = ListCaseRulesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCasesForContact {
+  export type Input = ListCasesForContactRequest;
+  export type Output = ListCasesForContactResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDomains {
+  export type Input = ListDomainsRequest;
+  export type Output = ListDomainsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFieldOptions {
+  export type Input = ListFieldOptionsRequest;
+  export type Output = ListFieldOptionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFields {
+  export type Input = ListFieldsRequest;
+  export type Output = ListFieldsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListLayouts {
+  export type Input = ListLayoutsRequest;
+  export type Output = ListLayoutsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTemplates {
+  export type Input = ListTemplatesRequest;
+  export type Output = ListTemplatesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutCaseEventConfiguration {
+  export type Input = PutCaseEventConfigurationRequest;
+  export type Output = PutCaseEventConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchCases {
+  export type Input = SearchCasesRequest;
+  export type Output = SearchCasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchRelatedItems {
+  export type Input = SearchRelatedItemsRequest;
+  export type Output = SearchRelatedItemsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCase {
+  export type Input = UpdateCaseRequest;
+  export type Output = UpdateCaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCaseRule {
+  export type Input = UpdateCaseRuleRequest;
+  export type Output = UpdateCaseRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateField {
+  export type Input = UpdateFieldRequest;
+  export type Output = UpdateFieldResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLayout {
+  export type Input = UpdateLayoutRequest;
+  export type Output = UpdateLayoutResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTemplate {
+  export type Input = UpdateTemplateRequest;
+  export type Output = UpdateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/controlcatalog/index.ts
+++ b/src/services/controlcatalog/index.ts
@@ -13,6 +13,57 @@ export declare class ControlCatalog extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  getControl(
+    input: GetControlRequest,
+  ): Effect.Effect<
+    GetControlResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCommonControls(
+    input: ListCommonControlsRequest,
+  ): Effect.Effect<
+    ListCommonControlsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listControls(
+    input: ListControlsRequest,
+  ): Effect.Effect<
+    ListControlsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDomains(
+    input: ListDomainsRequest,
+  ): Effect.Effect<
+    ListDomainsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listObjectives(
+    input: ListObjectivesRequest,
+  ): Effect.Effect<
+    ListObjectivesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Controlcatalog extends ControlCatalog {}
@@ -261,6 +312,62 @@ export declare class ValidationException extends EffectData.TaggedError(
 export declare namespace ListControlMappings {
   export type Input = ListControlMappingsRequest;
   export type Output = ListControlMappingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetControl {
+  export type Input = GetControlRequest;
+  export type Output = GetControlResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCommonControls {
+  export type Input = ListCommonControlsRequest;
+  export type Output = ListCommonControlsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListControls {
+  export type Input = ListControlsRequest;
+  export type Output = ListControlsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDomains {
+  export type Input = ListDomainsRequest;
+  export type Output = ListDomainsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListObjectives {
+  export type Input = ListObjectivesRequest;
+  export type Output = ListObjectivesResponse;
   export type Error =
     | AccessDeniedException
     | InternalServerException

--- a/src/services/controltower/index.ts
+++ b/src/services/controltower/index.ts
@@ -16,6 +16,309 @@ export declare class ControlTower extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createLandingZone(
+    input: CreateLandingZoneInput,
+  ): Effect.Effect<
+    CreateLandingZoneOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteLandingZone(
+    input: DeleteLandingZoneInput,
+  ): Effect.Effect<
+    DeleteLandingZoneOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disableBaseline(
+    input: DisableBaselineInput,
+  ): Effect.Effect<
+    DisableBaselineOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  enableBaseline(
+    input: EnableBaselineInput,
+  ): Effect.Effect<
+    EnableBaselineOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  enableControl(
+    input: EnableControlInput,
+  ): Effect.Effect<
+    EnableControlOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBaseline(
+    input: GetBaselineInput,
+  ): Effect.Effect<
+    GetBaselineOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBaselineOperation(
+    input: GetBaselineOperationInput,
+  ): Effect.Effect<
+    GetBaselineOperationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getControlOperation(
+    input: GetControlOperationInput,
+  ): Effect.Effect<
+    GetControlOperationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEnabledBaseline(
+    input: GetEnabledBaselineInput,
+  ): Effect.Effect<
+    GetEnabledBaselineOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEnabledControl(
+    input: GetEnabledControlInput,
+  ): Effect.Effect<
+    GetEnabledControlOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getLandingZone(
+    input: GetLandingZoneInput,
+  ): Effect.Effect<
+    GetLandingZoneOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getLandingZoneOperation(
+    input: GetLandingZoneOperationInput,
+  ): Effect.Effect<
+    GetLandingZoneOperationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBaselines(
+    input: ListBaselinesInput,
+  ): Effect.Effect<
+    ListBaselinesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listControlOperations(
+    input: ListControlOperationsInput,
+  ): Effect.Effect<
+    ListControlOperationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnabledBaselines(
+    input: ListEnabledBaselinesInput,
+  ): Effect.Effect<
+    ListEnabledBaselinesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnabledControls(
+    input: ListEnabledControlsInput,
+  ): Effect.Effect<
+    ListEnabledControlsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listLandingZoneOperations(
+    input: ListLandingZoneOperationsInput,
+  ): Effect.Effect<
+    ListLandingZoneOperationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listLandingZones(
+    input: ListLandingZonesInput,
+  ): Effect.Effect<
+    ListLandingZonesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTagsForResource(
+    input: ListTagsForResourceInput,
+  ): Effect.Effect<
+    ListTagsForResourceOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  resetEnabledBaseline(
+    input: ResetEnabledBaselineInput,
+  ): Effect.Effect<
+    ResetEnabledBaselineOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  resetEnabledControl(
+    input: ResetEnabledControlInput,
+  ): Effect.Effect<
+    ResetEnabledControlOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  resetLandingZone(
+    input: ResetLandingZoneInput,
+  ): Effect.Effect<
+    ResetLandingZoneOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  tagResource(
+    input: TagResourceInput,
+  ): Effect.Effect<
+    TagResourceOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  untagResource(
+    input: UntagResourceInput,
+  ): Effect.Effect<
+    UntagResourceOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEnabledBaseline(
+    input: UpdateEnabledBaselineInput,
+  ): Effect.Effect<
+    UpdateEnabledBaselineOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEnabledControl(
+    input: UpdateEnabledControlInput,
+  ): Effect.Effect<
+    UpdateEnabledControlOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLandingZone(
+    input: UpdateLandingZoneInput,
+  ): Effect.Effect<
+    UpdateLandingZoneOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Controltower extends ControlTower {}
@@ -516,6 +819,336 @@ export declare namespace DisableControl {
     | InternalServerException
     | ResourceNotFoundException
     | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateLandingZone {
+  export type Input = CreateLandingZoneInput;
+  export type Output = CreateLandingZoneOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLandingZone {
+  export type Input = DeleteLandingZoneInput;
+  export type Output = DeleteLandingZoneOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisableBaseline {
+  export type Input = DisableBaselineInput;
+  export type Output = DisableBaselineOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace EnableBaseline {
+  export type Input = EnableBaselineInput;
+  export type Output = EnableBaselineOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace EnableControl {
+  export type Input = EnableControlInput;
+  export type Output = EnableControlOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBaseline {
+  export type Input = GetBaselineInput;
+  export type Output = GetBaselineOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBaselineOperation {
+  export type Input = GetBaselineOperationInput;
+  export type Output = GetBaselineOperationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetControlOperation {
+  export type Input = GetControlOperationInput;
+  export type Output = GetControlOperationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnabledBaseline {
+  export type Input = GetEnabledBaselineInput;
+  export type Output = GetEnabledBaselineOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnabledControl {
+  export type Input = GetEnabledControlInput;
+  export type Output = GetEnabledControlOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetLandingZone {
+  export type Input = GetLandingZoneInput;
+  export type Output = GetLandingZoneOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetLandingZoneOperation {
+  export type Input = GetLandingZoneOperationInput;
+  export type Output = GetLandingZoneOperationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBaselines {
+  export type Input = ListBaselinesInput;
+  export type Output = ListBaselinesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListControlOperations {
+  export type Input = ListControlOperationsInput;
+  export type Output = ListControlOperationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnabledBaselines {
+  export type Input = ListEnabledBaselinesInput;
+  export type Output = ListEnabledBaselinesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnabledControls {
+  export type Input = ListEnabledControlsInput;
+  export type Output = ListEnabledControlsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListLandingZoneOperations {
+  export type Input = ListLandingZoneOperationsInput;
+  export type Output = ListLandingZoneOperationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListLandingZones {
+  export type Input = ListLandingZonesInput;
+  export type Output = ListLandingZonesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTagsForResource {
+  export type Input = ListTagsForResourceInput;
+  export type Output = ListTagsForResourceOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ResetEnabledBaseline {
+  export type Input = ResetEnabledBaselineInput;
+  export type Output = ResetEnabledBaselineOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ResetEnabledControl {
+  export type Input = ResetEnabledControlInput;
+  export type Output = ResetEnabledControlOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ResetLandingZone {
+  export type Input = ResetLandingZoneInput;
+  export type Output = ResetLandingZoneOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace TagResource {
+  export type Input = TagResourceInput;
+  export type Output = TagResourceOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UntagResource {
+  export type Input = UntagResourceInput;
+  export type Output = UntagResourceOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEnabledBaseline {
+  export type Input = UpdateEnabledBaselineInput;
+  export type Output = UpdateEnabledBaselineOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEnabledControl {
+  export type Input = UpdateEnabledControlInput;
+  export type Output = UpdateEnabledControlOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLandingZone {
+  export type Input = UpdateLandingZoneInput;
+  export type Output = UpdateLandingZoneOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/datazone/index.ts
+++ b/src/services/datazone/index.ts
@@ -1159,6 +1159,661 @@ export declare class DataZone extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  cancelMetadataGenerationRun(
+    input: CancelMetadataGenerationRunInput,
+  ): Effect.Effect<
+    CancelMetadataGenerationRunOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAsset(
+    input: CreateAssetInput,
+  ): Effect.Effect<
+    CreateAssetOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAssetRevision(
+    input: CreateAssetRevisionInput,
+  ): Effect.Effect<
+    CreateAssetRevisionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAssetType(
+    input: CreateAssetTypeInput,
+  ): Effect.Effect<
+    CreateAssetTypeOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataProduct(
+    input: CreateDataProductInput,
+  ): Effect.Effect<
+    CreateDataProductOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataProductRevision(
+    input: CreateDataProductRevisionInput,
+  ): Effect.Effect<
+    CreateDataProductRevisionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataSource(
+    input: CreateDataSourceInput,
+  ): Effect.Effect<
+    CreateDataSourceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDomain(
+    input: CreateDomainInput,
+  ): Effect.Effect<
+    CreateDomainOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDomainUnit(
+    input: CreateDomainUnitInput,
+  ): Effect.Effect<
+    CreateDomainUnitOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createFormType(
+    input: CreateFormTypeInput,
+  ): Effect.Effect<
+    CreateFormTypeOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createGlossary(
+    input: CreateGlossaryInput,
+  ): Effect.Effect<
+    CreateGlossaryOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createGlossaryTerm(
+    input: CreateGlossaryTermInput,
+  ): Effect.Effect<
+    CreateGlossaryTermOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRule(
+    input: CreateRuleInput,
+  ): Effect.Effect<
+    CreateRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAsset(
+    input: DeleteAssetInput,
+  ): Effect.Effect<
+    DeleteAssetOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAssetType(
+    input: DeleteAssetTypeInput,
+  ): Effect.Effect<
+    DeleteAssetTypeOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataProduct(
+    input: DeleteDataProductInput,
+  ): Effect.Effect<
+    DeleteDataProductOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataSource(
+    input: DeleteDataSourceInput,
+  ): Effect.Effect<
+    DeleteDataSourceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDomain(
+    input: DeleteDomainInput,
+  ): Effect.Effect<
+    DeleteDomainOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDomainUnit(
+    input: DeleteDomainUnitInput,
+  ): Effect.Effect<
+    DeleteDomainUnitOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEnvironmentBlueprintConfiguration(
+    input: DeleteEnvironmentBlueprintConfigurationInput,
+  ): Effect.Effect<
+    DeleteEnvironmentBlueprintConfigurationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteFormType(
+    input: DeleteFormTypeInput,
+  ): Effect.Effect<
+    DeleteFormTypeOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteGlossary(
+    input: DeleteGlossaryInput,
+  ): Effect.Effect<
+    DeleteGlossaryOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteGlossaryTerm(
+    input: DeleteGlossaryTermInput,
+  ): Effect.Effect<
+    DeleteGlossaryTermOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteListing(
+    input: DeleteListingInput,
+  ): Effect.Effect<
+    DeleteListingOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRule(
+    input: DeleteRuleInput,
+  ): Effect.Effect<
+    DeleteRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAsset(
+    input: GetAssetInput,
+  ): Effect.Effect<
+    GetAssetOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAssetType(
+    input: GetAssetTypeInput,
+  ): Effect.Effect<
+    GetAssetTypeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataProduct(
+    input: GetDataProductInput,
+  ): Effect.Effect<
+    GetDataProductOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataSource(
+    input: GetDataSourceInput,
+  ): Effect.Effect<
+    GetDataSourceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataSourceRun(
+    input: GetDataSourceRunInput,
+  ): Effect.Effect<
+    GetDataSourceRunOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDomain(
+    input: GetDomainInput,
+  ): Effect.Effect<
+    GetDomainOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDomainUnit(
+    input: GetDomainUnitInput,
+  ): Effect.Effect<
+    GetDomainUnitOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEnvironmentBlueprintConfiguration(
+    input: GetEnvironmentBlueprintConfigurationInput,
+  ): Effect.Effect<
+    GetEnvironmentBlueprintConfigurationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFormType(
+    input: GetFormTypeInput,
+  ): Effect.Effect<
+    GetFormTypeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getGlossary(
+    input: GetGlossaryInput,
+  ): Effect.Effect<
+    GetGlossaryOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getGlossaryTerm(
+    input: GetGlossaryTermInput,
+  ): Effect.Effect<
+    GetGlossaryTermOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getListing(
+    input: GetListingInput,
+  ): Effect.Effect<
+    GetListingOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMetadataGenerationRun(
+    input: GetMetadataGenerationRunInput,
+  ): Effect.Effect<
+    GetMetadataGenerationRunOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRule(
+    input: GetRuleInput,
+  ): Effect.Effect<
+    GetRuleOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataSourceRuns(
+    input: ListDataSourceRunsInput,
+  ): Effect.Effect<
+    ListDataSourceRunsOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataSources(
+    input: ListDataSourcesInput,
+  ): Effect.Effect<
+    ListDataSourcesOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDomainUnitsForParent(
+    input: ListDomainUnitsForParentInput,
+  ): Effect.Effect<
+    ListDomainUnitsForParentOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDomains(
+    input: ListDomainsInput,
+  ): Effect.Effect<
+    ListDomainsOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnvironmentBlueprintConfigurations(
+    input: ListEnvironmentBlueprintConfigurationsInput,
+  ): Effect.Effect<
+    ListEnvironmentBlueprintConfigurationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMetadataGenerationRuns(
+    input: ListMetadataGenerationRunsInput,
+  ): Effect.Effect<
+    ListMetadataGenerationRunsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRules(
+    input: ListRulesInput,
+  ): Effect.Effect<
+    ListRulesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putEnvironmentBlueprintConfiguration(
+    input: PutEnvironmentBlueprintConfigurationInput,
+  ): Effect.Effect<
+    PutEnvironmentBlueprintConfigurationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startDataSourceRun(
+    input: StartDataSourceRunInput,
+  ): Effect.Effect<
+    StartDataSourceRunOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startMetadataGenerationRun(
+    input: StartMetadataGenerationRunInput,
+  ): Effect.Effect<
+    StartMetadataGenerationRunOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataSource(
+    input: UpdateDataSourceInput,
+  ): Effect.Effect<
+    UpdateDataSourceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDomain(
+    input: UpdateDomainInput,
+  ): Effect.Effect<
+    UpdateDomainOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDomainUnit(
+    input: UpdateDomainUnitInput,
+  ): Effect.Effect<
+    UpdateDomainUnitOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateGlossary(
+    input: UpdateGlossaryInput,
+  ): Effect.Effect<
+    UpdateGlossaryOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateGlossaryTerm(
+    input: UpdateGlossaryTermInput,
+  ): Effect.Effect<
+    UpdateGlossaryTermOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateRule(
+    input: UpdateRuleInput,
+  ): Effect.Effect<
+    UpdateRuleOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Datazone extends DataZone {}
@@ -7488,6 +8143,716 @@ export declare namespace UpdateUserProfile {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelMetadataGenerationRun {
+  export type Input = CancelMetadataGenerationRunInput;
+  export type Output = CancelMetadataGenerationRunOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAsset {
+  export type Input = CreateAssetInput;
+  export type Output = CreateAssetOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAssetRevision {
+  export type Input = CreateAssetRevisionInput;
+  export type Output = CreateAssetRevisionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAssetType {
+  export type Input = CreateAssetTypeInput;
+  export type Output = CreateAssetTypeOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataProduct {
+  export type Input = CreateDataProductInput;
+  export type Output = CreateDataProductOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataProductRevision {
+  export type Input = CreateDataProductRevisionInput;
+  export type Output = CreateDataProductRevisionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataSource {
+  export type Input = CreateDataSourceInput;
+  export type Output = CreateDataSourceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDomain {
+  export type Input = CreateDomainInput;
+  export type Output = CreateDomainOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDomainUnit {
+  export type Input = CreateDomainUnitInput;
+  export type Output = CreateDomainUnitOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFormType {
+  export type Input = CreateFormTypeInput;
+  export type Output = CreateFormTypeOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGlossary {
+  export type Input = CreateGlossaryInput;
+  export type Output = CreateGlossaryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGlossaryTerm {
+  export type Input = CreateGlossaryTermInput;
+  export type Output = CreateGlossaryTermOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRule {
+  export type Input = CreateRuleInput;
+  export type Output = CreateRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAsset {
+  export type Input = DeleteAssetInput;
+  export type Output = DeleteAssetOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAssetType {
+  export type Input = DeleteAssetTypeInput;
+  export type Output = DeleteAssetTypeOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataProduct {
+  export type Input = DeleteDataProductInput;
+  export type Output = DeleteDataProductOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataSource {
+  export type Input = DeleteDataSourceInput;
+  export type Output = DeleteDataSourceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDomain {
+  export type Input = DeleteDomainInput;
+  export type Output = DeleteDomainOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDomainUnit {
+  export type Input = DeleteDomainUnitInput;
+  export type Output = DeleteDomainUnitOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEnvironmentBlueprintConfiguration {
+  export type Input = DeleteEnvironmentBlueprintConfigurationInput;
+  export type Output = DeleteEnvironmentBlueprintConfigurationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFormType {
+  export type Input = DeleteFormTypeInput;
+  export type Output = DeleteFormTypeOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGlossary {
+  export type Input = DeleteGlossaryInput;
+  export type Output = DeleteGlossaryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGlossaryTerm {
+  export type Input = DeleteGlossaryTermInput;
+  export type Output = DeleteGlossaryTermOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteListing {
+  export type Input = DeleteListingInput;
+  export type Output = DeleteListingOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRule {
+  export type Input = DeleteRuleInput;
+  export type Output = DeleteRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAsset {
+  export type Input = GetAssetInput;
+  export type Output = GetAssetOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAssetType {
+  export type Input = GetAssetTypeInput;
+  export type Output = GetAssetTypeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataProduct {
+  export type Input = GetDataProductInput;
+  export type Output = GetDataProductOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataSource {
+  export type Input = GetDataSourceInput;
+  export type Output = GetDataSourceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataSourceRun {
+  export type Input = GetDataSourceRunInput;
+  export type Output = GetDataSourceRunOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDomain {
+  export type Input = GetDomainInput;
+  export type Output = GetDomainOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDomainUnit {
+  export type Input = GetDomainUnitInput;
+  export type Output = GetDomainUnitOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnvironmentBlueprintConfiguration {
+  export type Input = GetEnvironmentBlueprintConfigurationInput;
+  export type Output = GetEnvironmentBlueprintConfigurationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFormType {
+  export type Input = GetFormTypeInput;
+  export type Output = GetFormTypeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetGlossary {
+  export type Input = GetGlossaryInput;
+  export type Output = GetGlossaryOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetGlossaryTerm {
+  export type Input = GetGlossaryTermInput;
+  export type Output = GetGlossaryTermOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetListing {
+  export type Input = GetListingInput;
+  export type Output = GetListingOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMetadataGenerationRun {
+  export type Input = GetMetadataGenerationRunInput;
+  export type Output = GetMetadataGenerationRunOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRule {
+  export type Input = GetRuleInput;
+  export type Output = GetRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataSourceRuns {
+  export type Input = ListDataSourceRunsInput;
+  export type Output = ListDataSourceRunsOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataSources {
+  export type Input = ListDataSourcesInput;
+  export type Output = ListDataSourcesOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDomainUnitsForParent {
+  export type Input = ListDomainUnitsForParentInput;
+  export type Output = ListDomainUnitsForParentOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDomains {
+  export type Input = ListDomainsInput;
+  export type Output = ListDomainsOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironmentBlueprintConfigurations {
+  export type Input = ListEnvironmentBlueprintConfigurationsInput;
+  export type Output = ListEnvironmentBlueprintConfigurationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMetadataGenerationRuns {
+  export type Input = ListMetadataGenerationRunsInput;
+  export type Output = ListMetadataGenerationRunsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRules {
+  export type Input = ListRulesInput;
+  export type Output = ListRulesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutEnvironmentBlueprintConfiguration {
+  export type Input = PutEnvironmentBlueprintConfigurationInput;
+  export type Output = PutEnvironmentBlueprintConfigurationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartDataSourceRun {
+  export type Input = StartDataSourceRunInput;
+  export type Output = StartDataSourceRunOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartMetadataGenerationRun {
+  export type Input = StartMetadataGenerationRunInput;
+  export type Output = StartMetadataGenerationRunOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataSource {
+  export type Input = UpdateDataSourceInput;
+  export type Output = UpdateDataSourceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDomain {
+  export type Input = UpdateDomainInput;
+  export type Output = UpdateDomainOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDomainUnit {
+  export type Input = UpdateDomainUnitInput;
+  export type Output = UpdateDomainUnitOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGlossary {
+  export type Input = UpdateGlossaryInput;
+  export type Output = UpdateGlossaryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGlossaryTerm {
+  export type Input = UpdateGlossaryTermInput;
+  export type Output = UpdateGlossaryTermOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRule {
+  export type Input = UpdateRuleInput;
+  export type Output = UpdateRuleOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/deadline/index.ts
+++ b/src/services/deadline/index.ts
@@ -220,6 +220,1053 @@ export declare class deadline extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateMemberToFarm(
+    input: AssociateMemberToFarmRequest,
+  ): Effect.Effect<
+    AssociateMemberToFarmResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateMemberToFleet(
+    input: AssociateMemberToFleetRequest,
+  ): Effect.Effect<
+    AssociateMemberToFleetResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateMemberToJob(
+    input: AssociateMemberToJobRequest,
+  ): Effect.Effect<
+    AssociateMemberToJobResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateMemberToQueue(
+    input: AssociateMemberToQueueRequest,
+  ): Effect.Effect<
+    AssociateMemberToQueueResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  assumeFleetRoleForRead(
+    input: AssumeFleetRoleForReadRequest,
+  ): Effect.Effect<
+    AssumeFleetRoleForReadResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  assumeFleetRoleForWorker(
+    input: AssumeFleetRoleForWorkerRequest,
+  ): Effect.Effect<
+    AssumeFleetRoleForWorkerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  assumeQueueRoleForRead(
+    input: AssumeQueueRoleForReadRequest,
+  ): Effect.Effect<
+    AssumeQueueRoleForReadResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  assumeQueueRoleForUser(
+    input: AssumeQueueRoleForUserRequest,
+  ): Effect.Effect<
+    AssumeQueueRoleForUserResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  assumeQueueRoleForWorker(
+    input: AssumeQueueRoleForWorkerRequest,
+  ): Effect.Effect<
+    AssumeQueueRoleForWorkerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchGetJobEntity(
+    input: BatchGetJobEntityRequest,
+  ): Effect.Effect<
+    BatchGetJobEntityResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  copyJobTemplate(
+    input: CopyJobTemplateRequest,
+  ): Effect.Effect<
+    CopyJobTemplateResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createBudget(
+    input: CreateBudgetRequest,
+  ): Effect.Effect<
+    CreateBudgetResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createFarm(
+    input: CreateFarmRequest,
+  ): Effect.Effect<
+    CreateFarmResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createFleet(
+    input: CreateFleetRequest,
+  ): Effect.Effect<
+    CreateFleetResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createJob(
+    input: CreateJobRequest,
+  ): Effect.Effect<
+    CreateJobResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createLicenseEndpoint(
+    input: CreateLicenseEndpointRequest,
+  ): Effect.Effect<
+    CreateLicenseEndpointResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createLimit(
+    input: CreateLimitRequest,
+  ): Effect.Effect<
+    CreateLimitResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createMonitor(
+    input: CreateMonitorRequest,
+  ): Effect.Effect<
+    CreateMonitorResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createQueue(
+    input: CreateQueueRequest,
+  ): Effect.Effect<
+    CreateQueueResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createQueueEnvironment(
+    input: CreateQueueEnvironmentRequest,
+  ): Effect.Effect<
+    CreateQueueEnvironmentResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createStorageProfile(
+    input: CreateStorageProfileRequest,
+  ): Effect.Effect<
+    CreateStorageProfileResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorker(
+    input: CreateWorkerRequest,
+  ): Effect.Effect<
+    CreateWorkerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteBudget(
+    input: DeleteBudgetRequest,
+  ): Effect.Effect<
+    DeleteBudgetResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteFarm(
+    input: DeleteFarmRequest,
+  ): Effect.Effect<
+    DeleteFarmResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteFleet(
+    input: DeleteFleetRequest,
+  ): Effect.Effect<
+    DeleteFleetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteLicenseEndpoint(
+    input: DeleteLicenseEndpointRequest,
+  ): Effect.Effect<
+    DeleteLicenseEndpointResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteLimit(
+    input: DeleteLimitRequest,
+  ): Effect.Effect<
+    DeleteLimitResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMeteredProduct(
+    input: DeleteMeteredProductRequest,
+  ): Effect.Effect<
+    DeleteMeteredProductResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMonitor(
+    input: DeleteMonitorRequest,
+  ): Effect.Effect<
+    DeleteMonitorResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteQueue(
+    input: DeleteQueueRequest,
+  ): Effect.Effect<
+    DeleteQueueResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteQueueEnvironment(
+    input: DeleteQueueEnvironmentRequest,
+  ): Effect.Effect<
+    DeleteQueueEnvironmentResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteStorageProfile(
+    input: DeleteStorageProfileRequest,
+  ): Effect.Effect<
+    DeleteStorageProfileResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorker(
+    input: DeleteWorkerRequest,
+  ): Effect.Effect<
+    DeleteWorkerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateMemberFromFarm(
+    input: DisassociateMemberFromFarmRequest,
+  ): Effect.Effect<
+    DisassociateMemberFromFarmResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateMemberFromFleet(
+    input: DisassociateMemberFromFleetRequest,
+  ): Effect.Effect<
+    DisassociateMemberFromFleetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateMemberFromJob(
+    input: DisassociateMemberFromJobRequest,
+  ): Effect.Effect<
+    DisassociateMemberFromJobResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateMemberFromQueue(
+    input: DisassociateMemberFromQueueRequest,
+  ): Effect.Effect<
+    DisassociateMemberFromQueueResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBudget(
+    input: GetBudgetRequest,
+  ): Effect.Effect<
+    GetBudgetResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFarm(
+    input: GetFarmRequest,
+  ): Effect.Effect<
+    GetFarmResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFleet(
+    input: GetFleetRequest,
+  ): Effect.Effect<
+    GetFleetResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getJob(
+    input: GetJobRequest,
+  ): Effect.Effect<
+    GetJobResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getLicenseEndpoint(
+    input: GetLicenseEndpointRequest,
+  ): Effect.Effect<
+    GetLicenseEndpointResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getLimit(
+    input: GetLimitRequest,
+  ): Effect.Effect<
+    GetLimitResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMonitor(
+    input: GetMonitorRequest,
+  ): Effect.Effect<
+    GetMonitorResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueue(
+    input: GetQueueRequest,
+  ): Effect.Effect<
+    GetQueueResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueueEnvironment(
+    input: GetQueueEnvironmentRequest,
+  ): Effect.Effect<
+    GetQueueEnvironmentResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSession(
+    input: GetSessionRequest,
+  ): Effect.Effect<
+    GetSessionResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSessionAction(
+    input: GetSessionActionRequest,
+  ): Effect.Effect<
+    GetSessionActionResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getStep(
+    input: GetStepRequest,
+  ): Effect.Effect<
+    GetStepResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getStorageProfile(
+    input: GetStorageProfileRequest,
+  ): Effect.Effect<
+    GetStorageProfileResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getStorageProfileForQueue(
+    input: GetStorageProfileForQueueRequest,
+  ): Effect.Effect<
+    GetStorageProfileForQueueResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTask(
+    input: GetTaskRequest,
+  ): Effect.Effect<
+    GetTaskResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorker(
+    input: GetWorkerRequest,
+  ): Effect.Effect<
+    GetWorkerResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBudgets(
+    input: ListBudgetsRequest,
+  ): Effect.Effect<
+    ListBudgetsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFarmMembers(
+    input: ListFarmMembersRequest,
+  ): Effect.Effect<
+    ListFarmMembersResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFarms(
+    input: ListFarmsRequest,
+  ): Effect.Effect<
+    ListFarmsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFleetMembers(
+    input: ListFleetMembersRequest,
+  ): Effect.Effect<
+    ListFleetMembersResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFleets(
+    input: ListFleetsRequest,
+  ): Effect.Effect<
+    ListFleetsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listJobMembers(
+    input: ListJobMembersRequest,
+  ): Effect.Effect<
+    ListJobMembersResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listJobParameterDefinitions(
+    input: ListJobParameterDefinitionsRequest,
+  ): Effect.Effect<
+    ListJobParameterDefinitionsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listJobs(
+    input: ListJobsRequest,
+  ): Effect.Effect<
+    ListJobsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listLicenseEndpoints(
+    input: ListLicenseEndpointsRequest,
+  ): Effect.Effect<
+    ListLicenseEndpointsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listLimits(
+    input: ListLimitsRequest,
+  ): Effect.Effect<
+    ListLimitsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMeteredProducts(
+    input: ListMeteredProductsRequest,
+  ): Effect.Effect<
+    ListMeteredProductsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMonitors(
+    input: ListMonitorsRequest,
+  ): Effect.Effect<
+    ListMonitorsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listQueueEnvironments(
+    input: ListQueueEnvironmentsRequest,
+  ): Effect.Effect<
+    ListQueueEnvironmentsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listQueueMembers(
+    input: ListQueueMembersRequest,
+  ): Effect.Effect<
+    ListQueueMembersResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listQueues(
+    input: ListQueuesRequest,
+  ): Effect.Effect<
+    ListQueuesResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSessionActions(
+    input: ListSessionActionsRequest,
+  ): Effect.Effect<
+    ListSessionActionsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSessions(
+    input: ListSessionsRequest,
+  ): Effect.Effect<
+    ListSessionsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSessionsForWorker(
+    input: ListSessionsForWorkerRequest,
+  ): Effect.Effect<
+    ListSessionsForWorkerResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listStepConsumers(
+    input: ListStepConsumersRequest,
+  ): Effect.Effect<
+    ListStepConsumersResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listStepDependencies(
+    input: ListStepDependenciesRequest,
+  ): Effect.Effect<
+    ListStepDependenciesResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSteps(
+    input: ListStepsRequest,
+  ): Effect.Effect<
+    ListStepsResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listStorageProfiles(
+    input: ListStorageProfilesRequest,
+  ): Effect.Effect<
+    ListStorageProfilesResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listStorageProfilesForQueue(
+    input: ListStorageProfilesForQueueRequest,
+  ): Effect.Effect<
+    ListStorageProfilesForQueueResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTasks(
+    input: ListTasksRequest,
+  ): Effect.Effect<
+    ListTasksResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkers(
+    input: ListWorkersRequest,
+  ): Effect.Effect<
+    ListWorkersResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putMeteredProduct(
+    input: PutMeteredProductRequest,
+  ): Effect.Effect<
+    PutMeteredProductResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateBudget(
+    input: UpdateBudgetRequest,
+  ): Effect.Effect<
+    UpdateBudgetResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateFarm(
+    input: UpdateFarmRequest,
+  ): Effect.Effect<
+    UpdateFarmResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateFleet(
+    input: UpdateFleetRequest,
+  ): Effect.Effect<
+    UpdateFleetResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateJob(
+    input: UpdateJobRequest,
+  ): Effect.Effect<
+    UpdateJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLimit(
+    input: UpdateLimitRequest,
+  ): Effect.Effect<
+    UpdateLimitResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateMonitor(
+    input: UpdateMonitorRequest,
+  ): Effect.Effect<
+    UpdateMonitorResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateQueue(
+    input: UpdateQueueRequest,
+  ): Effect.Effect<
+    UpdateQueueResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateQueueEnvironment(
+    input: UpdateQueueEnvironmentRequest,
+  ): Effect.Effect<
+    UpdateQueueEnvironmentResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSession(
+    input: UpdateSessionRequest,
+  ): Effect.Effect<
+    UpdateSessionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateStep(
+    input: UpdateStepRequest,
+  ): Effect.Effect<
+    UpdateStepResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateStorageProfile(
+    input: UpdateStorageProfileRequest,
+  ): Effect.Effect<
+    UpdateStorageProfileResponse,
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTask(
+    input: UpdateTaskRequest,
+  ): Effect.Effect<
+    UpdateTaskResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorker(
+    input: UpdateWorkerRequest,
+  ): Effect.Effect<
+    UpdateWorkerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkerSchedule(
+    input: UpdateWorkerScheduleRequest,
+  ): Effect.Effect<
+    UpdateWorkerScheduleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export interface AcceleratorCapabilities {
@@ -3154,6 +4201,1146 @@ export declare namespace UpdateQueueLimitAssociation {
   export type Output = UpdateQueueLimitAssociationResponse;
   export type Error =
     | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateMemberToFarm {
+  export type Input = AssociateMemberToFarmRequest;
+  export type Output = AssociateMemberToFarmResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateMemberToFleet {
+  export type Input = AssociateMemberToFleetRequest;
+  export type Output = AssociateMemberToFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateMemberToJob {
+  export type Input = AssociateMemberToJobRequest;
+  export type Output = AssociateMemberToJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateMemberToQueue {
+  export type Input = AssociateMemberToQueueRequest;
+  export type Output = AssociateMemberToQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssumeFleetRoleForRead {
+  export type Input = AssumeFleetRoleForReadRequest;
+  export type Output = AssumeFleetRoleForReadResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssumeFleetRoleForWorker {
+  export type Input = AssumeFleetRoleForWorkerRequest;
+  export type Output = AssumeFleetRoleForWorkerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssumeQueueRoleForRead {
+  export type Input = AssumeQueueRoleForReadRequest;
+  export type Output = AssumeQueueRoleForReadResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssumeQueueRoleForUser {
+  export type Input = AssumeQueueRoleForUserRequest;
+  export type Output = AssumeQueueRoleForUserResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssumeQueueRoleForWorker {
+  export type Input = AssumeQueueRoleForWorkerRequest;
+  export type Output = AssumeQueueRoleForWorkerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetJobEntity {
+  export type Input = BatchGetJobEntityRequest;
+  export type Output = BatchGetJobEntityResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CopyJobTemplate {
+  export type Input = CopyJobTemplateRequest;
+  export type Output = CopyJobTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBudget {
+  export type Input = CreateBudgetRequest;
+  export type Output = CreateBudgetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFarm {
+  export type Input = CreateFarmRequest;
+  export type Output = CreateFarmResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFleet {
+  export type Input = CreateFleetRequest;
+  export type Output = CreateFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateJob {
+  export type Input = CreateJobRequest;
+  export type Output = CreateJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateLicenseEndpoint {
+  export type Input = CreateLicenseEndpointRequest;
+  export type Output = CreateLicenseEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateLimit {
+  export type Input = CreateLimitRequest;
+  export type Output = CreateLimitResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMonitor {
+  export type Input = CreateMonitorRequest;
+  export type Output = CreateMonitorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateQueue {
+  export type Input = CreateQueueRequest;
+  export type Output = CreateQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateQueueEnvironment {
+  export type Input = CreateQueueEnvironmentRequest;
+  export type Output = CreateQueueEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateStorageProfile {
+  export type Input = CreateStorageProfileRequest;
+  export type Output = CreateStorageProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorker {
+  export type Input = CreateWorkerRequest;
+  export type Output = CreateWorkerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteBudget {
+  export type Input = DeleteBudgetRequest;
+  export type Output = DeleteBudgetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFarm {
+  export type Input = DeleteFarmRequest;
+  export type Output = DeleteFarmResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFleet {
+  export type Input = DeleteFleetRequest;
+  export type Output = DeleteFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLicenseEndpoint {
+  export type Input = DeleteLicenseEndpointRequest;
+  export type Output = DeleteLicenseEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLimit {
+  export type Input = DeleteLimitRequest;
+  export type Output = DeleteLimitResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMeteredProduct {
+  export type Input = DeleteMeteredProductRequest;
+  export type Output = DeleteMeteredProductResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMonitor {
+  export type Input = DeleteMonitorRequest;
+  export type Output = DeleteMonitorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteQueue {
+  export type Input = DeleteQueueRequest;
+  export type Output = DeleteQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteQueueEnvironment {
+  export type Input = DeleteQueueEnvironmentRequest;
+  export type Output = DeleteQueueEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteStorageProfile {
+  export type Input = DeleteStorageProfileRequest;
+  export type Output = DeleteStorageProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorker {
+  export type Input = DeleteWorkerRequest;
+  export type Output = DeleteWorkerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateMemberFromFarm {
+  export type Input = DisassociateMemberFromFarmRequest;
+  export type Output = DisassociateMemberFromFarmResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateMemberFromFleet {
+  export type Input = DisassociateMemberFromFleetRequest;
+  export type Output = DisassociateMemberFromFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateMemberFromJob {
+  export type Input = DisassociateMemberFromJobRequest;
+  export type Output = DisassociateMemberFromJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateMemberFromQueue {
+  export type Input = DisassociateMemberFromQueueRequest;
+  export type Output = DisassociateMemberFromQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBudget {
+  export type Input = GetBudgetRequest;
+  export type Output = GetBudgetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFarm {
+  export type Input = GetFarmRequest;
+  export type Output = GetFarmResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFleet {
+  export type Input = GetFleetRequest;
+  export type Output = GetFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetJob {
+  export type Input = GetJobRequest;
+  export type Output = GetJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetLicenseEndpoint {
+  export type Input = GetLicenseEndpointRequest;
+  export type Output = GetLicenseEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetLimit {
+  export type Input = GetLimitRequest;
+  export type Output = GetLimitResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMonitor {
+  export type Input = GetMonitorRequest;
+  export type Output = GetMonitorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueue {
+  export type Input = GetQueueRequest;
+  export type Output = GetQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueueEnvironment {
+  export type Input = GetQueueEnvironmentRequest;
+  export type Output = GetQueueEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSession {
+  export type Input = GetSessionRequest;
+  export type Output = GetSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSessionAction {
+  export type Input = GetSessionActionRequest;
+  export type Output = GetSessionActionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetStep {
+  export type Input = GetStepRequest;
+  export type Output = GetStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetStorageProfile {
+  export type Input = GetStorageProfileRequest;
+  export type Output = GetStorageProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetStorageProfileForQueue {
+  export type Input = GetStorageProfileForQueueRequest;
+  export type Output = GetStorageProfileForQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTask {
+  export type Input = GetTaskRequest;
+  export type Output = GetTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorker {
+  export type Input = GetWorkerRequest;
+  export type Output = GetWorkerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBudgets {
+  export type Input = ListBudgetsRequest;
+  export type Output = ListBudgetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFarmMembers {
+  export type Input = ListFarmMembersRequest;
+  export type Output = ListFarmMembersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFarms {
+  export type Input = ListFarmsRequest;
+  export type Output = ListFarmsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFleetMembers {
+  export type Input = ListFleetMembersRequest;
+  export type Output = ListFleetMembersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFleets {
+  export type Input = ListFleetsRequest;
+  export type Output = ListFleetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListJobMembers {
+  export type Input = ListJobMembersRequest;
+  export type Output = ListJobMembersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListJobParameterDefinitions {
+  export type Input = ListJobParameterDefinitionsRequest;
+  export type Output = ListJobParameterDefinitionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListJobs {
+  export type Input = ListJobsRequest;
+  export type Output = ListJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListLicenseEndpoints {
+  export type Input = ListLicenseEndpointsRequest;
+  export type Output = ListLicenseEndpointsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListLimits {
+  export type Input = ListLimitsRequest;
+  export type Output = ListLimitsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMeteredProducts {
+  export type Input = ListMeteredProductsRequest;
+  export type Output = ListMeteredProductsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMonitors {
+  export type Input = ListMonitorsRequest;
+  export type Output = ListMonitorsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListQueueEnvironments {
+  export type Input = ListQueueEnvironmentsRequest;
+  export type Output = ListQueueEnvironmentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListQueueMembers {
+  export type Input = ListQueueMembersRequest;
+  export type Output = ListQueueMembersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListQueues {
+  export type Input = ListQueuesRequest;
+  export type Output = ListQueuesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSessionActions {
+  export type Input = ListSessionActionsRequest;
+  export type Output = ListSessionActionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSessions {
+  export type Input = ListSessionsRequest;
+  export type Output = ListSessionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSessionsForWorker {
+  export type Input = ListSessionsForWorkerRequest;
+  export type Output = ListSessionsForWorkerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListStepConsumers {
+  export type Input = ListStepConsumersRequest;
+  export type Output = ListStepConsumersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListStepDependencies {
+  export type Input = ListStepDependenciesRequest;
+  export type Output = ListStepDependenciesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSteps {
+  export type Input = ListStepsRequest;
+  export type Output = ListStepsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListStorageProfiles {
+  export type Input = ListStorageProfilesRequest;
+  export type Output = ListStorageProfilesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListStorageProfilesForQueue {
+  export type Input = ListStorageProfilesForQueueRequest;
+  export type Output = ListStorageProfilesForQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTasks {
+  export type Input = ListTasksRequest;
+  export type Output = ListTasksResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkers {
+  export type Input = ListWorkersRequest;
+  export type Output = ListWorkersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutMeteredProduct {
+  export type Input = PutMeteredProductRequest;
+  export type Output = PutMeteredProductResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBudget {
+  export type Input = UpdateBudgetRequest;
+  export type Output = UpdateBudgetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFarm {
+  export type Input = UpdateFarmRequest;
+  export type Output = UpdateFarmResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFleet {
+  export type Input = UpdateFleetRequest;
+  export type Output = UpdateFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateJob {
+  export type Input = UpdateJobRequest;
+  export type Output = UpdateJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLimit {
+  export type Input = UpdateLimitRequest;
+  export type Output = UpdateLimitResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMonitor {
+  export type Input = UpdateMonitorRequest;
+  export type Output = UpdateMonitorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateQueue {
+  export type Input = UpdateQueueRequest;
+  export type Output = UpdateQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateQueueEnvironment {
+  export type Input = UpdateQueueEnvironmentRequest;
+  export type Output = UpdateQueueEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSession {
+  export type Input = UpdateSessionRequest;
+  export type Output = UpdateSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateStep {
+  export type Input = UpdateStepRequest;
+  export type Output = UpdateStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateStorageProfile {
+  export type Input = UpdateStorageProfileRequest;
+  export type Output = UpdateStorageProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTask {
+  export type Input = UpdateTaskRequest;
+  export type Output = UpdateTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorker {
+  export type Input = UpdateWorkerRequest;
+  export type Output = UpdateWorkerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerErrorException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkerSchedule {
+  export type Input = UpdateWorkerScheduleRequest;
+  export type Output = UpdateWorkerScheduleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerErrorException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/drs/index.ts
+++ b/src/services/drs/index.ts
@@ -115,6 +115,456 @@ export declare class drs extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateSourceNetworkStack(
+    input: AssociateSourceNetworkStackRequest,
+  ): Effect.Effect<
+    AssociateSourceNetworkStackResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createLaunchConfigurationTemplate(
+    input: CreateLaunchConfigurationTemplateRequest,
+  ): Effect.Effect<
+    CreateLaunchConfigurationTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createReplicationConfigurationTemplate(
+    input: CreateReplicationConfigurationTemplateRequest,
+  ): Effect.Effect<
+    ReplicationConfigurationTemplate,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSourceNetwork(
+    input: CreateSourceNetworkRequest,
+  ): Effect.Effect<
+    CreateSourceNetworkResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteJob(
+    input: DeleteJobRequest,
+  ): Effect.Effect<
+    DeleteJobResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteLaunchConfigurationTemplate(
+    input: DeleteLaunchConfigurationTemplateRequest,
+  ): Effect.Effect<
+    DeleteLaunchConfigurationTemplateResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteRecoveryInstance(
+    input: DeleteRecoveryInstanceRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteReplicationConfigurationTemplate(
+    input: DeleteReplicationConfigurationTemplateRequest,
+  ): Effect.Effect<
+    DeleteReplicationConfigurationTemplateResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteSourceNetwork(
+    input: DeleteSourceNetworkRequest,
+  ): Effect.Effect<
+    DeleteSourceNetworkResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteSourceServer(
+    input: DeleteSourceServerRequest,
+  ): Effect.Effect<
+    DeleteSourceServerResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  describeJobLogItems(
+    input: DescribeJobLogItemsRequest,
+  ): Effect.Effect<
+    DescribeJobLogItemsResponse,
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeJobs(
+    input: DescribeJobsRequest,
+  ): Effect.Effect<
+    DescribeJobsResponse,
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeLaunchConfigurationTemplates(
+    input: DescribeLaunchConfigurationTemplatesRequest,
+  ): Effect.Effect<
+    DescribeLaunchConfigurationTemplatesResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeRecoveryInstances(
+    input: DescribeRecoveryInstancesRequest,
+  ): Effect.Effect<
+    DescribeRecoveryInstancesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  describeRecoverySnapshots(
+    input: DescribeRecoverySnapshotsRequest,
+  ): Effect.Effect<
+    DescribeRecoverySnapshotsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeReplicationConfigurationTemplates(
+    input: DescribeReplicationConfigurationTemplatesRequest,
+  ): Effect.Effect<
+    DescribeReplicationConfigurationTemplatesResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeSourceNetworks(
+    input: DescribeSourceNetworksRequest,
+  ): Effect.Effect<
+    DescribeSourceNetworksResponse,
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeSourceServers(
+    input: DescribeSourceServersRequest,
+  ): Effect.Effect<
+    DescribeSourceServersResponse,
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disconnectRecoveryInstance(
+    input: DisconnectRecoveryInstanceRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  disconnectSourceServer(
+    input: DisconnectSourceServerRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  exportSourceNetworkCfnTemplate(
+    input: ExportSourceNetworkCfnTemplateRequest,
+  ): Effect.Effect<
+    ExportSourceNetworkCfnTemplateResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFailbackReplicationConfiguration(
+    input: GetFailbackReplicationConfigurationRequest,
+  ): Effect.Effect<
+    GetFailbackReplicationConfigurationResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  getLaunchConfiguration(
+    input: GetLaunchConfigurationRequest,
+  ): Effect.Effect<
+    LaunchConfiguration,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  getReplicationConfiguration(
+    input: GetReplicationConfigurationRequest,
+  ): Effect.Effect<
+    ReplicationConfiguration,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  retryDataReplication(
+    input: RetryDataReplicationRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  reverseReplication(
+    input: ReverseReplicationRequest,
+  ): Effect.Effect<
+    ReverseReplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startFailbackLaunch(
+    input: StartFailbackLaunchRequest,
+  ): Effect.Effect<
+    StartFailbackLaunchResponse,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startRecovery(
+    input: StartRecoveryRequest,
+  ): Effect.Effect<
+    StartRecoveryResponse,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  startReplication(
+    input: StartReplicationRequest,
+  ): Effect.Effect<
+    StartReplicationResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  startSourceNetworkRecovery(
+    input: StartSourceNetworkRecoveryRequest,
+  ): Effect.Effect<
+    StartSourceNetworkRecoveryResponse,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startSourceNetworkReplication(
+    input: StartSourceNetworkReplicationRequest,
+  ): Effect.Effect<
+    StartSourceNetworkReplicationResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  stopFailback(
+    input: StopFailbackRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  stopReplication(
+    input: StopReplicationRequest,
+  ): Effect.Effect<
+    StopReplicationResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  stopSourceNetworkReplication(
+    input: StopSourceNetworkReplicationRequest,
+  ): Effect.Effect<
+    StopSourceNetworkReplicationResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  terminateRecoveryInstances(
+    input: TerminateRecoveryInstancesRequest,
+  ): Effect.Effect<
+    TerminateRecoveryInstancesResponse,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  updateFailbackReplicationConfiguration(
+    input: UpdateFailbackReplicationConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  updateLaunchConfiguration(
+    input: UpdateLaunchConfigurationRequest,
+  ): Effect.Effect<
+    LaunchConfiguration,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLaunchConfigurationTemplate(
+    input: UpdateLaunchConfigurationTemplateRequest,
+  ): Effect.Effect<
+    UpdateLaunchConfigurationTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateReplicationConfiguration(
+    input: UpdateReplicationConfigurationRequest,
+  ): Effect.Effect<
+    ReplicationConfiguration,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateReplicationConfigurationTemplate(
+    input: UpdateReplicationConfigurationTemplateRequest,
+  ): Effect.Effect<
+    ReplicationConfigurationTemplate,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Drs extends drs {}
@@ -1340,6 +1790,496 @@ export declare namespace UntagResource {
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateSourceNetworkStack {
+  export type Input = AssociateSourceNetworkStackRequest;
+  export type Output = AssociateSourceNetworkStackResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateLaunchConfigurationTemplate {
+  export type Input = CreateLaunchConfigurationTemplateRequest;
+  export type Output = CreateLaunchConfigurationTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateReplicationConfigurationTemplate {
+  export type Input = CreateReplicationConfigurationTemplateRequest;
+  export type Output = ReplicationConfigurationTemplate;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSourceNetwork {
+  export type Input = CreateSourceNetworkRequest;
+  export type Output = CreateSourceNetworkResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteJob {
+  export type Input = DeleteJobRequest;
+  export type Output = DeleteJobResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLaunchConfigurationTemplate {
+  export type Input = DeleteLaunchConfigurationTemplateRequest;
+  export type Output = DeleteLaunchConfigurationTemplateResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRecoveryInstance {
+  export type Input = DeleteRecoveryInstanceRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteReplicationConfigurationTemplate {
+  export type Input = DeleteReplicationConfigurationTemplateRequest;
+  export type Output = DeleteReplicationConfigurationTemplateResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSourceNetwork {
+  export type Input = DeleteSourceNetworkRequest;
+  export type Output = DeleteSourceNetworkResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSourceServer {
+  export type Input = DeleteSourceServerRequest;
+  export type Output = DeleteSourceServerResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeJobLogItems {
+  export type Input = DescribeJobLogItemsRequest;
+  export type Output = DescribeJobLogItemsResponse;
+  export type Error =
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeJobs {
+  export type Input = DescribeJobsRequest;
+  export type Output = DescribeJobsResponse;
+  export type Error =
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeLaunchConfigurationTemplates {
+  export type Input = DescribeLaunchConfigurationTemplatesRequest;
+  export type Output = DescribeLaunchConfigurationTemplatesResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeRecoveryInstances {
+  export type Input = DescribeRecoveryInstancesRequest;
+  export type Output = DescribeRecoveryInstancesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeRecoverySnapshots {
+  export type Input = DescribeRecoverySnapshotsRequest;
+  export type Output = DescribeRecoverySnapshotsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeReplicationConfigurationTemplates {
+  export type Input = DescribeReplicationConfigurationTemplatesRequest;
+  export type Output = DescribeReplicationConfigurationTemplatesResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeSourceNetworks {
+  export type Input = DescribeSourceNetworksRequest;
+  export type Output = DescribeSourceNetworksResponse;
+  export type Error =
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeSourceServers {
+  export type Input = DescribeSourceServersRequest;
+  export type Output = DescribeSourceServersResponse;
+  export type Error =
+    | InternalServerException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisconnectRecoveryInstance {
+  export type Input = DisconnectRecoveryInstanceRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DisconnectSourceServer {
+  export type Input = DisconnectSourceServerRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace ExportSourceNetworkCfnTemplate {
+  export type Input = ExportSourceNetworkCfnTemplateRequest;
+  export type Output = ExportSourceNetworkCfnTemplateResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFailbackReplicationConfiguration {
+  export type Input = GetFailbackReplicationConfigurationRequest;
+  export type Output = GetFailbackReplicationConfigurationResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace GetLaunchConfiguration {
+  export type Input = GetLaunchConfigurationRequest;
+  export type Output = LaunchConfiguration;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace GetReplicationConfiguration {
+  export type Input = GetReplicationConfigurationRequest;
+  export type Output = ReplicationConfiguration;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace RetryDataReplication {
+  export type Input = RetryDataReplicationRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ReverseReplication {
+  export type Input = ReverseReplicationRequest;
+  export type Output = ReverseReplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartFailbackLaunch {
+  export type Input = StartFailbackLaunchRequest;
+  export type Output = StartFailbackLaunchResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartRecovery {
+  export type Input = StartRecoveryRequest;
+  export type Output = StartRecoveryResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace StartReplication {
+  export type Input = StartReplicationRequest;
+  export type Output = StartReplicationResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace StartSourceNetworkRecovery {
+  export type Input = StartSourceNetworkRecoveryRequest;
+  export type Output = StartSourceNetworkRecoveryResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartSourceNetworkReplication {
+  export type Input = StartSourceNetworkReplicationRequest;
+  export type Output = StartSourceNetworkReplicationResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace StopFailback {
+  export type Input = StopFailbackRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace StopReplication {
+  export type Input = StopReplicationRequest;
+  export type Output = StopReplicationResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace StopSourceNetworkReplication {
+  export type Input = StopSourceNetworkReplicationRequest;
+  export type Output = StopSourceNetworkReplicationResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace TerminateRecoveryInstances {
+  export type Input = TerminateRecoveryInstancesRequest;
+  export type Output = TerminateRecoveryInstancesResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFailbackReplicationConfiguration {
+  export type Input = UpdateFailbackReplicationConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLaunchConfiguration {
+  export type Input = UpdateLaunchConfigurationRequest;
+  export type Output = LaunchConfiguration;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLaunchConfigurationTemplate {
+  export type Input = UpdateLaunchConfigurationTemplateRequest;
+  export type Output = UpdateLaunchConfigurationTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateReplicationConfiguration {
+  export type Input = UpdateReplicationConfigurationRequest;
+  export type Output = ReplicationConfiguration;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateReplicationConfigurationTemplate {
+  export type Input = UpdateReplicationConfigurationTemplateRequest;
+  export type Output = ReplicationConfigurationTemplate;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UninitializedAccountException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/dsql/index.ts
+++ b/src/services/dsql/index.ts
@@ -18,6 +18,52 @@ export declare class DSQL extends AWSServiceClient {
   untagResource(
     input: UntagResourceInput,
   ): Effect.Effect<{}, ResourceNotFoundException | CommonAwsError>;
+  createCluster(
+    input: CreateClusterInput,
+  ): Effect.Effect<
+    CreateClusterOutput,
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCluster(
+    input: DeleteClusterInput,
+  ): Effect.Effect<
+    DeleteClusterOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  getCluster(
+    input: GetClusterInput,
+  ): Effect.Effect<
+    GetClusterOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getVpcEndpointServiceName(
+    input: GetVpcEndpointServiceNameInput,
+  ): Effect.Effect<
+    GetVpcEndpointServiceNameOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listClusters(
+    input: ListClustersInput,
+  ): Effect.Effect<
+    ListClustersOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  updateCluster(
+    input: UpdateClusterInput,
+  ): Effect.Effect<
+    UpdateClusterOutput,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Dsql extends DSQL {}
@@ -243,4 +289,56 @@ export declare namespace UntagResource {
   export type Input = UntagResourceInput;
   export type Output = {};
   export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace CreateCluster {
+  export type Input = CreateClusterInput;
+  export type Output = CreateClusterOutput;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCluster {
+  export type Input = DeleteClusterInput;
+  export type Output = DeleteClusterOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetCluster {
+  export type Input = GetClusterInput;
+  export type Output = GetClusterOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetVpcEndpointServiceName {
+  export type Input = GetVpcEndpointServiceNameInput;
+  export type Output = GetVpcEndpointServiceNameOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListClusters {
+  export type Input = ListClustersInput;
+  export type Output = ListClustersOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace UpdateCluster {
+  export type Input = UpdateClusterInput;
+  export type Output = UpdateClusterOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
 }

--- a/src/services/emr-serverless/index.ts
+++ b/src/services/emr-serverless/index.ts
@@ -30,6 +30,120 @@ export declare class EMRServerless extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  cancelJobRun(
+    input: CancelJobRunRequest,
+  ): Effect.Effect<
+    CancelJobRunResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createApplication(
+    input: CreateApplicationRequest,
+  ): Effect.Effect<
+    CreateApplicationResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteApplication(
+    input: DeleteApplicationRequest,
+  ): Effect.Effect<
+    DeleteApplicationResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApplication(
+    input: GetApplicationRequest,
+  ): Effect.Effect<
+    GetApplicationResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDashboardForJobRun(
+    input: GetDashboardForJobRunRequest,
+  ): Effect.Effect<
+    GetDashboardForJobRunResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getJobRun(
+    input: GetJobRunRequest,
+  ): Effect.Effect<
+    GetJobRunResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApplications(
+    input: ListApplicationsRequest,
+  ): Effect.Effect<
+    ListApplicationsResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listJobRunAttempts(
+    input: ListJobRunAttemptsRequest,
+  ): Effect.Effect<
+    ListJobRunAttemptsResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listJobRuns(
+    input: ListJobRunsRequest,
+  ): Effect.Effect<
+    ListJobRunsResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  startApplication(
+    input: StartApplicationRequest,
+  ): Effect.Effect<
+    StartApplicationResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startJobRun(
+    input: StartJobRunRequest,
+  ): Effect.Effect<
+    StartJobRunResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopApplication(
+    input: StopApplicationRequest,
+  ): Effect.Effect<
+    StopApplicationResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateApplication(
+    input: UpdateApplicationRequest,
+  ): Effect.Effect<
+    UpdateApplicationResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class EmrServerless extends EMRServerless {}
@@ -595,6 +709,137 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelJobRun {
+  export type Input = CancelJobRunRequest;
+  export type Output = CancelJobRunResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateApplication {
+  export type Input = CreateApplicationRequest;
+  export type Output = CreateApplicationResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplication {
+  export type Input = DeleteApplicationRequest;
+  export type Output = DeleteApplicationResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApplication {
+  export type Input = GetApplicationRequest;
+  export type Output = GetApplicationResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDashboardForJobRun {
+  export type Input = GetDashboardForJobRunRequest;
+  export type Output = GetDashboardForJobRunResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetJobRun {
+  export type Input = GetJobRunRequest;
+  export type Output = GetJobRunResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplications {
+  export type Input = ListApplicationsRequest;
+  export type Output = ListApplicationsResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListJobRunAttempts {
+  export type Input = ListJobRunAttemptsRequest;
+  export type Output = ListJobRunAttemptsResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListJobRuns {
+  export type Input = ListJobRunsRequest;
+  export type Output = ListJobRunsResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartApplication {
+  export type Input = StartApplicationRequest;
+  export type Output = StartApplicationResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartJobRun {
+  export type Input = StartJobRunRequest;
+  export type Output = StartJobRunResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopApplication {
+  export type Input = StopApplicationRequest;
+  export type Output = StopApplicationResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateApplication {
+  export type Input = UpdateApplicationRequest;
+  export type Output = UpdateApplicationResponse;
   export type Error =
     | InternalServerException
     | ResourceNotFoundException

--- a/src/services/evidently/index.ts
+++ b/src/services/evidently/index.ts
@@ -39,6 +39,361 @@ export declare class Evidently extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  batchEvaluateFeature(
+    input: BatchEvaluateFeatureRequest,
+  ): Effect.Effect<
+    BatchEvaluateFeatureResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createExperiment(
+    input: CreateExperimentRequest,
+  ): Effect.Effect<
+    CreateExperimentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createFeature(
+    input: CreateFeatureRequest,
+  ): Effect.Effect<
+    CreateFeatureResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createLaunch(
+    input: CreateLaunchRequest,
+  ): Effect.Effect<
+    CreateLaunchResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createProject(
+    input: CreateProjectRequest,
+  ): Effect.Effect<
+    CreateProjectResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSegment(
+    input: CreateSegmentRequest,
+  ): Effect.Effect<
+    CreateSegmentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteExperiment(
+    input: DeleteExperimentRequest,
+  ): Effect.Effect<
+    DeleteExperimentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteFeature(
+    input: DeleteFeatureRequest,
+  ): Effect.Effect<
+    DeleteFeatureResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteLaunch(
+    input: DeleteLaunchRequest,
+  ): Effect.Effect<
+    DeleteLaunchResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteProject(
+    input: DeleteProjectRequest,
+  ): Effect.Effect<
+    DeleteProjectResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSegment(
+    input: DeleteSegmentRequest,
+  ): Effect.Effect<
+    DeleteSegmentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  evaluateFeature(
+    input: EvaluateFeatureRequest,
+  ): Effect.Effect<
+    EvaluateFeatureResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getExperiment(
+    input: GetExperimentRequest,
+  ): Effect.Effect<
+    GetExperimentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getExperimentResults(
+    input: GetExperimentResultsRequest,
+  ): Effect.Effect<
+    GetExperimentResultsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFeature(
+    input: GetFeatureRequest,
+  ): Effect.Effect<
+    GetFeatureResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getLaunch(
+    input: GetLaunchRequest,
+  ): Effect.Effect<
+    GetLaunchResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getProject(
+    input: GetProjectRequest,
+  ): Effect.Effect<
+    GetProjectResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSegment(
+    input: GetSegmentRequest,
+  ): Effect.Effect<
+    GetSegmentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listExperiments(
+    input: ListExperimentsRequest,
+  ): Effect.Effect<
+    ListExperimentsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFeatures(
+    input: ListFeaturesRequest,
+  ): Effect.Effect<
+    ListFeaturesResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listLaunches(
+    input: ListLaunchesRequest,
+  ): Effect.Effect<
+    ListLaunchesResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listProjects(
+    input: ListProjectsRequest,
+  ): Effect.Effect<
+    ListProjectsResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSegmentReferences(
+    input: ListSegmentReferencesRequest,
+  ): Effect.Effect<
+    ListSegmentReferencesResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSegments(
+    input: ListSegmentsRequest,
+  ): Effect.Effect<
+    ListSegmentsResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putProjectEvents(
+    input: PutProjectEventsRequest,
+  ): Effect.Effect<
+    PutProjectEventsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startExperiment(
+    input: StartExperimentRequest,
+  ): Effect.Effect<
+    StartExperimentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startLaunch(
+    input: StartLaunchRequest,
+  ): Effect.Effect<
+    StartLaunchResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopExperiment(
+    input: StopExperimentRequest,
+  ): Effect.Effect<
+    StopExperimentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopLaunch(
+    input: StopLaunchRequest,
+  ): Effect.Effect<
+    StopLaunchResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateExperiment(
+    input: UpdateExperimentRequest,
+  ): Effect.Effect<
+    UpdateExperimentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateFeature(
+    input: UpdateFeatureRequest,
+  ): Effect.Effect<
+    UpdateFeatureResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLaunch(
+    input: UpdateLaunchRequest,
+  ): Effect.Effect<
+    UpdateLaunchResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateProject(
+    input: UpdateProjectRequest,
+  ): Effect.Effect<
+    UpdateProjectResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateProjectDataDelivery(
+    input: UpdateProjectDataDeliveryRequest,
+  ): Effect.Effect<
+    UpdateProjectDataDeliveryResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -922,6 +1277,395 @@ export declare namespace UntagResource {
   export type Error =
     | ConflictException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchEvaluateFeature {
+  export type Input = BatchEvaluateFeatureRequest;
+  export type Output = BatchEvaluateFeatureResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateExperiment {
+  export type Input = CreateExperimentRequest;
+  export type Output = CreateExperimentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFeature {
+  export type Input = CreateFeatureRequest;
+  export type Output = CreateFeatureResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateLaunch {
+  export type Input = CreateLaunchRequest;
+  export type Output = CreateLaunchResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateProject {
+  export type Input = CreateProjectRequest;
+  export type Output = CreateProjectResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSegment {
+  export type Input = CreateSegmentRequest;
+  export type Output = CreateSegmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteExperiment {
+  export type Input = DeleteExperimentRequest;
+  export type Output = DeleteExperimentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFeature {
+  export type Input = DeleteFeatureRequest;
+  export type Output = DeleteFeatureResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLaunch {
+  export type Input = DeleteLaunchRequest;
+  export type Output = DeleteLaunchResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteProject {
+  export type Input = DeleteProjectRequest;
+  export type Output = DeleteProjectResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSegment {
+  export type Input = DeleteSegmentRequest;
+  export type Output = DeleteSegmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace EvaluateFeature {
+  export type Input = EvaluateFeatureRequest;
+  export type Output = EvaluateFeatureResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetExperiment {
+  export type Input = GetExperimentRequest;
+  export type Output = GetExperimentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetExperimentResults {
+  export type Input = GetExperimentResultsRequest;
+  export type Output = GetExperimentResultsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFeature {
+  export type Input = GetFeatureRequest;
+  export type Output = GetFeatureResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetLaunch {
+  export type Input = GetLaunchRequest;
+  export type Output = GetLaunchResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetProject {
+  export type Input = GetProjectRequest;
+  export type Output = GetProjectResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSegment {
+  export type Input = GetSegmentRequest;
+  export type Output = GetSegmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListExperiments {
+  export type Input = ListExperimentsRequest;
+  export type Output = ListExperimentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFeatures {
+  export type Input = ListFeaturesRequest;
+  export type Output = ListFeaturesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListLaunches {
+  export type Input = ListLaunchesRequest;
+  export type Output = ListLaunchesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListProjects {
+  export type Input = ListProjectsRequest;
+  export type Output = ListProjectsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSegmentReferences {
+  export type Input = ListSegmentReferencesRequest;
+  export type Output = ListSegmentReferencesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSegments {
+  export type Input = ListSegmentsRequest;
+  export type Output = ListSegmentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutProjectEvents {
+  export type Input = PutProjectEventsRequest;
+  export type Output = PutProjectEventsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartExperiment {
+  export type Input = StartExperimentRequest;
+  export type Output = StartExperimentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartLaunch {
+  export type Input = StartLaunchRequest;
+  export type Output = StartLaunchResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopExperiment {
+  export type Input = StopExperimentRequest;
+  export type Output = StopExperimentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopLaunch {
+  export type Input = StopLaunchRequest;
+  export type Output = StopLaunchResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateExperiment {
+  export type Input = UpdateExperimentRequest;
+  export type Output = UpdateExperimentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFeature {
+  export type Input = UpdateFeatureRequest;
+  export type Output = UpdateFeatureResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLaunch {
+  export type Input = UpdateLaunchRequest;
+  export type Output = UpdateLaunchResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProject {
+  export type Input = UpdateProjectRequest;
+  export type Output = UpdateProjectResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProjectDataDelivery {
+  export type Input = UpdateProjectDataDeliveryRequest;
+  export type Output = UpdateProjectDataDeliveryResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/evs/index.ts
+++ b/src/services/evs/index.ts
@@ -24,6 +24,54 @@ export declare class evs extends AWSServiceClient {
     UntagResourceResponse,
     ResourceNotFoundException | TagPolicyException | CommonAwsError
   >;
+  createEnvironment(
+    input: CreateEnvironmentRequest,
+  ): Effect.Effect<
+    CreateEnvironmentResponse,
+    ValidationException | CommonAwsError
+  >;
+  createEnvironmentHost(
+    input: CreateEnvironmentHostRequest,
+  ): Effect.Effect<
+    CreateEnvironmentHostResponse,
+    ThrottlingException | ValidationException | CommonAwsError
+  >;
+  deleteEnvironment(
+    input: DeleteEnvironmentRequest,
+  ): Effect.Effect<
+    DeleteEnvironmentResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  deleteEnvironmentHost(
+    input: DeleteEnvironmentHostRequest,
+  ): Effect.Effect<
+    DeleteEnvironmentHostResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  getEnvironment(
+    input: GetEnvironmentRequest,
+  ): Effect.Effect<
+    GetEnvironmentResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  listEnvironmentHosts(
+    input: ListEnvironmentHostsRequest,
+  ): Effect.Effect<
+    ListEnvironmentHostsResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  listEnvironmentVlans(
+    input: ListEnvironmentVlansRequest,
+  ): Effect.Effect<
+    ListEnvironmentVlansResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  listEnvironments(
+    input: ListEnvironmentsRequest,
+  ): Effect.Effect<
+    ListEnvironmentsResponse,
+    ValidationException | CommonAwsError
+  >;
 }
 
 export declare class Evs extends evs {}
@@ -384,4 +432,70 @@ export declare namespace UntagResource {
     | ResourceNotFoundException
     | TagPolicyException
     | CommonAwsError;
+}
+
+export declare namespace CreateEnvironment {
+  export type Input = CreateEnvironmentRequest;
+  export type Output = CreateEnvironmentResponse;
+  export type Error = ValidationException | CommonAwsError;
+}
+
+export declare namespace CreateEnvironmentHost {
+  export type Input = CreateEnvironmentHostRequest;
+  export type Output = CreateEnvironmentHostResponse;
+  export type Error =
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEnvironment {
+  export type Input = DeleteEnvironmentRequest;
+  export type Output = DeleteEnvironmentResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEnvironmentHost {
+  export type Input = DeleteEnvironmentHostRequest;
+  export type Output = DeleteEnvironmentHostResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnvironment {
+  export type Input = GetEnvironmentRequest;
+  export type Output = GetEnvironmentResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironmentHosts {
+  export type Input = ListEnvironmentHostsRequest;
+  export type Output = ListEnvironmentHostsResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironmentVlans {
+  export type Input = ListEnvironmentVlansRequest;
+  export type Output = ListEnvironmentVlansResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironments {
+  export type Input = ListEnvironmentsRequest;
+  export type Output = ListEnvironmentsResponse;
+  export type Error = ValidationException | CommonAwsError;
 }

--- a/src/services/gameliftstreams/index.ts
+++ b/src/services/gameliftstreams/index.ts
@@ -157,6 +157,121 @@ export declare class GameLiftStreams extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createApplication(
+    input: CreateApplicationInput,
+  ): Effect.Effect<
+    CreateApplicationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createStreamGroup(
+    input: CreateStreamGroupInput,
+  ): Effect.Effect<
+    CreateStreamGroupOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteApplication(
+    input: DeleteApplicationInput,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteStreamGroup(
+    input: DeleteStreamGroupInput,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApplication(
+    input: GetApplicationInput,
+  ): Effect.Effect<
+    GetApplicationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getStreamGroup(
+    input: GetStreamGroupInput,
+  ): Effect.Effect<
+    GetStreamGroupOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApplications(
+    input: ListApplicationsInput,
+  ): Effect.Effect<
+    ListApplicationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listStreamGroups(
+    input: ListStreamGroupsInput,
+  ): Effect.Effect<
+    ListStreamGroupsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateApplication(
+    input: UpdateApplicationInput,
+  ): Effect.Effect<
+    UpdateApplicationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateStreamGroup(
+    input: UpdateStreamGroupInput,
+  ): Effect.Effect<
+    UpdateStreamGroupOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Gameliftstreams extends GameLiftStreams {}
@@ -826,6 +941,131 @@ export declare namespace UntagResource {
   export type Error =
     | AccessDeniedException
     | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateApplication {
+  export type Input = CreateApplicationInput;
+  export type Output = CreateApplicationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateStreamGroup {
+  export type Input = CreateStreamGroupInput;
+  export type Output = CreateStreamGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplication {
+  export type Input = DeleteApplicationInput;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteStreamGroup {
+  export type Input = DeleteStreamGroupInput;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApplication {
+  export type Input = GetApplicationInput;
+  export type Output = GetApplicationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetStreamGroup {
+  export type Input = GetStreamGroupInput;
+  export type Output = GetStreamGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplications {
+  export type Input = ListApplicationsInput;
+  export type Output = ListApplicationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListStreamGroups {
+  export type Input = ListStreamGroupsInput;
+  export type Output = ListStreamGroupsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateApplication {
+  export type Input = UpdateApplicationInput;
+  export type Output = UpdateApplicationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateStreamGroup {
+  export type Input = UpdateStreamGroupInput;
+  export type Output = UpdateStreamGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/grafana/index.ts
+++ b/src/services/grafana/index.ts
@@ -47,6 +47,251 @@ export declare class grafana extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateLicense(
+    input: AssociateLicenseRequest,
+  ): Effect.Effect<
+    AssociateLicenseResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkspace(
+    input: CreateWorkspaceRequest,
+  ): Effect.Effect<
+    CreateWorkspaceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkspaceApiKey(
+    input: CreateWorkspaceApiKeyRequest,
+  ): Effect.Effect<
+    CreateWorkspaceApiKeyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkspaceServiceAccount(
+    input: CreateWorkspaceServiceAccountRequest,
+  ): Effect.Effect<
+    CreateWorkspaceServiceAccountResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkspaceServiceAccountToken(
+    input: CreateWorkspaceServiceAccountTokenRequest,
+  ): Effect.Effect<
+    CreateWorkspaceServiceAccountTokenResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkspace(
+    input: DeleteWorkspaceRequest,
+  ): Effect.Effect<
+    DeleteWorkspaceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkspaceApiKey(
+    input: DeleteWorkspaceApiKeyRequest,
+  ): Effect.Effect<
+    DeleteWorkspaceApiKeyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkspaceServiceAccount(
+    input: DeleteWorkspaceServiceAccountRequest,
+  ): Effect.Effect<
+    DeleteWorkspaceServiceAccountResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkspaceServiceAccountToken(
+    input: DeleteWorkspaceServiceAccountTokenRequest,
+  ): Effect.Effect<
+    DeleteWorkspaceServiceAccountTokenResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeWorkspace(
+    input: DescribeWorkspaceRequest,
+  ): Effect.Effect<
+    DescribeWorkspaceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeWorkspaceAuthentication(
+    input: DescribeWorkspaceAuthenticationRequest,
+  ): Effect.Effect<
+    DescribeWorkspaceAuthenticationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeWorkspaceConfiguration(
+    input: DescribeWorkspaceConfigurationRequest,
+  ): Effect.Effect<
+    DescribeWorkspaceConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  disassociateLicense(
+    input: DisassociateLicenseRequest,
+  ): Effect.Effect<
+    DisassociateLicenseResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPermissions(
+    input: ListPermissionsRequest,
+  ): Effect.Effect<
+    ListPermissionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkspaceServiceAccountTokens(
+    input: ListWorkspaceServiceAccountTokensRequest,
+  ): Effect.Effect<
+    ListWorkspaceServiceAccountTokensResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkspaceServiceAccounts(
+    input: ListWorkspaceServiceAccountsRequest,
+  ): Effect.Effect<
+    ListWorkspaceServiceAccountsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkspaces(
+    input: ListWorkspacesRequest,
+  ): Effect.Effect<
+    ListWorkspacesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updatePermissions(
+    input: UpdatePermissionsRequest,
+  ): Effect.Effect<
+    UpdatePermissionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkspace(
+    input: UpdateWorkspaceRequest,
+  ): Effect.Effect<
+    UpdateWorkspaceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkspaceAuthentication(
+    input: UpdateWorkspaceAuthenticationRequest,
+  ): Effect.Effect<
+    UpdateWorkspaceAuthenticationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkspaceConfiguration(
+    input: UpdateWorkspaceConfigurationRequest,
+  ): Effect.Effect<
+    UpdateWorkspaceConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Grafana extends grafana {}
@@ -610,6 +855,272 @@ export declare namespace UntagResource {
   export type Output = UntagResourceResponse;
   export type Error =
     | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateLicense {
+  export type Input = AssociateLicenseRequest;
+  export type Output = AssociateLicenseResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkspace {
+  export type Input = CreateWorkspaceRequest;
+  export type Output = CreateWorkspaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkspaceApiKey {
+  export type Input = CreateWorkspaceApiKeyRequest;
+  export type Output = CreateWorkspaceApiKeyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkspaceServiceAccount {
+  export type Input = CreateWorkspaceServiceAccountRequest;
+  export type Output = CreateWorkspaceServiceAccountResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkspaceServiceAccountToken {
+  export type Input = CreateWorkspaceServiceAccountTokenRequest;
+  export type Output = CreateWorkspaceServiceAccountTokenResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkspace {
+  export type Input = DeleteWorkspaceRequest;
+  export type Output = DeleteWorkspaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkspaceApiKey {
+  export type Input = DeleteWorkspaceApiKeyRequest;
+  export type Output = DeleteWorkspaceApiKeyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkspaceServiceAccount {
+  export type Input = DeleteWorkspaceServiceAccountRequest;
+  export type Output = DeleteWorkspaceServiceAccountResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkspaceServiceAccountToken {
+  export type Input = DeleteWorkspaceServiceAccountTokenRequest;
+  export type Output = DeleteWorkspaceServiceAccountTokenResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeWorkspace {
+  export type Input = DescribeWorkspaceRequest;
+  export type Output = DescribeWorkspaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeWorkspaceAuthentication {
+  export type Input = DescribeWorkspaceAuthenticationRequest;
+  export type Output = DescribeWorkspaceAuthenticationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeWorkspaceConfiguration {
+  export type Input = DescribeWorkspaceConfigurationRequest;
+  export type Output = DescribeWorkspaceConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateLicense {
+  export type Input = DisassociateLicenseRequest;
+  export type Output = DisassociateLicenseResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPermissions {
+  export type Input = ListPermissionsRequest;
+  export type Output = ListPermissionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkspaceServiceAccountTokens {
+  export type Input = ListWorkspaceServiceAccountTokensRequest;
+  export type Output = ListWorkspaceServiceAccountTokensResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkspaceServiceAccounts {
+  export type Input = ListWorkspaceServiceAccountsRequest;
+  export type Output = ListWorkspaceServiceAccountsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkspaces {
+  export type Input = ListWorkspacesRequest;
+  export type Output = ListWorkspacesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePermissions {
+  export type Input = UpdatePermissionsRequest;
+  export type Output = UpdatePermissionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkspace {
+  export type Input = UpdateWorkspaceRequest;
+  export type Output = UpdateWorkspaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkspaceAuthentication {
+  export type Input = UpdateWorkspaceAuthenticationRequest;
+  export type Output = UpdateWorkspaceAuthenticationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkspaceConfiguration {
+  export type Input = UpdateWorkspaceConfigurationRequest;
+  export type Output = UpdateWorkspaceConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/groundstation/index.ts
+++ b/src/services/groundstation/index.ts
@@ -39,6 +39,268 @@ export declare class GroundStation extends AWSServiceClient {
     | ResourceNotFoundException
     | CommonAwsError
   >;
+  cancelContact(
+    input: CancelContactRequest,
+  ): Effect.Effect<
+    ContactIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  createConfig(
+    input: CreateConfigRequest,
+  ): Effect.Effect<
+    ConfigIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceLimitExceededException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  createDataflowEndpointGroup(
+    input: CreateDataflowEndpointGroupRequest,
+  ): Effect.Effect<
+    DataflowEndpointGroupIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  createEphemeris(
+    input: CreateEphemerisRequest,
+  ): Effect.Effect<
+    EphemerisIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  createMissionProfile(
+    input: CreateMissionProfileRequest,
+  ): Effect.Effect<
+    MissionProfileIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  deleteConfig(
+    input: DeleteConfigRequest,
+  ): Effect.Effect<
+    ConfigIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  deleteDataflowEndpointGroup(
+    input: DeleteDataflowEndpointGroupRequest,
+  ): Effect.Effect<
+    DataflowEndpointGroupIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  deleteEphemeris(
+    input: DeleteEphemerisRequest,
+  ): Effect.Effect<
+    EphemerisIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  deleteMissionProfile(
+    input: DeleteMissionProfileRequest,
+  ): Effect.Effect<
+    MissionProfileIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  describeContact(
+    input: DescribeContactRequest,
+  ): Effect.Effect<
+    DescribeContactResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  describeEphemeris(
+    input: DescribeEphemerisRequest,
+  ): Effect.Effect<
+    DescribeEphemerisResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  getAgentConfiguration(
+    input: GetAgentConfigurationRequest,
+  ): Effect.Effect<
+    GetAgentConfigurationResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  getConfig(
+    input: GetConfigRequest,
+  ): Effect.Effect<
+    GetConfigResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  getDataflowEndpointGroup(
+    input: GetDataflowEndpointGroupRequest,
+  ): Effect.Effect<
+    GetDataflowEndpointGroupResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  getMissionProfile(
+    input: GetMissionProfileRequest,
+  ): Effect.Effect<
+    GetMissionProfileResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  getSatellite(
+    input: GetSatelliteRequest,
+  ): Effect.Effect<
+    GetSatelliteResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  listConfigs(
+    input: ListConfigsRequest,
+  ): Effect.Effect<
+    ListConfigsResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  listContacts(
+    input: ListContactsRequest,
+  ): Effect.Effect<
+    ListContactsResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  listDataflowEndpointGroups(
+    input: ListDataflowEndpointGroupsRequest,
+  ): Effect.Effect<
+    ListDataflowEndpointGroupsResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  listEphemerides(
+    input: ListEphemeridesRequest,
+  ): Effect.Effect<
+    ListEphemeridesResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  listGroundStations(
+    input: ListGroundStationsRequest,
+  ): Effect.Effect<
+    ListGroundStationsResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  listMissionProfiles(
+    input: ListMissionProfilesRequest,
+  ): Effect.Effect<
+    ListMissionProfilesResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  listSatellites(
+    input: ListSatellitesRequest,
+  ): Effect.Effect<
+    ListSatellitesResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  registerAgent(
+    input: RegisterAgentRequest,
+  ): Effect.Effect<
+    RegisterAgentResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  reserveContact(
+    input: ReserveContactRequest,
+  ): Effect.Effect<
+    ContactIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  updateAgentStatus(
+    input: UpdateAgentStatusRequest,
+  ): Effect.Effect<
+    UpdateAgentStatusResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  updateConfig(
+    input: UpdateConfigRequest,
+  ): Effect.Effect<
+    ConfigIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  updateEphemeris(
+    input: UpdateEphemerisRequest,
+  ): Effect.Effect<
+    EphemerisIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
+  updateMissionProfile(
+    input: UpdateMissionProfileRequest,
+  ): Effect.Effect<
+    MissionProfileIdResponse,
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError
+  >;
 }
 
 export declare class Groundstation extends GroundStation {}
@@ -862,6 +1124,297 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace CancelContact {
+  export type Input = CancelContactRequest;
+  export type Output = ContactIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConfig {
+  export type Input = CreateConfigRequest;
+  export type Output = ConfigIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceLimitExceededException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataflowEndpointGroup {
+  export type Input = CreateDataflowEndpointGroupRequest;
+  export type Output = DataflowEndpointGroupIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEphemeris {
+  export type Input = CreateEphemerisRequest;
+  export type Output = EphemerisIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMissionProfile {
+  export type Input = CreateMissionProfileRequest;
+  export type Output = MissionProfileIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConfig {
+  export type Input = DeleteConfigRequest;
+  export type Output = ConfigIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataflowEndpointGroup {
+  export type Input = DeleteDataflowEndpointGroupRequest;
+  export type Output = DataflowEndpointGroupIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEphemeris {
+  export type Input = DeleteEphemerisRequest;
+  export type Output = EphemerisIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMissionProfile {
+  export type Input = DeleteMissionProfileRequest;
+  export type Output = MissionProfileIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeContact {
+  export type Input = DescribeContactRequest;
+  export type Output = DescribeContactResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeEphemeris {
+  export type Input = DescribeEphemerisRequest;
+  export type Output = DescribeEphemerisResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetAgentConfiguration {
+  export type Input = GetAgentConfigurationRequest;
+  export type Output = GetAgentConfigurationResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetConfig {
+  export type Input = GetConfigRequest;
+  export type Output = GetConfigResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataflowEndpointGroup {
+  export type Input = GetDataflowEndpointGroupRequest;
+  export type Output = GetDataflowEndpointGroupResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetMissionProfile {
+  export type Input = GetMissionProfileRequest;
+  export type Output = GetMissionProfileResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetSatellite {
+  export type Input = GetSatelliteRequest;
+  export type Output = GetSatelliteResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListConfigs {
+  export type Input = ListConfigsRequest;
+  export type Output = ListConfigsResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListContacts {
+  export type Input = ListContactsRequest;
+  export type Output = ListContactsResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataflowEndpointGroups {
+  export type Input = ListDataflowEndpointGroupsRequest;
+  export type Output = ListDataflowEndpointGroupsResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListEphemerides {
+  export type Input = ListEphemeridesRequest;
+  export type Output = ListEphemeridesResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListGroundStations {
+  export type Input = ListGroundStationsRequest;
+  export type Output = ListGroundStationsResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListMissionProfiles {
+  export type Input = ListMissionProfilesRequest;
+  export type Output = ListMissionProfilesResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ListSatellites {
+  export type Input = ListSatellitesRequest;
+  export type Output = ListSatellitesResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace RegisterAgent {
+  export type Input = RegisterAgentRequest;
+  export type Output = RegisterAgentResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace ReserveContact {
+  export type Input = ReserveContactRequest;
+  export type Output = ContactIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgentStatus {
+  export type Input = UpdateAgentStatusRequest;
+  export type Output = UpdateAgentStatusResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConfig {
+  export type Input = UpdateConfigRequest;
+  export type Output = ConfigIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEphemeris {
+  export type Input = UpdateEphemerisRequest;
+  export type Output = EphemerisIdResponse;
+  export type Error =
+    | DependencyException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMissionProfile {
+  export type Input = UpdateMissionProfileRequest;
+  export type Output = MissionProfileIdResponse;
   export type Error =
     | DependencyException
     | InvalidParameterException

--- a/src/services/identitystore/index.ts
+++ b/src/services/identitystore/index.ts
@@ -33,6 +33,119 @@ export declare class identitystore extends AWSServiceClient {
     ListGroupMembershipsForMemberResponse,
     ResourceNotFoundException | ValidationException | CommonAwsError
   >;
+  createGroup(
+    input: CreateGroupRequest,
+  ): Effect.Effect<
+    CreateGroupResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createGroupMembership(
+    input: CreateGroupMembershipRequest,
+  ): Effect.Effect<
+    CreateGroupMembershipResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createUser(
+    input: CreateUserRequest,
+  ): Effect.Effect<
+    CreateUserResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteGroup(
+    input: DeleteGroupRequest,
+  ): Effect.Effect<
+    DeleteGroupResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteGroupMembership(
+    input: DeleteGroupMembershipRequest,
+  ): Effect.Effect<
+    DeleteGroupMembershipResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteUser(
+    input: DeleteUserRequest,
+  ): Effect.Effect<
+    DeleteUserResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeGroup(
+    input: DescribeGroupRequest,
+  ): Effect.Effect<
+    DescribeGroupResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  describeGroupMembership(
+    input: DescribeGroupMembershipRequest,
+  ): Effect.Effect<
+    DescribeGroupMembershipResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  describeUser(
+    input: DescribeUserRequest,
+  ): Effect.Effect<
+    DescribeUserResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  listGroupMemberships(
+    input: ListGroupMembershipsRequest,
+  ): Effect.Effect<
+    ListGroupMembershipsResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  listGroups(
+    input: ListGroupsRequest,
+  ): Effect.Effect<
+    ListGroupsResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  listUsers(
+    input: ListUsersRequest,
+  ): Effect.Effect<
+    ListUsersResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  updateGroup(
+    input: UpdateGroupRequest,
+  ): Effect.Effect<
+    UpdateGroupResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateUser(
+    input: UpdateUserRequest,
+  ): Effect.Effect<
+    UpdateUserResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Identitystore extends identitystore {}
@@ -445,6 +558,145 @@ export declare namespace ListGroupMembershipsForMember {
   export type Output = ListGroupMembershipsForMemberResponse;
   export type Error =
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGroup {
+  export type Input = CreateGroupRequest;
+  export type Output = CreateGroupResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGroupMembership {
+  export type Input = CreateGroupMembershipRequest;
+  export type Output = CreateGroupMembershipResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateUser {
+  export type Input = CreateUserRequest;
+  export type Output = CreateUserResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGroup {
+  export type Input = DeleteGroupRequest;
+  export type Output = DeleteGroupResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGroupMembership {
+  export type Input = DeleteGroupMembershipRequest;
+  export type Output = DeleteGroupMembershipResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteUser {
+  export type Input = DeleteUserRequest;
+  export type Output = DeleteUserResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeGroup {
+  export type Input = DescribeGroupRequest;
+  export type Output = DescribeGroupResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeGroupMembership {
+  export type Input = DescribeGroupMembershipRequest;
+  export type Output = DescribeGroupMembershipResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeUser {
+  export type Input = DescribeUserRequest;
+  export type Output = DescribeUserResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListGroupMemberships {
+  export type Input = ListGroupMembershipsRequest;
+  export type Output = ListGroupMembershipsResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListGroups {
+  export type Input = ListGroupsRequest;
+  export type Output = ListGroupsResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListUsers {
+  export type Input = ListUsersRequest;
+  export type Output = ListUsersResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGroup {
+  export type Input = UpdateGroupRequest;
+  export type Output = UpdateGroupResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateUser {
+  export type Input = UpdateUserRequest;
+  export type Output = UpdateUserResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/internetmonitor/index.ts
+++ b/src/services/internetmonitor/index.ts
@@ -36,6 +36,144 @@ export declare class InternetMonitor extends AWSServiceClient {
     | TooManyRequestsException
     | CommonAwsError
   >;
+  createMonitor(
+    input: CreateMonitorInput,
+  ): Effect.Effect<
+    CreateMonitorOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMonitor(
+    input: DeleteMonitorInput,
+  ): Effect.Effect<
+    DeleteMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getHealthEvent(
+    input: GetHealthEventInput,
+  ): Effect.Effect<
+    GetHealthEventOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getInternetEvent(
+    input: GetInternetEventInput,
+  ): Effect.Effect<
+    GetInternetEventOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMonitor(
+    input: GetMonitorInput,
+  ): Effect.Effect<
+    GetMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueryResults(
+    input: GetQueryResultsInput,
+  ): Effect.Effect<
+    GetQueryResultsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueryStatus(
+    input: GetQueryStatusInput,
+  ): Effect.Effect<
+    GetQueryStatusOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listHealthEvents(
+    input: ListHealthEventsInput,
+  ): Effect.Effect<
+    ListHealthEventsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listInternetEvents(
+    input: ListInternetEventsInput,
+  ): Effect.Effect<
+    ListInternetEventsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMonitors(
+    input: ListMonitorsInput,
+  ): Effect.Effect<
+    ListMonitorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startQuery(
+    input: StartQueryInput,
+  ): Effect.Effect<
+    StartQueryOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopQuery(
+    input: StopQueryInput,
+  ): Effect.Effect<
+    StopQueryOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateMonitor(
+    input: UpdateMonitorInput,
+  ): Effect.Effect<
+    UpdateMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Internetmonitor extends InternetMonitor {}
@@ -473,5 +611,156 @@ export declare namespace UntagResource {
     | InternalServerErrorException
     | NotFoundException
     | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMonitor {
+  export type Input = CreateMonitorInput;
+  export type Output = CreateMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMonitor {
+  export type Input = DeleteMonitorInput;
+  export type Output = DeleteMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetHealthEvent {
+  export type Input = GetHealthEventInput;
+  export type Output = GetHealthEventOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetInternetEvent {
+  export type Input = GetInternetEventInput;
+  export type Output = GetInternetEventOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMonitor {
+  export type Input = GetMonitorInput;
+  export type Output = GetMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueryResults {
+  export type Input = GetQueryResultsInput;
+  export type Output = GetQueryResultsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueryStatus {
+  export type Input = GetQueryStatusInput;
+  export type Output = GetQueryStatusOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListHealthEvents {
+  export type Input = ListHealthEventsInput;
+  export type Output = ListHealthEventsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListInternetEvents {
+  export type Input = ListInternetEventsInput;
+  export type Output = ListInternetEventsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMonitors {
+  export type Input = ListMonitorsInput;
+  export type Output = ListMonitorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartQuery {
+  export type Input = StartQueryInput;
+  export type Output = StartQueryOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopQuery {
+  export type Input = StopQueryInput;
+  export type Output = StopQueryOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMonitor {
+  export type Input = UpdateMonitorInput;
+  export type Output = UpdateMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
     | CommonAwsError;
 }

--- a/src/services/iot-managed-integrations/index.ts
+++ b/src/services/iot-managed-integrations/index.ts
@@ -73,6 +73,900 @@ export declare class IoTManagedIntegrations extends AWSServiceClient {
     | UnauthorizedException
     | CommonAwsError
   >;
+  createAccountAssociation(
+    input: CreateAccountAssociationRequest,
+  ): Effect.Effect<
+    CreateAccountAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCloudConnector(
+    input: CreateCloudConnectorRequest,
+  ): Effect.Effect<
+    CreateCloudConnectorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConnectorDestination(
+    input: CreateConnectorDestinationRequest,
+  ): Effect.Effect<
+    CreateConnectorDestinationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCredentialLocker(
+    input: CreateCredentialLockerRequest,
+  ): Effect.Effect<
+    CreateCredentialLockerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDestination(
+    input: CreateDestinationRequest,
+  ): Effect.Effect<
+    CreateDestinationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEventLogConfiguration(
+    input: CreateEventLogConfigurationRequest,
+  ): Effect.Effect<
+    CreateEventLogConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createManagedThing(
+    input: CreateManagedThingRequest,
+  ): Effect.Effect<
+    CreateManagedThingResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createNotificationConfiguration(
+    input: CreateNotificationConfigurationRequest,
+  ): Effect.Effect<
+    CreateNotificationConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createOtaTask(
+    input: CreateOtaTaskRequest,
+  ): Effect.Effect<
+    CreateOtaTaskResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createOtaTaskConfiguration(
+    input: CreateOtaTaskConfigurationRequest,
+  ): Effect.Effect<
+    CreateOtaTaskConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createProvisioningProfile(
+    input: CreateProvisioningProfileRequest,
+  ): Effect.Effect<
+    CreateProvisioningProfileResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAccountAssociation(
+    input: DeleteAccountAssociationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCloudConnector(
+    input: DeleteCloudConnectorRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConnectorDestination(
+    input: DeleteConnectorDestinationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCredentialLocker(
+    input: DeleteCredentialLockerRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDestination(
+    input: DeleteDestinationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEventLogConfiguration(
+    input: DeleteEventLogConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteManagedThing(
+    input: DeleteManagedThingRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteNotificationConfiguration(
+    input: DeleteNotificationConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteOtaTask(
+    input: DeleteOtaTaskRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteOtaTaskConfiguration(
+    input: DeleteOtaTaskConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteProvisioningProfile(
+    input: DeleteProvisioningProfileRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deregisterAccountAssociation(
+    input: DeregisterAccountAssociationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAccountAssociation(
+    input: GetAccountAssociationRequest,
+  ): Effect.Effect<
+    GetAccountAssociationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCloudConnector(
+    input: GetCloudConnectorRequest,
+  ): Effect.Effect<
+    GetCloudConnectorResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConnectorDestination(
+    input: GetConnectorDestinationRequest,
+  ): Effect.Effect<
+    GetConnectorDestinationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCredentialLocker(
+    input: GetCredentialLockerRequest,
+  ): Effect.Effect<
+    GetCredentialLockerResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDefaultEncryptionConfiguration(
+    input: GetDefaultEncryptionConfigurationRequest,
+  ): Effect.Effect<
+    GetDefaultEncryptionConfigurationResponse,
+    | AccessDeniedException
+    | InternalFailureException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDestination(
+    input: GetDestinationRequest,
+  ): Effect.Effect<
+    GetDestinationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDeviceDiscovery(
+    input: GetDeviceDiscoveryRequest,
+  ): Effect.Effect<
+    GetDeviceDiscoveryResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEventLogConfiguration(
+    input: GetEventLogConfigurationRequest,
+  ): Effect.Effect<
+    GetEventLogConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getHubConfiguration(
+    input: GetHubConfigurationRequest,
+  ): Effect.Effect<
+    GetHubConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getManagedThing(
+    input: GetManagedThingRequest,
+  ): Effect.Effect<
+    GetManagedThingResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getManagedThingCapabilities(
+    input: GetManagedThingCapabilitiesRequest,
+  ): Effect.Effect<
+    GetManagedThingCapabilitiesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getManagedThingConnectivityData(
+    input: GetManagedThingConnectivityDataRequest,
+  ): Effect.Effect<
+    GetManagedThingConnectivityDataResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getManagedThingMetaData(
+    input: GetManagedThingMetaDataRequest,
+  ): Effect.Effect<
+    GetManagedThingMetaDataResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getManagedThingState(
+    input: GetManagedThingStateRequest,
+  ): Effect.Effect<
+    GetManagedThingStateResponse,
+    | AccessDeniedException
+    | InternalFailureException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getNotificationConfiguration(
+    input: GetNotificationConfigurationRequest,
+  ): Effect.Effect<
+    GetNotificationConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getOtaTask(
+    input: GetOtaTaskRequest,
+  ): Effect.Effect<
+    GetOtaTaskResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getOtaTaskConfiguration(
+    input: GetOtaTaskConfigurationRequest,
+  ): Effect.Effect<
+    GetOtaTaskConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getProvisioningProfile(
+    input: GetProvisioningProfileRequest,
+  ): Effect.Effect<
+    GetProvisioningProfileResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRuntimeLogConfiguration(
+    input: GetRuntimeLogConfigurationRequest,
+  ): Effect.Effect<
+    GetRuntimeLogConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSchemaVersion(
+    input: GetSchemaVersionRequest,
+  ): Effect.Effect<
+    GetSchemaVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAccountAssociations(
+    input: ListAccountAssociationsRequest,
+  ): Effect.Effect<
+    ListAccountAssociationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCloudConnectors(
+    input: ListCloudConnectorsRequest,
+  ): Effect.Effect<
+    ListCloudConnectorsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listConnectorDestinations(
+    input: ListConnectorDestinationsRequest,
+  ): Effect.Effect<
+    ListConnectorDestinationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCredentialLockers(
+    input: ListCredentialLockersRequest,
+  ): Effect.Effect<
+    ListCredentialLockersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDestinations(
+    input: ListDestinationsRequest,
+  ): Effect.Effect<
+    ListDestinationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDeviceDiscoveries(
+    input: ListDeviceDiscoveriesRequest,
+  ): Effect.Effect<
+    ListDeviceDiscoveriesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDiscoveredDevices(
+    input: ListDiscoveredDevicesRequest,
+  ): Effect.Effect<
+    ListDiscoveredDevicesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEventLogConfigurations(
+    input: ListEventLogConfigurationsRequest,
+  ): Effect.Effect<
+    ListEventLogConfigurationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listManagedThingAccountAssociations(
+    input: ListManagedThingAccountAssociationsRequest,
+  ): Effect.Effect<
+    ListManagedThingAccountAssociationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listManagedThingSchemas(
+    input: ListManagedThingSchemasRequest,
+  ): Effect.Effect<
+    ListManagedThingSchemasResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listManagedThings(
+    input: ListManagedThingsRequest,
+  ): Effect.Effect<
+    ListManagedThingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listNotificationConfigurations(
+    input: ListNotificationConfigurationsRequest,
+  ): Effect.Effect<
+    ListNotificationConfigurationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listOtaTaskConfigurations(
+    input: ListOtaTaskConfigurationsRequest,
+  ): Effect.Effect<
+    ListOtaTaskConfigurationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listOtaTaskExecutions(
+    input: ListOtaTaskExecutionsRequest,
+  ): Effect.Effect<
+    ListOtaTaskExecutionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listOtaTasks(
+    input: ListOtaTasksRequest,
+  ): Effect.Effect<
+    ListOtaTasksResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listProvisioningProfiles(
+    input: ListProvisioningProfilesRequest,
+  ): Effect.Effect<
+    ListProvisioningProfilesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSchemaVersions(
+    input: ListSchemaVersionsRequest,
+  ): Effect.Effect<
+    ListSchemaVersionsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putDefaultEncryptionConfiguration(
+    input: PutDefaultEncryptionConfigurationRequest,
+  ): Effect.Effect<
+    PutDefaultEncryptionConfigurationResponse,
+    | AccessDeniedException
+    | InternalFailureException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putHubConfiguration(
+    input: PutHubConfigurationRequest,
+  ): Effect.Effect<
+    PutHubConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putRuntimeLogConfiguration(
+    input: PutRuntimeLogConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  registerAccountAssociation(
+    input: RegisterAccountAssociationRequest,
+  ): Effect.Effect<
+    RegisterAccountAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  resetRuntimeLogConfiguration(
+    input: ResetRuntimeLogConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  sendManagedThingCommand(
+    input: SendManagedThingCommandRequest,
+  ): Effect.Effect<
+    SendManagedThingCommandResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startAccountAssociationRefresh(
+    input: StartAccountAssociationRefreshRequest,
+  ): Effect.Effect<
+    StartAccountAssociationRefreshResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startDeviceDiscovery(
+    input: StartDeviceDiscoveryRequest,
+  ): Effect.Effect<
+    StartDeviceDiscoveryResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAccountAssociation(
+    input: UpdateAccountAssociationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCloudConnector(
+    input: UpdateCloudConnectorRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateConnectorDestination(
+    input: UpdateConnectorDestinationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDestination(
+    input: UpdateDestinationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEventLogConfiguration(
+    input: UpdateEventLogConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateManagedThing(
+    input: UpdateManagedThingRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateNotificationConfiguration(
+    input: UpdateNotificationConfigurationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateOtaTask(
+    input: UpdateOtaTaskRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export interface AbortConfigCriteria {
@@ -1771,5 +2665,975 @@ export declare namespace UntagResource {
     | ResourceNotFoundException
     | ThrottlingException
     | UnauthorizedException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAccountAssociation {
+  export type Input = CreateAccountAssociationRequest;
+  export type Output = CreateAccountAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCloudConnector {
+  export type Input = CreateCloudConnectorRequest;
+  export type Output = CreateCloudConnectorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConnectorDestination {
+  export type Input = CreateConnectorDestinationRequest;
+  export type Output = CreateConnectorDestinationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCredentialLocker {
+  export type Input = CreateCredentialLockerRequest;
+  export type Output = CreateCredentialLockerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDestination {
+  export type Input = CreateDestinationRequest;
+  export type Output = CreateDestinationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEventLogConfiguration {
+  export type Input = CreateEventLogConfigurationRequest;
+  export type Output = CreateEventLogConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateManagedThing {
+  export type Input = CreateManagedThingRequest;
+  export type Output = CreateManagedThingResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateNotificationConfiguration {
+  export type Input = CreateNotificationConfigurationRequest;
+  export type Output = CreateNotificationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateOtaTask {
+  export type Input = CreateOtaTaskRequest;
+  export type Output = CreateOtaTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateOtaTaskConfiguration {
+  export type Input = CreateOtaTaskConfigurationRequest;
+  export type Output = CreateOtaTaskConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateProvisioningProfile {
+  export type Input = CreateProvisioningProfileRequest;
+  export type Output = CreateProvisioningProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAccountAssociation {
+  export type Input = DeleteAccountAssociationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCloudConnector {
+  export type Input = DeleteCloudConnectorRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConnectorDestination {
+  export type Input = DeleteConnectorDestinationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCredentialLocker {
+  export type Input = DeleteCredentialLockerRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDestination {
+  export type Input = DeleteDestinationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEventLogConfiguration {
+  export type Input = DeleteEventLogConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteManagedThing {
+  export type Input = DeleteManagedThingRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteNotificationConfiguration {
+  export type Input = DeleteNotificationConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteOtaTask {
+  export type Input = DeleteOtaTaskRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteOtaTaskConfiguration {
+  export type Input = DeleteOtaTaskConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteProvisioningProfile {
+  export type Input = DeleteProvisioningProfileRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeregisterAccountAssociation {
+  export type Input = DeregisterAccountAssociationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAccountAssociation {
+  export type Input = GetAccountAssociationRequest;
+  export type Output = GetAccountAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCloudConnector {
+  export type Input = GetCloudConnectorRequest;
+  export type Output = GetCloudConnectorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConnectorDestination {
+  export type Input = GetConnectorDestinationRequest;
+  export type Output = GetConnectorDestinationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCredentialLocker {
+  export type Input = GetCredentialLockerRequest;
+  export type Output = GetCredentialLockerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDefaultEncryptionConfiguration {
+  export type Input = GetDefaultEncryptionConfigurationRequest;
+  export type Output = GetDefaultEncryptionConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalFailureException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDestination {
+  export type Input = GetDestinationRequest;
+  export type Output = GetDestinationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDeviceDiscovery {
+  export type Input = GetDeviceDiscoveryRequest;
+  export type Output = GetDeviceDiscoveryResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEventLogConfiguration {
+  export type Input = GetEventLogConfigurationRequest;
+  export type Output = GetEventLogConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetHubConfiguration {
+  export type Input = GetHubConfigurationRequest;
+  export type Output = GetHubConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetManagedThing {
+  export type Input = GetManagedThingRequest;
+  export type Output = GetManagedThingResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetManagedThingCapabilities {
+  export type Input = GetManagedThingCapabilitiesRequest;
+  export type Output = GetManagedThingCapabilitiesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetManagedThingConnectivityData {
+  export type Input = GetManagedThingConnectivityDataRequest;
+  export type Output = GetManagedThingConnectivityDataResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetManagedThingMetaData {
+  export type Input = GetManagedThingMetaDataRequest;
+  export type Output = GetManagedThingMetaDataResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetManagedThingState {
+  export type Input = GetManagedThingStateRequest;
+  export type Output = GetManagedThingStateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalFailureException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetNotificationConfiguration {
+  export type Input = GetNotificationConfigurationRequest;
+  export type Output = GetNotificationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetOtaTask {
+  export type Input = GetOtaTaskRequest;
+  export type Output = GetOtaTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetOtaTaskConfiguration {
+  export type Input = GetOtaTaskConfigurationRequest;
+  export type Output = GetOtaTaskConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetProvisioningProfile {
+  export type Input = GetProvisioningProfileRequest;
+  export type Output = GetProvisioningProfileResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRuntimeLogConfiguration {
+  export type Input = GetRuntimeLogConfigurationRequest;
+  export type Output = GetRuntimeLogConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSchemaVersion {
+  export type Input = GetSchemaVersionRequest;
+  export type Output = GetSchemaVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAccountAssociations {
+  export type Input = ListAccountAssociationsRequest;
+  export type Output = ListAccountAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCloudConnectors {
+  export type Input = ListCloudConnectorsRequest;
+  export type Output = ListCloudConnectorsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConnectorDestinations {
+  export type Input = ListConnectorDestinationsRequest;
+  export type Output = ListConnectorDestinationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCredentialLockers {
+  export type Input = ListCredentialLockersRequest;
+  export type Output = ListCredentialLockersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDestinations {
+  export type Input = ListDestinationsRequest;
+  export type Output = ListDestinationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDeviceDiscoveries {
+  export type Input = ListDeviceDiscoveriesRequest;
+  export type Output = ListDeviceDiscoveriesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDiscoveredDevices {
+  export type Input = ListDiscoveredDevicesRequest;
+  export type Output = ListDiscoveredDevicesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEventLogConfigurations {
+  export type Input = ListEventLogConfigurationsRequest;
+  export type Output = ListEventLogConfigurationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListManagedThingAccountAssociations {
+  export type Input = ListManagedThingAccountAssociationsRequest;
+  export type Output = ListManagedThingAccountAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListManagedThingSchemas {
+  export type Input = ListManagedThingSchemasRequest;
+  export type Output = ListManagedThingSchemasResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListManagedThings {
+  export type Input = ListManagedThingsRequest;
+  export type Output = ListManagedThingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListNotificationConfigurations {
+  export type Input = ListNotificationConfigurationsRequest;
+  export type Output = ListNotificationConfigurationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListOtaTaskConfigurations {
+  export type Input = ListOtaTaskConfigurationsRequest;
+  export type Output = ListOtaTaskConfigurationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListOtaTaskExecutions {
+  export type Input = ListOtaTaskExecutionsRequest;
+  export type Output = ListOtaTaskExecutionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListOtaTasks {
+  export type Input = ListOtaTasksRequest;
+  export type Output = ListOtaTasksResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListProvisioningProfiles {
+  export type Input = ListProvisioningProfilesRequest;
+  export type Output = ListProvisioningProfilesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSchemaVersions {
+  export type Input = ListSchemaVersionsRequest;
+  export type Output = ListSchemaVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutDefaultEncryptionConfiguration {
+  export type Input = PutDefaultEncryptionConfigurationRequest;
+  export type Output = PutDefaultEncryptionConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalFailureException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutHubConfiguration {
+  export type Input = PutHubConfigurationRequest;
+  export type Output = PutHubConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutRuntimeLogConfiguration {
+  export type Input = PutRuntimeLogConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RegisterAccountAssociation {
+  export type Input = RegisterAccountAssociationRequest;
+  export type Output = RegisterAccountAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ResetRuntimeLogConfiguration {
+  export type Input = ResetRuntimeLogConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SendManagedThingCommand {
+  export type Input = SendManagedThingCommandRequest;
+  export type Output = SendManagedThingCommandResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartAccountAssociationRefresh {
+  export type Input = StartAccountAssociationRefreshRequest;
+  export type Output = StartAccountAssociationRefreshResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartDeviceDiscovery {
+  export type Input = StartDeviceDiscoveryRequest;
+  export type Output = StartDeviceDiscoveryResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAccountAssociation {
+  export type Input = UpdateAccountAssociationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCloudConnector {
+  export type Input = UpdateCloudConnectorRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConnectorDestination {
+  export type Input = UpdateConnectorDestinationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDestination {
+  export type Input = UpdateDestinationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEventLogConfiguration {
+  export type Input = UpdateEventLogConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateManagedThing {
+  export type Input = UpdateManagedThingRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateNotificationConfiguration {
+  export type Input = UpdateNotificationConfigurationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateOtaTask {
+  export type Input = UpdateOtaTaskRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
     | CommonAwsError;
 }

--- a/src/services/iotfleetwise/index.ts
+++ b/src/services/iotfleetwise/index.ts
@@ -131,6 +131,521 @@ export declare class IoTFleetWise extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateVehicleFleet(
+    input: AssociateVehicleFleetRequest,
+  ): Effect.Effect<
+    AssociateVehicleFleetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCampaign(
+    input: CreateCampaignRequest,
+  ): Effect.Effect<
+    CreateCampaignResponse,
+    | AccessDeniedException
+    | ConflictException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDecoderManifest(
+    input: CreateDecoderManifestRequest,
+  ): Effect.Effect<
+    CreateDecoderManifestResponse,
+    | AccessDeniedException
+    | ConflictException
+    | DecoderManifestValidationException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createFleet(
+    input: CreateFleetRequest,
+  ): Effect.Effect<
+    CreateFleetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createModelManifest(
+    input: CreateModelManifestRequest,
+  ): Effect.Effect<
+    CreateModelManifestResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSignalCatalog(
+    input: CreateSignalCatalogRequest,
+  ): Effect.Effect<
+    CreateSignalCatalogResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InvalidNodeException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createStateTemplate(
+    input: CreateStateTemplateRequest,
+  ): Effect.Effect<
+    CreateStateTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createVehicle(
+    input: CreateVehicleRequest,
+  ): Effect.Effect<
+    CreateVehicleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCampaign(
+    input: DeleteCampaignRequest,
+  ): Effect.Effect<
+    DeleteCampaignResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDecoderManifest(
+    input: DeleteDecoderManifestRequest,
+  ): Effect.Effect<
+    DeleteDecoderManifestResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteFleet(
+    input: DeleteFleetRequest,
+  ): Effect.Effect<
+    DeleteFleetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteModelManifest(
+    input: DeleteModelManifestRequest,
+  ): Effect.Effect<
+    DeleteModelManifestResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSignalCatalog(
+    input: DeleteSignalCatalogRequest,
+  ): Effect.Effect<
+    DeleteSignalCatalogResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteStateTemplate(
+    input: DeleteStateTemplateRequest,
+  ): Effect.Effect<
+    DeleteStateTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteVehicle(
+    input: DeleteVehicleRequest,
+  ): Effect.Effect<
+    DeleteVehicleResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateVehicleFleet(
+    input: DisassociateVehicleFleetRequest,
+  ): Effect.Effect<
+    DisassociateVehicleFleetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCampaign(
+    input: GetCampaignRequest,
+  ): Effect.Effect<
+    GetCampaignResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDecoderManifest(
+    input: GetDecoderManifestRequest,
+  ): Effect.Effect<
+    GetDecoderManifestResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getFleet(
+    input: GetFleetRequest,
+  ): Effect.Effect<
+    GetFleetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getModelManifest(
+    input: GetModelManifestRequest,
+  ): Effect.Effect<
+    GetModelManifestResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSignalCatalog(
+    input: GetSignalCatalogRequest,
+  ): Effect.Effect<
+    GetSignalCatalogResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getStateTemplate(
+    input: GetStateTemplateRequest,
+  ): Effect.Effect<
+    GetStateTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getVehicle(
+    input: GetVehicleRequest,
+  ): Effect.Effect<
+    GetVehicleResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  importDecoderManifest(
+    input: ImportDecoderManifestRequest,
+  ): Effect.Effect<
+    ImportDecoderManifestResponse,
+    | AccessDeniedException
+    | ConflictException
+    | DecoderManifestValidationException
+    | InvalidSignalsException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  importSignalCatalog(
+    input: ImportSignalCatalogRequest,
+  ): Effect.Effect<
+    ImportSignalCatalogResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCampaigns(
+    input: ListCampaignsRequest,
+  ): Effect.Effect<
+    ListCampaignsResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDecoderManifestNetworkInterfaces(
+    input: ListDecoderManifestNetworkInterfacesRequest,
+  ): Effect.Effect<
+    ListDecoderManifestNetworkInterfacesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDecoderManifestSignals(
+    input: ListDecoderManifestSignalsRequest,
+  ): Effect.Effect<
+    ListDecoderManifestSignalsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDecoderManifests(
+    input: ListDecoderManifestsRequest,
+  ): Effect.Effect<
+    ListDecoderManifestsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFleets(
+    input: ListFleetsRequest,
+  ): Effect.Effect<
+    ListFleetsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listFleetsForVehicle(
+    input: ListFleetsForVehicleRequest,
+  ): Effect.Effect<
+    ListFleetsForVehicleResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listModelManifestNodes(
+    input: ListModelManifestNodesRequest,
+  ): Effect.Effect<
+    ListModelManifestNodesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listModelManifests(
+    input: ListModelManifestsRequest,
+  ): Effect.Effect<
+    ListModelManifestsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSignalCatalogNodes(
+    input: ListSignalCatalogNodesRequest,
+  ): Effect.Effect<
+    ListSignalCatalogNodesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSignalCatalogs(
+    input: ListSignalCatalogsRequest,
+  ): Effect.Effect<
+    ListSignalCatalogsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listStateTemplates(
+    input: ListStateTemplatesRequest,
+  ): Effect.Effect<
+    ListStateTemplatesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listVehicles(
+    input: ListVehiclesRequest,
+  ): Effect.Effect<
+    ListVehiclesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listVehiclesInFleet(
+    input: ListVehiclesInFleetRequest,
+  ): Effect.Effect<
+    ListVehiclesInFleetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCampaign(
+    input: UpdateCampaignRequest,
+  ): Effect.Effect<
+    UpdateCampaignResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDecoderManifest(
+    input: UpdateDecoderManifestRequest,
+  ): Effect.Effect<
+    UpdateDecoderManifestResponse,
+    | AccessDeniedException
+    | ConflictException
+    | DecoderManifestValidationException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateFleet(
+    input: UpdateFleetRequest,
+  ): Effect.Effect<
+    UpdateFleetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateModelManifest(
+    input: UpdateModelManifestRequest,
+  ): Effect.Effect<
+    UpdateModelManifestResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidSignalsException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSignalCatalog(
+    input: UpdateSignalCatalogRequest,
+  ): Effect.Effect<
+    UpdateSignalCatalogResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidNodeException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateStateTemplate(
+    input: UpdateStateTemplateRequest,
+  ): Effect.Effect<
+    UpdateStateTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateVehicle(
+    input: UpdateVehicleRequest,
+  ): Effect.Effect<
+    UpdateVehicleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Iotfleetwise extends IoTFleetWise {}
@@ -1704,6 +2219,566 @@ export declare namespace UntagResource {
   export type Error =
     | AccessDeniedException
     | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateVehicleFleet {
+  export type Input = AssociateVehicleFleetRequest;
+  export type Output = AssociateVehicleFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCampaign {
+  export type Input = CreateCampaignRequest;
+  export type Output = CreateCampaignResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDecoderManifest {
+  export type Input = CreateDecoderManifestRequest;
+  export type Output = CreateDecoderManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | DecoderManifestValidationException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFleet {
+  export type Input = CreateFleetRequest;
+  export type Output = CreateFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateModelManifest {
+  export type Input = CreateModelManifestRequest;
+  export type Output = CreateModelManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSignalCatalog {
+  export type Input = CreateSignalCatalogRequest;
+  export type Output = CreateSignalCatalogResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InvalidNodeException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateStateTemplate {
+  export type Input = CreateStateTemplateRequest;
+  export type Output = CreateStateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateVehicle {
+  export type Input = CreateVehicleRequest;
+  export type Output = CreateVehicleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCampaign {
+  export type Input = DeleteCampaignRequest;
+  export type Output = DeleteCampaignResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDecoderManifest {
+  export type Input = DeleteDecoderManifestRequest;
+  export type Output = DeleteDecoderManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFleet {
+  export type Input = DeleteFleetRequest;
+  export type Output = DeleteFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteModelManifest {
+  export type Input = DeleteModelManifestRequest;
+  export type Output = DeleteModelManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSignalCatalog {
+  export type Input = DeleteSignalCatalogRequest;
+  export type Output = DeleteSignalCatalogResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteStateTemplate {
+  export type Input = DeleteStateTemplateRequest;
+  export type Output = DeleteStateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVehicle {
+  export type Input = DeleteVehicleRequest;
+  export type Output = DeleteVehicleResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateVehicleFleet {
+  export type Input = DisassociateVehicleFleetRequest;
+  export type Output = DisassociateVehicleFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCampaign {
+  export type Input = GetCampaignRequest;
+  export type Output = GetCampaignResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDecoderManifest {
+  export type Input = GetDecoderManifestRequest;
+  export type Output = GetDecoderManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetFleet {
+  export type Input = GetFleetRequest;
+  export type Output = GetFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetModelManifest {
+  export type Input = GetModelManifestRequest;
+  export type Output = GetModelManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSignalCatalog {
+  export type Input = GetSignalCatalogRequest;
+  export type Output = GetSignalCatalogResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetStateTemplate {
+  export type Input = GetStateTemplateRequest;
+  export type Output = GetStateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetVehicle {
+  export type Input = GetVehicleRequest;
+  export type Output = GetVehicleResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ImportDecoderManifest {
+  export type Input = ImportDecoderManifestRequest;
+  export type Output = ImportDecoderManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | DecoderManifestValidationException
+    | InvalidSignalsException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ImportSignalCatalog {
+  export type Input = ImportSignalCatalogRequest;
+  export type Output = ImportSignalCatalogResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCampaigns {
+  export type Input = ListCampaignsRequest;
+  export type Output = ListCampaignsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDecoderManifestNetworkInterfaces {
+  export type Input = ListDecoderManifestNetworkInterfacesRequest;
+  export type Output = ListDecoderManifestNetworkInterfacesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDecoderManifestSignals {
+  export type Input = ListDecoderManifestSignalsRequest;
+  export type Output = ListDecoderManifestSignalsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDecoderManifests {
+  export type Input = ListDecoderManifestsRequest;
+  export type Output = ListDecoderManifestsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFleets {
+  export type Input = ListFleetsRequest;
+  export type Output = ListFleetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListFleetsForVehicle {
+  export type Input = ListFleetsForVehicleRequest;
+  export type Output = ListFleetsForVehicleResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListModelManifestNodes {
+  export type Input = ListModelManifestNodesRequest;
+  export type Output = ListModelManifestNodesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListModelManifests {
+  export type Input = ListModelManifestsRequest;
+  export type Output = ListModelManifestsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSignalCatalogNodes {
+  export type Input = ListSignalCatalogNodesRequest;
+  export type Output = ListSignalCatalogNodesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSignalCatalogs {
+  export type Input = ListSignalCatalogsRequest;
+  export type Output = ListSignalCatalogsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListStateTemplates {
+  export type Input = ListStateTemplatesRequest;
+  export type Output = ListStateTemplatesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListVehicles {
+  export type Input = ListVehiclesRequest;
+  export type Output = ListVehiclesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListVehiclesInFleet {
+  export type Input = ListVehiclesInFleetRequest;
+  export type Output = ListVehiclesInFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCampaign {
+  export type Input = UpdateCampaignRequest;
+  export type Output = UpdateCampaignResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDecoderManifest {
+  export type Input = UpdateDecoderManifestRequest;
+  export type Output = UpdateDecoderManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | DecoderManifestValidationException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFleet {
+  export type Input = UpdateFleetRequest;
+  export type Output = UpdateFleetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateModelManifest {
+  export type Input = UpdateModelManifestRequest;
+  export type Output = UpdateModelManifestResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidSignalsException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSignalCatalog {
+  export type Input = UpdateSignalCatalogRequest;
+  export type Output = UpdateSignalCatalogResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidNodeException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateStateTemplate {
+  export type Input = UpdateStateTemplateRequest;
+  export type Output = UpdateStateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | InvalidSignalsException
+    | LimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateVehicle {
+  export type Input = UpdateVehicleRequest;
+  export type Output = UpdateVehicleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | LimitExceededException
     | ResourceNotFoundException
     | ThrottlingException
     | ValidationException

--- a/src/services/lambda/index.ts
+++ b/src/services/lambda/index.ts
@@ -1,4 +1,5 @@
 import type { Effect, Stream, Data as EffectData } from "effect";
+import type { Buffer } from "node:buffer";
 import type { CommonAwsError } from "../../error.ts";
 import { AWSServiceClient } from "../../client.ts";
 
@@ -34,6 +35,735 @@ export declare class Lambda extends AWSServiceClient {
     input: UntagResourceRequest,
   ): Effect.Effect<
     {},
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  addLayerVersionPermission(
+    input: AddLayerVersionPermissionRequest,
+  ): Effect.Effect<
+    AddLayerVersionPermissionResponse,
+    | InvalidParameterValueException
+    | PolicyLengthExceededException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  addPermission(
+    input: AddPermissionRequest,
+  ): Effect.Effect<
+    AddPermissionResponse,
+    | InvalidParameterValueException
+    | PolicyLengthExceededException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createAlias(
+    input: CreateAliasRequest,
+  ): Effect.Effect<
+    AliasConfiguration,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createCodeSigningConfig(
+    input: CreateCodeSigningConfigRequest,
+  ): Effect.Effect<
+    CreateCodeSigningConfigResponse,
+    InvalidParameterValueException | ServiceException | CommonAwsError
+  >;
+  createEventSourceMapping(
+    input: CreateEventSourceMappingRequest,
+  ): Effect.Effect<
+    EventSourceMappingConfiguration,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createFunction(
+    input: CreateFunctionRequest,
+  ): Effect.Effect<
+    FunctionConfiguration,
+    | CodeSigningConfigNotFoundException
+    | CodeStorageExceededException
+    | CodeVerificationFailedException
+    | InvalidCodeSignatureException
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createFunctionUrlConfig(
+    input: CreateFunctionUrlConfigRequest,
+  ): Effect.Effect<
+    CreateFunctionUrlConfigResponse,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteAlias(
+    input: DeleteAliasRequest,
+  ): Effect.Effect<
+    {},
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteCodeSigningConfig(
+    input: DeleteCodeSigningConfigRequest,
+  ): Effect.Effect<
+    DeleteCodeSigningConfigResponse,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError
+  >;
+  deleteEventSourceMapping(
+    input: DeleteEventSourceMappingRequest,
+  ): Effect.Effect<
+    EventSourceMappingConfiguration,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceInUseException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteFunction(
+    input: DeleteFunctionRequest,
+  ): Effect.Effect<
+    {},
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteFunctionCodeSigningConfig(
+    input: DeleteFunctionCodeSigningConfigRequest,
+  ): Effect.Effect<
+    {},
+    | CodeSigningConfigNotFoundException
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteFunctionConcurrency(
+    input: DeleteFunctionConcurrencyRequest,
+  ): Effect.Effect<
+    {},
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteFunctionEventInvokeConfig(
+    input: DeleteFunctionEventInvokeConfigRequest,
+  ): Effect.Effect<
+    {},
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteFunctionUrlConfig(
+    input: DeleteFunctionUrlConfigRequest,
+  ): Effect.Effect<
+    {},
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteLayerVersion(
+    input: DeleteLayerVersionRequest,
+  ): Effect.Effect<
+    {},
+    ServiceException | TooManyRequestsException | CommonAwsError
+  >;
+  deleteProvisionedConcurrencyConfig(
+    input: DeleteProvisionedConcurrencyConfigRequest,
+  ): Effect.Effect<
+    {},
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getAlias(
+    input: GetAliasRequest,
+  ): Effect.Effect<
+    AliasConfiguration,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getCodeSigningConfig(
+    input: GetCodeSigningConfigRequest,
+  ): Effect.Effect<
+    GetCodeSigningConfigResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError
+  >;
+  getEventSourceMapping(
+    input: GetEventSourceMappingRequest,
+  ): Effect.Effect<
+    EventSourceMappingConfiguration,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getFunction(
+    input: GetFunctionRequest,
+  ): Effect.Effect<
+    GetFunctionResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getFunctionCodeSigningConfig(
+    input: GetFunctionCodeSigningConfigRequest,
+  ): Effect.Effect<
+    GetFunctionCodeSigningConfigResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getFunctionConcurrency(
+    input: GetFunctionConcurrencyRequest,
+  ): Effect.Effect<
+    GetFunctionConcurrencyResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getFunctionConfiguration(
+    input: GetFunctionConfigurationRequest,
+  ): Effect.Effect<
+    FunctionConfiguration,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getFunctionEventInvokeConfig(
+    input: GetFunctionEventInvokeConfigRequest,
+  ): Effect.Effect<
+    FunctionEventInvokeConfig,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getFunctionRecursionConfig(
+    input: GetFunctionRecursionConfigRequest,
+  ): Effect.Effect<
+    GetFunctionRecursionConfigResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getFunctionUrlConfig(
+    input: GetFunctionUrlConfigRequest,
+  ): Effect.Effect<
+    GetFunctionUrlConfigResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getLayerVersion(
+    input: GetLayerVersionRequest,
+  ): Effect.Effect<
+    GetLayerVersionResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getLayerVersionByArn(
+    input: GetLayerVersionByArnRequest,
+  ): Effect.Effect<
+    GetLayerVersionResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getLayerVersionPolicy(
+    input: GetLayerVersionPolicyRequest,
+  ): Effect.Effect<
+    GetLayerVersionPolicyResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getPolicy(
+    input: GetPolicyRequest,
+  ): Effect.Effect<
+    GetPolicyResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getProvisionedConcurrencyConfig(
+    input: GetProvisionedConcurrencyConfigRequest,
+  ): Effect.Effect<
+    GetProvisionedConcurrencyConfigResponse,
+    | InvalidParameterValueException
+    | ProvisionedConcurrencyConfigNotFoundException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  getRuntimeManagementConfig(
+    input: GetRuntimeManagementConfigRequest,
+  ): Effect.Effect<
+    GetRuntimeManagementConfigResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  invoke(
+    input: InvocationRequest,
+  ): Effect.Effect<
+    InvocationResponse,
+    | EC2AccessDeniedException
+    | EC2ThrottledException
+    | EC2UnexpectedException
+    | EFSIOException
+    | EFSMountConnectivityException
+    | EFSMountFailureException
+    | EFSMountTimeoutException
+    | ENILimitReachedException
+    | InvalidParameterValueException
+    | InvalidRequestContentException
+    | InvalidRuntimeException
+    | InvalidSecurityGroupIDException
+    | InvalidSubnetIDException
+    | InvalidZipFileException
+    | KMSAccessDeniedException
+    | KMSDisabledException
+    | KMSInvalidStateException
+    | KMSNotFoundException
+    | RecursiveInvocationException
+    | RequestTooLargeException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ResourceNotReadyException
+    | ServiceException
+    | SnapStartException
+    | SnapStartNotReadyException
+    | SnapStartTimeoutException
+    | SubnetIPAddressLimitReachedException
+    | TooManyRequestsException
+    | UnsupportedMediaTypeException
+    | CommonAwsError
+  >;
+  invokeAsync(
+    input: InvokeAsyncRequest,
+  ): Effect.Effect<
+    InvokeAsyncResponse,
+    | InvalidRequestContentException
+    | InvalidRuntimeException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError
+  >;
+  invokeWithResponseStream(
+    input: InvokeWithResponseStreamRequest,
+  ): Effect.Effect<
+    InvokeWithResponseStreamResponse,
+    | EC2AccessDeniedException
+    | EC2ThrottledException
+    | EC2UnexpectedException
+    | EFSIOException
+    | EFSMountConnectivityException
+    | EFSMountFailureException
+    | EFSMountTimeoutException
+    | ENILimitReachedException
+    | InvalidParameterValueException
+    | InvalidRequestContentException
+    | InvalidRuntimeException
+    | InvalidSecurityGroupIDException
+    | InvalidSubnetIDException
+    | InvalidZipFileException
+    | KMSAccessDeniedException
+    | KMSDisabledException
+    | KMSInvalidStateException
+    | KMSNotFoundException
+    | RecursiveInvocationException
+    | RequestTooLargeException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ResourceNotReadyException
+    | ServiceException
+    | SnapStartException
+    | SnapStartNotReadyException
+    | SnapStartTimeoutException
+    | SubnetIPAddressLimitReachedException
+    | TooManyRequestsException
+    | UnsupportedMediaTypeException
+    | CommonAwsError
+  >;
+  listAliases(
+    input: ListAliasesRequest,
+  ): Effect.Effect<
+    ListAliasesResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listCodeSigningConfigs(
+    input: ListCodeSigningConfigsRequest,
+  ): Effect.Effect<
+    ListCodeSigningConfigsResponse,
+    InvalidParameterValueException | ServiceException | CommonAwsError
+  >;
+  listEventSourceMappings(
+    input: ListEventSourceMappingsRequest,
+  ): Effect.Effect<
+    ListEventSourceMappingsResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listFunctionEventInvokeConfigs(
+    input: ListFunctionEventInvokeConfigsRequest,
+  ): Effect.Effect<
+    ListFunctionEventInvokeConfigsResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listFunctionUrlConfigs(
+    input: ListFunctionUrlConfigsRequest,
+  ): Effect.Effect<
+    ListFunctionUrlConfigsResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listFunctions(
+    input: ListFunctionsRequest,
+  ): Effect.Effect<
+    ListFunctionsResponse,
+    | InvalidParameterValueException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listFunctionsByCodeSigningConfig(
+    input: ListFunctionsByCodeSigningConfigRequest,
+  ): Effect.Effect<
+    ListFunctionsByCodeSigningConfigResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError
+  >;
+  listLayerVersions(
+    input: ListLayerVersionsRequest,
+  ): Effect.Effect<
+    ListLayerVersionsResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listLayers(
+    input: ListLayersRequest,
+  ): Effect.Effect<
+    ListLayersResponse,
+    | InvalidParameterValueException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listProvisionedConcurrencyConfigs(
+    input: ListProvisionedConcurrencyConfigsRequest,
+  ): Effect.Effect<
+    ListProvisionedConcurrencyConfigsResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listVersionsByFunction(
+    input: ListVersionsByFunctionRequest,
+  ): Effect.Effect<
+    ListVersionsByFunctionResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  publishLayerVersion(
+    input: PublishLayerVersionRequest,
+  ): Effect.Effect<
+    PublishLayerVersionResponse,
+    | CodeStorageExceededException
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  publishVersion(
+    input: PublishVersionRequest,
+  ): Effect.Effect<
+    FunctionConfiguration,
+    | CodeStorageExceededException
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  putFunctionCodeSigningConfig(
+    input: PutFunctionCodeSigningConfigRequest,
+  ): Effect.Effect<
+    PutFunctionCodeSigningConfigResponse,
+    | CodeSigningConfigNotFoundException
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  putFunctionConcurrency(
+    input: PutFunctionConcurrencyRequest,
+  ): Effect.Effect<
+    Concurrency,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  putFunctionEventInvokeConfig(
+    input: PutFunctionEventInvokeConfigRequest,
+  ): Effect.Effect<
+    FunctionEventInvokeConfig,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  putFunctionRecursionConfig(
+    input: PutFunctionRecursionConfigRequest,
+  ): Effect.Effect<
+    PutFunctionRecursionConfigResponse,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  putProvisionedConcurrencyConfig(
+    input: PutProvisionedConcurrencyConfigRequest,
+  ): Effect.Effect<
+    PutProvisionedConcurrencyConfigResponse,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  putRuntimeManagementConfig(
+    input: PutRuntimeManagementConfigRequest,
+  ): Effect.Effect<
+    PutRuntimeManagementConfigResponse,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  removeLayerVersionPermission(
+    input: RemoveLayerVersionPermissionRequest,
+  ): Effect.Effect<
+    {},
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  removePermission(
+    input: RemovePermissionRequest,
+  ): Effect.Effect<
+    {},
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateAlias(
+    input: UpdateAliasRequest,
+  ): Effect.Effect<
+    AliasConfiguration,
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateCodeSigningConfig(
+    input: UpdateCodeSigningConfigRequest,
+  ): Effect.Effect<
+    UpdateCodeSigningConfigResponse,
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError
+  >;
+  updateEventSourceMapping(
+    input: UpdateEventSourceMappingRequest,
+  ): Effect.Effect<
+    EventSourceMappingConfiguration,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceInUseException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFunctionCode(
+    input: UpdateFunctionCodeRequest,
+  ): Effect.Effect<
+    FunctionConfiguration,
+    | CodeSigningConfigNotFoundException
+    | CodeStorageExceededException
+    | CodeVerificationFailedException
+    | InvalidCodeSignatureException
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFunctionConfiguration(
+    input: UpdateFunctionConfigurationRequest,
+  ): Effect.Effect<
+    FunctionConfiguration,
+    | CodeSigningConfigNotFoundException
+    | CodeVerificationFailedException
+    | InvalidCodeSignatureException
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFunctionEventInvokeConfig(
+    input: UpdateFunctionEventInvokeConfigRequest,
+  ): Effect.Effect<
+    FunctionEventInvokeConfig,
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFunctionUrlConfig(
+    input: UpdateFunctionUrlConfigRequest,
+  ): Effect.Effect<
+    UpdateFunctionUrlConfigResponse,
     | InvalidParameterValueException
     | ResourceConflictException
     | ResourceNotFoundException
@@ -763,7 +1493,7 @@ export interface InvocationResponse {
 export type InvocationType = "Event" | "RequestResponse" | "DryRun";
 export interface InvokeAsyncRequest {
   FunctionName: string;
-  InvokeArgs: Uint8Array | string | Stream.Stream<Uint8Array>;
+  InvokeArgs: Uint8Array | string | Buffer | Stream.Stream<Uint8Array>;
 }
 export interface InvokeAsyncResponse {
   Status?: number;
@@ -1677,6 +2407,805 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = {};
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace AddLayerVersionPermission {
+  export type Input = AddLayerVersionPermissionRequest;
+  export type Output = AddLayerVersionPermissionResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | PolicyLengthExceededException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace AddPermission {
+  export type Input = AddPermissionRequest;
+  export type Output = AddPermissionResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | PolicyLengthExceededException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAlias {
+  export type Input = CreateAliasRequest;
+  export type Output = AliasConfiguration;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCodeSigningConfig {
+  export type Input = CreateCodeSigningConfigRequest;
+  export type Output = CreateCodeSigningConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ServiceException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEventSourceMapping {
+  export type Input = CreateEventSourceMappingRequest;
+  export type Output = EventSourceMappingConfiguration;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFunction {
+  export type Input = CreateFunctionRequest;
+  export type Output = FunctionConfiguration;
+  export type Error =
+    | CodeSigningConfigNotFoundException
+    | CodeStorageExceededException
+    | CodeVerificationFailedException
+    | InvalidCodeSignatureException
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFunctionUrlConfig {
+  export type Input = CreateFunctionUrlConfigRequest;
+  export type Output = CreateFunctionUrlConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAlias {
+  export type Input = DeleteAliasRequest;
+  export type Output = {};
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCodeSigningConfig {
+  export type Input = DeleteCodeSigningConfigRequest;
+  export type Output = DeleteCodeSigningConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEventSourceMapping {
+  export type Input = DeleteEventSourceMappingRequest;
+  export type Output = EventSourceMappingConfiguration;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceInUseException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFunction {
+  export type Input = DeleteFunctionRequest;
+  export type Output = {};
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFunctionCodeSigningConfig {
+  export type Input = DeleteFunctionCodeSigningConfigRequest;
+  export type Output = {};
+  export type Error =
+    | CodeSigningConfigNotFoundException
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFunctionConcurrency {
+  export type Input = DeleteFunctionConcurrencyRequest;
+  export type Output = {};
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFunctionEventInvokeConfig {
+  export type Input = DeleteFunctionEventInvokeConfigRequest;
+  export type Output = {};
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFunctionUrlConfig {
+  export type Input = DeleteFunctionUrlConfigRequest;
+  export type Output = {};
+  export type Error =
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLayerVersion {
+  export type Input = DeleteLayerVersionRequest;
+  export type Output = {};
+  export type Error =
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteProvisionedConcurrencyConfig {
+  export type Input = DeleteProvisionedConcurrencyConfigRequest;
+  export type Output = {};
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetAlias {
+  export type Input = GetAliasRequest;
+  export type Output = AliasConfiguration;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetCodeSigningConfig {
+  export type Input = GetCodeSigningConfigRequest;
+  export type Output = GetCodeSigningConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError;
+}
+
+export declare namespace GetEventSourceMapping {
+  export type Input = GetEventSourceMappingRequest;
+  export type Output = EventSourceMappingConfiguration;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetFunction {
+  export type Input = GetFunctionRequest;
+  export type Output = GetFunctionResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetFunctionCodeSigningConfig {
+  export type Input = GetFunctionCodeSigningConfigRequest;
+  export type Output = GetFunctionCodeSigningConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetFunctionConcurrency {
+  export type Input = GetFunctionConcurrencyRequest;
+  export type Output = GetFunctionConcurrencyResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetFunctionConfiguration {
+  export type Input = GetFunctionConfigurationRequest;
+  export type Output = FunctionConfiguration;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetFunctionEventInvokeConfig {
+  export type Input = GetFunctionEventInvokeConfigRequest;
+  export type Output = FunctionEventInvokeConfig;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetFunctionRecursionConfig {
+  export type Input = GetFunctionRecursionConfigRequest;
+  export type Output = GetFunctionRecursionConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetFunctionUrlConfig {
+  export type Input = GetFunctionUrlConfigRequest;
+  export type Output = GetFunctionUrlConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetLayerVersion {
+  export type Input = GetLayerVersionRequest;
+  export type Output = GetLayerVersionResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetLayerVersionByArn {
+  export type Input = GetLayerVersionByArnRequest;
+  export type Output = GetLayerVersionResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetLayerVersionPolicy {
+  export type Input = GetLayerVersionPolicyRequest;
+  export type Output = GetLayerVersionPolicyResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetPolicy {
+  export type Input = GetPolicyRequest;
+  export type Output = GetPolicyResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetProvisionedConcurrencyConfig {
+  export type Input = GetProvisionedConcurrencyConfigRequest;
+  export type Output = GetProvisionedConcurrencyConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ProvisionedConcurrencyConfigNotFoundException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GetRuntimeManagementConfig {
+  export type Input = GetRuntimeManagementConfigRequest;
+  export type Output = GetRuntimeManagementConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace Invoke {
+  export type Input = InvocationRequest;
+  export type Output = InvocationResponse;
+  export type Error =
+    | EC2AccessDeniedException
+    | EC2ThrottledException
+    | EC2UnexpectedException
+    | EFSIOException
+    | EFSMountConnectivityException
+    | EFSMountFailureException
+    | EFSMountTimeoutException
+    | ENILimitReachedException
+    | InvalidParameterValueException
+    | InvalidRequestContentException
+    | InvalidRuntimeException
+    | InvalidSecurityGroupIDException
+    | InvalidSubnetIDException
+    | InvalidZipFileException
+    | KMSAccessDeniedException
+    | KMSDisabledException
+    | KMSInvalidStateException
+    | KMSNotFoundException
+    | RecursiveInvocationException
+    | RequestTooLargeException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ResourceNotReadyException
+    | ServiceException
+    | SnapStartException
+    | SnapStartNotReadyException
+    | SnapStartTimeoutException
+    | SubnetIPAddressLimitReachedException
+    | TooManyRequestsException
+    | UnsupportedMediaTypeException
+    | CommonAwsError;
+}
+
+export declare namespace InvokeAsync {
+  export type Input = InvokeAsyncRequest;
+  export type Output = InvokeAsyncResponse;
+  export type Error =
+    | InvalidRequestContentException
+    | InvalidRuntimeException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError;
+}
+
+export declare namespace InvokeWithResponseStream {
+  export type Input = InvokeWithResponseStreamRequest;
+  export type Output = InvokeWithResponseStreamResponse;
+  export type Error =
+    | EC2AccessDeniedException
+    | EC2ThrottledException
+    | EC2UnexpectedException
+    | EFSIOException
+    | EFSMountConnectivityException
+    | EFSMountFailureException
+    | EFSMountTimeoutException
+    | ENILimitReachedException
+    | InvalidParameterValueException
+    | InvalidRequestContentException
+    | InvalidRuntimeException
+    | InvalidSecurityGroupIDException
+    | InvalidSubnetIDException
+    | InvalidZipFileException
+    | KMSAccessDeniedException
+    | KMSDisabledException
+    | KMSInvalidStateException
+    | KMSNotFoundException
+    | RecursiveInvocationException
+    | RequestTooLargeException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ResourceNotReadyException
+    | ServiceException
+    | SnapStartException
+    | SnapStartNotReadyException
+    | SnapStartTimeoutException
+    | SubnetIPAddressLimitReachedException
+    | TooManyRequestsException
+    | UnsupportedMediaTypeException
+    | CommonAwsError;
+}
+
+export declare namespace ListAliases {
+  export type Input = ListAliasesRequest;
+  export type Output = ListAliasesResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListCodeSigningConfigs {
+  export type Input = ListCodeSigningConfigsRequest;
+  export type Output = ListCodeSigningConfigsResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ServiceException
+    | CommonAwsError;
+}
+
+export declare namespace ListEventSourceMappings {
+  export type Input = ListEventSourceMappingsRequest;
+  export type Output = ListEventSourceMappingsResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListFunctionEventInvokeConfigs {
+  export type Input = ListFunctionEventInvokeConfigsRequest;
+  export type Output = ListFunctionEventInvokeConfigsResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListFunctionUrlConfigs {
+  export type Input = ListFunctionUrlConfigsRequest;
+  export type Output = ListFunctionUrlConfigsResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListFunctions {
+  export type Input = ListFunctionsRequest;
+  export type Output = ListFunctionsResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListFunctionsByCodeSigningConfig {
+  export type Input = ListFunctionsByCodeSigningConfigRequest;
+  export type Output = ListFunctionsByCodeSigningConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError;
+}
+
+export declare namespace ListLayerVersions {
+  export type Input = ListLayerVersionsRequest;
+  export type Output = ListLayerVersionsResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListLayers {
+  export type Input = ListLayersRequest;
+  export type Output = ListLayersResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListProvisionedConcurrencyConfigs {
+  export type Input = ListProvisionedConcurrencyConfigsRequest;
+  export type Output = ListProvisionedConcurrencyConfigsResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListVersionsByFunction {
+  export type Input = ListVersionsByFunctionRequest;
+  export type Output = ListVersionsByFunctionResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PublishLayerVersion {
+  export type Input = PublishLayerVersionRequest;
+  export type Output = PublishLayerVersionResponse;
+  export type Error =
+    | CodeStorageExceededException
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PublishVersion {
+  export type Input = PublishVersionRequest;
+  export type Output = FunctionConfiguration;
+  export type Error =
+    | CodeStorageExceededException
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PutFunctionCodeSigningConfig {
+  export type Input = PutFunctionCodeSigningConfigRequest;
+  export type Output = PutFunctionCodeSigningConfigResponse;
+  export type Error =
+    | CodeSigningConfigNotFoundException
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PutFunctionConcurrency {
+  export type Input = PutFunctionConcurrencyRequest;
+  export type Output = Concurrency;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PutFunctionEventInvokeConfig {
+  export type Input = PutFunctionEventInvokeConfigRequest;
+  export type Output = FunctionEventInvokeConfig;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PutFunctionRecursionConfig {
+  export type Input = PutFunctionRecursionConfigRequest;
+  export type Output = PutFunctionRecursionConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PutProvisionedConcurrencyConfig {
+  export type Input = PutProvisionedConcurrencyConfigRequest;
+  export type Output = PutProvisionedConcurrencyConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PutRuntimeManagementConfig {
+  export type Input = PutRuntimeManagementConfigRequest;
+  export type Output = PutRuntimeManagementConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveLayerVersionPermission {
+  export type Input = RemoveLayerVersionPermissionRequest;
+  export type Output = {};
+  export type Error =
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RemovePermission {
+  export type Input = RemovePermissionRequest;
+  export type Output = {};
+  export type Error =
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAlias {
+  export type Input = UpdateAliasRequest;
+  export type Output = AliasConfiguration;
+  export type Error =
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCodeSigningConfig {
+  export type Input = UpdateCodeSigningConfigRequest;
+  export type Output = UpdateCodeSigningConfigResponse;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceNotFoundException
+    | ServiceException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEventSourceMapping {
+  export type Input = UpdateEventSourceMappingRequest;
+  export type Output = EventSourceMappingConfiguration;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceInUseException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFunctionCode {
+  export type Input = UpdateFunctionCodeRequest;
+  export type Output = FunctionConfiguration;
+  export type Error =
+    | CodeSigningConfigNotFoundException
+    | CodeStorageExceededException
+    | CodeVerificationFailedException
+    | InvalidCodeSignatureException
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFunctionConfiguration {
+  export type Input = UpdateFunctionConfigurationRequest;
+  export type Output = FunctionConfiguration;
+  export type Error =
+    | CodeSigningConfigNotFoundException
+    | CodeVerificationFailedException
+    | InvalidCodeSignatureException
+    | InvalidParameterValueException
+    | PreconditionFailedException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFunctionEventInvokeConfig {
+  export type Input = UpdateFunctionEventInvokeConfigRequest;
+  export type Output = FunctionEventInvokeConfig;
+  export type Error =
+    | InvalidParameterValueException
+    | ResourceConflictException
+    | ResourceNotFoundException
+    | ServiceException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFunctionUrlConfig {
+  export type Input = UpdateFunctionUrlConfigRequest;
+  export type Output = UpdateFunctionUrlConfigResponse;
   export type Error =
     | InvalidParameterValueException
     | ResourceConflictException

--- a/src/services/launch-wizard/index.ts
+++ b/src/services/launch-wizard/index.ts
@@ -30,6 +30,83 @@ export declare class LaunchWizard extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createDeployment(
+    input: CreateDeploymentInput,
+  ): Effect.Effect<
+    CreateDeploymentOutput,
+    | InternalServerException
+    | ResourceLimitException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDeployment(
+    input: DeleteDeploymentInput,
+  ): Effect.Effect<
+    DeleteDeploymentOutput,
+    | InternalServerException
+    | ResourceLimitException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDeployment(
+    input: GetDeploymentInput,
+  ): Effect.Effect<
+    GetDeploymentOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorkload(
+    input: GetWorkloadInput,
+  ): Effect.Effect<
+    GetWorkloadOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorkloadDeploymentPattern(
+    input: GetWorkloadDeploymentPatternInput,
+  ): Effect.Effect<
+    GetWorkloadDeploymentPatternOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDeploymentEvents(
+    input: ListDeploymentEventsInput,
+  ): Effect.Effect<
+    ListDeploymentEventsOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDeployments(
+    input: ListDeploymentsInput,
+  ): Effect.Effect<
+    ListDeploymentsOutput,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listWorkloadDeploymentPatterns(
+    input: ListWorkloadDeploymentPatternsInput,
+  ): Effect.Effect<
+    ListWorkloadDeploymentPatternsOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkloads(
+    input: ListWorkloadsInput,
+  ): Effect.Effect<
+    ListWorkloadsOutput,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
 }
 
 export type AllowedValues = Array<string>;
@@ -313,6 +390,96 @@ export declare namespace UntagResource {
   export type Error =
     | InternalServerException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDeployment {
+  export type Input = CreateDeploymentInput;
+  export type Output = CreateDeploymentOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceLimitException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDeployment {
+  export type Input = DeleteDeploymentInput;
+  export type Output = DeleteDeploymentOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceLimitException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDeployment {
+  export type Input = GetDeploymentInput;
+  export type Output = GetDeploymentOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkload {
+  export type Input = GetWorkloadInput;
+  export type Output = GetWorkloadOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkloadDeploymentPattern {
+  export type Input = GetWorkloadDeploymentPatternInput;
+  export type Output = GetWorkloadDeploymentPatternOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDeploymentEvents {
+  export type Input = ListDeploymentEventsInput;
+  export type Output = ListDeploymentEventsOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDeployments {
+  export type Input = ListDeploymentsInput;
+  export type Output = ListDeploymentsOutput;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkloadDeploymentPatterns {
+  export type Input = ListWorkloadDeploymentPatternsInput;
+  export type Output = ListWorkloadDeploymentPatternsOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkloads {
+  export type Input = ListWorkloadsInput;
+  export type Output = ListWorkloadsOutput;
+  export type Error =
+    | InternalServerException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/m2/index.ts
+++ b/src/services/m2/index.ts
@@ -54,6 +54,379 @@ export declare class m2 extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  cancelBatchJobExecution(
+    input: CancelBatchJobExecutionRequest,
+  ): Effect.Effect<
+    CancelBatchJobExecutionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createApplication(
+    input: CreateApplicationRequest,
+  ): Effect.Effect<
+    CreateApplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataSetExportTask(
+    input: CreateDataSetExportTaskRequest,
+  ): Effect.Effect<
+    CreateDataSetExportTaskResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataSetImportTask(
+    input: CreateDataSetImportTaskRequest,
+  ): Effect.Effect<
+    CreateDataSetImportTaskResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDeployment(
+    input: CreateDeploymentRequest,
+  ): Effect.Effect<
+    CreateDeploymentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEnvironment(
+    input: CreateEnvironmentRequest,
+  ): Effect.Effect<
+    CreateEnvironmentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteApplication(
+    input: DeleteApplicationRequest,
+  ): Effect.Effect<
+    DeleteApplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteApplicationFromEnvironment(
+    input: DeleteApplicationFromEnvironmentRequest,
+  ): Effect.Effect<
+    DeleteApplicationFromEnvironmentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEnvironment(
+    input: DeleteEnvironmentRequest,
+  ): Effect.Effect<
+    DeleteEnvironmentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApplication(
+    input: GetApplicationRequest,
+  ): Effect.Effect<
+    GetApplicationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApplicationVersion(
+    input: GetApplicationVersionRequest,
+  ): Effect.Effect<
+    GetApplicationVersionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBatchJobExecution(
+    input: GetBatchJobExecutionRequest,
+  ): Effect.Effect<
+    GetBatchJobExecutionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataSetDetails(
+    input: GetDataSetDetailsRequest,
+  ): Effect.Effect<
+    GetDataSetDetailsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ExecutionTimeoutException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataSetExportTask(
+    input: GetDataSetExportTaskRequest,
+  ): Effect.Effect<
+    GetDataSetExportTaskResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataSetImportTask(
+    input: GetDataSetImportTaskRequest,
+  ): Effect.Effect<
+    GetDataSetImportTaskResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDeployment(
+    input: GetDeploymentRequest,
+  ): Effect.Effect<
+    GetDeploymentResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEnvironment(
+    input: GetEnvironmentRequest,
+  ): Effect.Effect<
+    GetEnvironmentResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApplicationVersions(
+    input: ListApplicationVersionsRequest,
+  ): Effect.Effect<
+    ListApplicationVersionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApplications(
+    input: ListApplicationsRequest,
+  ): Effect.Effect<
+    ListApplicationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBatchJobDefinitions(
+    input: ListBatchJobDefinitionsRequest,
+  ): Effect.Effect<
+    ListBatchJobDefinitionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBatchJobExecutions(
+    input: ListBatchJobExecutionsRequest,
+  ): Effect.Effect<
+    ListBatchJobExecutionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBatchJobRestartPoints(
+    input: ListBatchJobRestartPointsRequest,
+  ): Effect.Effect<
+    ListBatchJobRestartPointsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataSetExportHistory(
+    input: ListDataSetExportHistoryRequest,
+  ): Effect.Effect<
+    ListDataSetExportHistoryResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataSetImportHistory(
+    input: ListDataSetImportHistoryRequest,
+  ): Effect.Effect<
+    ListDataSetImportHistoryResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataSets(
+    input: ListDataSetsRequest,
+  ): Effect.Effect<
+    ListDataSetsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ExecutionTimeoutException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDeployments(
+    input: ListDeploymentsRequest,
+  ): Effect.Effect<
+    ListDeploymentsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnvironments(
+    input: ListEnvironmentsRequest,
+  ): Effect.Effect<
+    ListEnvironmentsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startApplication(
+    input: StartApplicationRequest,
+  ): Effect.Effect<
+    StartApplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startBatchJob(
+    input: StartBatchJobRequest,
+  ): Effect.Effect<
+    StartBatchJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopApplication(
+    input: StopApplicationRequest,
+  ): Effect.Effect<
+    StopApplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateApplication(
+    input: UpdateApplicationRequest,
+  ): Effect.Effect<
+    UpdateApplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEnvironment(
+    input: UpdateEnvironmentRequest,
+  ): Effect.Effect<
+    UpdateEnvironmentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class M2 extends m2 {}
@@ -979,6 +1352,411 @@ export declare namespace UntagResource {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelBatchJobExecution {
+  export type Input = CancelBatchJobExecutionRequest;
+  export type Output = CancelBatchJobExecutionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateApplication {
+  export type Input = CreateApplicationRequest;
+  export type Output = CreateApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataSetExportTask {
+  export type Input = CreateDataSetExportTaskRequest;
+  export type Output = CreateDataSetExportTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataSetImportTask {
+  export type Input = CreateDataSetImportTaskRequest;
+  export type Output = CreateDataSetImportTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDeployment {
+  export type Input = CreateDeploymentRequest;
+  export type Output = CreateDeploymentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEnvironment {
+  export type Input = CreateEnvironmentRequest;
+  export type Output = CreateEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplication {
+  export type Input = DeleteApplicationRequest;
+  export type Output = DeleteApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplicationFromEnvironment {
+  export type Input = DeleteApplicationFromEnvironmentRequest;
+  export type Output = DeleteApplicationFromEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEnvironment {
+  export type Input = DeleteEnvironmentRequest;
+  export type Output = DeleteEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApplication {
+  export type Input = GetApplicationRequest;
+  export type Output = GetApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApplicationVersion {
+  export type Input = GetApplicationVersionRequest;
+  export type Output = GetApplicationVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBatchJobExecution {
+  export type Input = GetBatchJobExecutionRequest;
+  export type Output = GetBatchJobExecutionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataSetDetails {
+  export type Input = GetDataSetDetailsRequest;
+  export type Output = GetDataSetDetailsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ExecutionTimeoutException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataSetExportTask {
+  export type Input = GetDataSetExportTaskRequest;
+  export type Output = GetDataSetExportTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataSetImportTask {
+  export type Input = GetDataSetImportTaskRequest;
+  export type Output = GetDataSetImportTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDeployment {
+  export type Input = GetDeploymentRequest;
+  export type Output = GetDeploymentResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnvironment {
+  export type Input = GetEnvironmentRequest;
+  export type Output = GetEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplicationVersions {
+  export type Input = ListApplicationVersionsRequest;
+  export type Output = ListApplicationVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplications {
+  export type Input = ListApplicationsRequest;
+  export type Output = ListApplicationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBatchJobDefinitions {
+  export type Input = ListBatchJobDefinitionsRequest;
+  export type Output = ListBatchJobDefinitionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBatchJobExecutions {
+  export type Input = ListBatchJobExecutionsRequest;
+  export type Output = ListBatchJobExecutionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBatchJobRestartPoints {
+  export type Input = ListBatchJobRestartPointsRequest;
+  export type Output = ListBatchJobRestartPointsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataSetExportHistory {
+  export type Input = ListDataSetExportHistoryRequest;
+  export type Output = ListDataSetExportHistoryResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataSetImportHistory {
+  export type Input = ListDataSetImportHistoryRequest;
+  export type Output = ListDataSetImportHistoryResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataSets {
+  export type Input = ListDataSetsRequest;
+  export type Output = ListDataSetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ExecutionTimeoutException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDeployments {
+  export type Input = ListDeploymentsRequest;
+  export type Output = ListDeploymentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironments {
+  export type Input = ListEnvironmentsRequest;
+  export type Output = ListEnvironmentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartApplication {
+  export type Input = StartApplicationRequest;
+  export type Output = StartApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartBatchJob {
+  export type Input = StartBatchJobRequest;
+  export type Output = StartBatchJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopApplication {
+  export type Input = StopApplicationRequest;
+  export type Output = StopApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateApplication {
+  export type Input = UpdateApplicationRequest;
+  export type Output = UpdateApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEnvironment {
+  export type Input = UpdateEnvironmentRequest;
+  export type Output = UpdateEnvironmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/mailmanager/index.ts
+++ b/src/services/mailmanager/index.ts
@@ -229,6 +229,299 @@ export declare class MailManager extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createAddonInstance(
+    input: CreateAddonInstanceRequest,
+  ): Effect.Effect<
+    CreateAddonInstanceResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAddonSubscription(
+    input: CreateAddonSubscriptionRequest,
+  ): Effect.Effect<
+    CreateAddonSubscriptionResponse,
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAddressList(
+    input: CreateAddressListRequest,
+  ): Effect.Effect<
+    CreateAddressListResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createArchive(
+    input: CreateArchiveRequest,
+  ): Effect.Effect<
+    CreateArchiveResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createIngressPoint(
+    input: CreateIngressPointRequest,
+  ): Effect.Effect<
+    CreateIngressPointResponse,
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRelay(
+    input: CreateRelayRequest,
+  ): Effect.Effect<
+    CreateRelayResponse,
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRuleSet(
+    input: CreateRuleSetRequest,
+  ): Effect.Effect<
+    CreateRuleSetResponse,
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTrafficPolicy(
+    input: CreateTrafficPolicyRequest,
+  ): Effect.Effect<
+    CreateTrafficPolicyResponse,
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAddonInstance(
+    input: DeleteAddonInstanceRequest,
+  ): Effect.Effect<
+    DeleteAddonInstanceResponse,
+    ConflictException | ValidationException | CommonAwsError
+  >;
+  deleteAddonSubscription(
+    input: DeleteAddonSubscriptionRequest,
+  ): Effect.Effect<
+    DeleteAddonSubscriptionResponse,
+    ConflictException | ValidationException | CommonAwsError
+  >;
+  deleteAddressList(
+    input: DeleteAddressListRequest,
+  ): Effect.Effect<
+    DeleteAddressListResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteArchive(
+    input: DeleteArchiveRequest,
+  ): Effect.Effect<
+    DeleteArchiveResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteIngressPoint(
+    input: DeleteIngressPointRequest,
+  ): Effect.Effect<
+    DeleteIngressPointResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRelay(
+    input: DeleteRelayRequest,
+  ): Effect.Effect<
+    DeleteRelayResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRuleSet(
+    input: DeleteRuleSetRequest,
+  ): Effect.Effect<
+    DeleteRuleSetResponse,
+    ConflictException | ValidationException | CommonAwsError
+  >;
+  deleteTrafficPolicy(
+    input: DeleteTrafficPolicyRequest,
+  ): Effect.Effect<
+    DeleteTrafficPolicyResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAddonInstance(
+    input: GetAddonInstanceRequest,
+  ): Effect.Effect<
+    GetAddonInstanceResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  getAddonSubscription(
+    input: GetAddonSubscriptionRequest,
+  ): Effect.Effect<
+    GetAddonSubscriptionResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  getAddressList(
+    input: GetAddressListRequest,
+  ): Effect.Effect<
+    GetAddressListResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getArchive(
+    input: GetArchiveRequest,
+  ): Effect.Effect<
+    GetArchiveResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getIngressPoint(
+    input: GetIngressPointRequest,
+  ): Effect.Effect<
+    GetIngressPointResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  getRelay(
+    input: GetRelayRequest,
+  ): Effect.Effect<
+    GetRelayResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  getRuleSet(
+    input: GetRuleSetRequest,
+  ): Effect.Effect<
+    GetRuleSetResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  getTrafficPolicy(
+    input: GetTrafficPolicyRequest,
+  ): Effect.Effect<
+    GetTrafficPolicyResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  listAddonInstances(
+    input: ListAddonInstancesRequest,
+  ): Effect.Effect<
+    ListAddonInstancesResponse,
+    ValidationException | CommonAwsError
+  >;
+  listAddonSubscriptions(
+    input: ListAddonSubscriptionsRequest,
+  ): Effect.Effect<
+    ListAddonSubscriptionsResponse,
+    ValidationException | CommonAwsError
+  >;
+  listAddressLists(
+    input: ListAddressListsRequest,
+  ): Effect.Effect<
+    ListAddressListsResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listArchives(
+    input: ListArchivesRequest,
+  ): Effect.Effect<
+    ListArchivesResponse,
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIngressPoints(
+    input: ListIngressPointsRequest,
+  ): Effect.Effect<
+    ListIngressPointsResponse,
+    ValidationException | CommonAwsError
+  >;
+  listRelays(
+    input: ListRelaysRequest,
+  ): Effect.Effect<ListRelaysResponse, ValidationException | CommonAwsError>;
+  listRuleSets(
+    input: ListRuleSetsRequest,
+  ): Effect.Effect<ListRuleSetsResponse, ValidationException | CommonAwsError>;
+  listTrafficPolicies(
+    input: ListTrafficPoliciesRequest,
+  ): Effect.Effect<
+    ListTrafficPoliciesResponse,
+    ValidationException | CommonAwsError
+  >;
+  updateArchive(
+    input: UpdateArchiveRequest,
+  ): Effect.Effect<
+    UpdateArchiveResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateIngressPoint(
+    input: UpdateIngressPointRequest,
+  ): Effect.Effect<
+    UpdateIngressPointResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateRelay(
+    input: UpdateRelayRequest,
+  ): Effect.Effect<
+    UpdateRelayResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateRuleSet(
+    input: UpdateRuleSetRequest,
+  ): Effect.Effect<
+    UpdateRuleSetResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTrafficPolicy(
+    input: UpdateTrafficPolicyRequest,
+  ): Effect.Effect<
+    UpdateTrafficPolicyResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Mailmanager extends MailManager {}
@@ -1789,6 +2082,345 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAddonInstance {
+  export type Input = CreateAddonInstanceRequest;
+  export type Output = CreateAddonInstanceResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAddonSubscription {
+  export type Input = CreateAddonSubscriptionRequest;
+  export type Output = CreateAddonSubscriptionResponse;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAddressList {
+  export type Input = CreateAddressListRequest;
+  export type Output = CreateAddressListResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateArchive {
+  export type Input = CreateArchiveRequest;
+  export type Output = CreateArchiveResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateIngressPoint {
+  export type Input = CreateIngressPointRequest;
+  export type Output = CreateIngressPointResponse;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRelay {
+  export type Input = CreateRelayRequest;
+  export type Output = CreateRelayResponse;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRuleSet {
+  export type Input = CreateRuleSetRequest;
+  export type Output = CreateRuleSetResponse;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTrafficPolicy {
+  export type Input = CreateTrafficPolicyRequest;
+  export type Output = CreateTrafficPolicyResponse;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAddonInstance {
+  export type Input = DeleteAddonInstanceRequest;
+  export type Output = DeleteAddonInstanceResponse;
+  export type Error = ConflictException | ValidationException | CommonAwsError;
+}
+
+export declare namespace DeleteAddonSubscription {
+  export type Input = DeleteAddonSubscriptionRequest;
+  export type Output = DeleteAddonSubscriptionResponse;
+  export type Error = ConflictException | ValidationException | CommonAwsError;
+}
+
+export declare namespace DeleteAddressList {
+  export type Input = DeleteAddressListRequest;
+  export type Output = DeleteAddressListResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteArchive {
+  export type Input = DeleteArchiveRequest;
+  export type Output = DeleteArchiveResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIngressPoint {
+  export type Input = DeleteIngressPointRequest;
+  export type Output = DeleteIngressPointResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRelay {
+  export type Input = DeleteRelayRequest;
+  export type Output = DeleteRelayResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRuleSet {
+  export type Input = DeleteRuleSetRequest;
+  export type Output = DeleteRuleSetResponse;
+  export type Error = ConflictException | ValidationException | CommonAwsError;
+}
+
+export declare namespace DeleteTrafficPolicy {
+  export type Input = DeleteTrafficPolicyRequest;
+  export type Output = DeleteTrafficPolicyResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAddonInstance {
+  export type Input = GetAddonInstanceRequest;
+  export type Output = GetAddonInstanceResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAddonSubscription {
+  export type Input = GetAddonSubscriptionRequest;
+  export type Output = GetAddonSubscriptionResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAddressList {
+  export type Input = GetAddressListRequest;
+  export type Output = GetAddressListResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetArchive {
+  export type Input = GetArchiveRequest;
+  export type Output = GetArchiveResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetIngressPoint {
+  export type Input = GetIngressPointRequest;
+  export type Output = GetIngressPointResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRelay {
+  export type Input = GetRelayRequest;
+  export type Output = GetRelayResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRuleSet {
+  export type Input = GetRuleSetRequest;
+  export type Output = GetRuleSetResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTrafficPolicy {
+  export type Input = GetTrafficPolicyRequest;
+  export type Output = GetTrafficPolicyResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAddonInstances {
+  export type Input = ListAddonInstancesRequest;
+  export type Output = ListAddonInstancesResponse;
+  export type Error = ValidationException | CommonAwsError;
+}
+
+export declare namespace ListAddonSubscriptions {
+  export type Input = ListAddonSubscriptionsRequest;
+  export type Output = ListAddonSubscriptionsResponse;
+  export type Error = ValidationException | CommonAwsError;
+}
+
+export declare namespace ListAddressLists {
+  export type Input = ListAddressListsRequest;
+  export type Output = ListAddressListsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListArchives {
+  export type Input = ListArchivesRequest;
+  export type Output = ListArchivesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIngressPoints {
+  export type Input = ListIngressPointsRequest;
+  export type Output = ListIngressPointsResponse;
+  export type Error = ValidationException | CommonAwsError;
+}
+
+export declare namespace ListRelays {
+  export type Input = ListRelaysRequest;
+  export type Output = ListRelaysResponse;
+  export type Error = ValidationException | CommonAwsError;
+}
+
+export declare namespace ListRuleSets {
+  export type Input = ListRuleSetsRequest;
+  export type Output = ListRuleSetsResponse;
+  export type Error = ValidationException | CommonAwsError;
+}
+
+export declare namespace ListTrafficPolicies {
+  export type Input = ListTrafficPoliciesRequest;
+  export type Output = ListTrafficPoliciesResponse;
+  export type Error = ValidationException | CommonAwsError;
+}
+
+export declare namespace UpdateArchive {
+  export type Input = UpdateArchiveRequest;
+  export type Output = UpdateArchiveResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateIngressPoint {
+  export type Input = UpdateIngressPointRequest;
+  export type Output = UpdateIngressPointResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRelay {
+  export type Input = UpdateRelayRequest;
+  export type Output = UpdateRelayResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRuleSet {
+  export type Input = UpdateRuleSetRequest;
+  export type Output = UpdateRuleSetResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTrafficPolicy {
+  export type Input = UpdateTrafficPolicyRequest;
+  export type Output = UpdateTrafficPolicyResponse;
   export type Error =
     | ConflictException
     | ResourceNotFoundException

--- a/src/services/marketplace-deployment/index.ts
+++ b/src/services/marketplace-deployment/index.ts
@@ -38,6 +38,19 @@ export declare class MarketplaceDeployment extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  putDeploymentParameter(
+    input: PutDeploymentParameterRequest,
+  ): Effect.Effect<
+    PutDeploymentParameterResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -166,6 +179,20 @@ export declare namespace UntagResource {
     | ConflictException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutDeploymentParameter {
+  export type Input = PutDeploymentParameterRequest;
+  export type Output = PutDeploymentParameterResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/mediaconnect/index.ts
+++ b/src/services/mediaconnect/index.ts
@@ -40,6 +40,590 @@ export declare class MediaConnect extends AWSServiceClient {
     | NotFoundException
     | CommonAwsError
   >;
+  addBridgeOutputs(
+    input: AddBridgeOutputsRequest,
+  ): Effect.Effect<
+    AddBridgeOutputsResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  addBridgeSources(
+    input: AddBridgeSourcesRequest,
+  ): Effect.Effect<
+    AddBridgeSourcesResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  addFlowMediaStreams(
+    input: AddFlowMediaStreamsRequest,
+  ): Effect.Effect<
+    AddFlowMediaStreamsResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  addFlowOutputs(
+    input: AddFlowOutputsRequest,
+  ): Effect.Effect<
+    AddFlowOutputsResponse,
+    | AddFlowOutputs420Exception
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  addFlowSources(
+    input: AddFlowSourcesRequest,
+  ): Effect.Effect<
+    AddFlowSourcesResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  addFlowVpcInterfaces(
+    input: AddFlowVpcInterfacesRequest,
+  ): Effect.Effect<
+    AddFlowVpcInterfacesResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createBridge(
+    input: CreateBridgeRequest,
+  ): Effect.Effect<
+    CreateBridgeResponse,
+    | BadRequestException
+    | ConflictException
+    | CreateBridge420Exception
+    | ForbiddenException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createFlow(
+    input: CreateFlowRequest,
+  ): Effect.Effect<
+    CreateFlowResponse,
+    | BadRequestException
+    | CreateFlow420Exception
+    | ForbiddenException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  createGateway(
+    input: CreateGatewayRequest,
+  ): Effect.Effect<
+    CreateGatewayResponse,
+    | BadRequestException
+    | ConflictException
+    | CreateGateway420Exception
+    | ForbiddenException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteBridge(
+    input: DeleteBridgeRequest,
+  ): Effect.Effect<
+    DeleteBridgeResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteFlow(
+    input: DeleteFlowRequest,
+  ): Effect.Effect<
+    DeleteFlowResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deleteGateway(
+    input: DeleteGatewayRequest,
+  ): Effect.Effect<
+    DeleteGatewayResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  deregisterGatewayInstance(
+    input: DeregisterGatewayInstanceRequest,
+  ): Effect.Effect<
+    DeregisterGatewayInstanceResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeBridge(
+    input: DescribeBridgeRequest,
+  ): Effect.Effect<
+    DescribeBridgeResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeFlow(
+    input: DescribeFlowRequest,
+  ): Effect.Effect<
+    DescribeFlowResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeFlowSourceMetadata(
+    input: DescribeFlowSourceMetadataRequest,
+  ): Effect.Effect<
+    DescribeFlowSourceMetadataResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeFlowSourceThumbnail(
+    input: DescribeFlowSourceThumbnailRequest,
+  ): Effect.Effect<
+    DescribeFlowSourceThumbnailResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeGateway(
+    input: DescribeGatewayRequest,
+  ): Effect.Effect<
+    DescribeGatewayResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeGatewayInstance(
+    input: DescribeGatewayInstanceRequest,
+  ): Effect.Effect<
+    DescribeGatewayInstanceResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeOffering(
+    input: DescribeOfferingRequest,
+  ): Effect.Effect<
+    DescribeOfferingResponse,
+    | BadRequestException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  describeReservation(
+    input: DescribeReservationRequest,
+  ): Effect.Effect<
+    DescribeReservationResponse,
+    | BadRequestException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  grantFlowEntitlements(
+    input: GrantFlowEntitlementsRequest,
+  ): Effect.Effect<
+    GrantFlowEntitlementsResponse,
+    | BadRequestException
+    | ForbiddenException
+    | GrantFlowEntitlements420Exception
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listBridges(
+    input: ListBridgesRequest,
+  ): Effect.Effect<
+    ListBridgesResponse,
+    | BadRequestException
+    | ConflictException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listFlows(
+    input: ListFlowsRequest,
+  ): Effect.Effect<
+    ListFlowsResponse,
+    | BadRequestException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listGatewayInstances(
+    input: ListGatewayInstancesRequest,
+  ): Effect.Effect<
+    ListGatewayInstancesResponse,
+    | BadRequestException
+    | ConflictException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listGateways(
+    input: ListGatewaysRequest,
+  ): Effect.Effect<
+    ListGatewaysResponse,
+    | BadRequestException
+    | ConflictException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listOfferings(
+    input: ListOfferingsRequest,
+  ): Effect.Effect<
+    ListOfferingsResponse,
+    | BadRequestException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  listReservations(
+    input: ListReservationsRequest,
+  ): Effect.Effect<
+    ListReservationsResponse,
+    | BadRequestException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  purchaseOffering(
+    input: PurchaseOfferingRequest,
+  ): Effect.Effect<
+    PurchaseOfferingResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  removeBridgeOutput(
+    input: RemoveBridgeOutputRequest,
+  ): Effect.Effect<
+    RemoveBridgeOutputResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  removeBridgeSource(
+    input: RemoveBridgeSourceRequest,
+  ): Effect.Effect<
+    RemoveBridgeSourceResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  removeFlowMediaStream(
+    input: RemoveFlowMediaStreamRequest,
+  ): Effect.Effect<
+    RemoveFlowMediaStreamResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  removeFlowOutput(
+    input: RemoveFlowOutputRequest,
+  ): Effect.Effect<
+    RemoveFlowOutputResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  removeFlowSource(
+    input: RemoveFlowSourceRequest,
+  ): Effect.Effect<
+    RemoveFlowSourceResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  removeFlowVpcInterface(
+    input: RemoveFlowVpcInterfaceRequest,
+  ): Effect.Effect<
+    RemoveFlowVpcInterfaceResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  revokeFlowEntitlement(
+    input: RevokeFlowEntitlementRequest,
+  ): Effect.Effect<
+    RevokeFlowEntitlementResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  startFlow(
+    input: StartFlowRequest,
+  ): Effect.Effect<
+    StartFlowResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  stopFlow(
+    input: StopFlowRequest,
+  ): Effect.Effect<
+    StopFlowResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateBridge(
+    input: UpdateBridgeRequest,
+  ): Effect.Effect<
+    UpdateBridgeResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateBridgeOutput(
+    input: UpdateBridgeOutputRequest,
+  ): Effect.Effect<
+    UpdateBridgeOutputResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateBridgeSource(
+    input: UpdateBridgeSourceRequest,
+  ): Effect.Effect<
+    UpdateBridgeSourceResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateBridgeState(
+    input: UpdateBridgeStateRequest,
+  ): Effect.Effect<
+    UpdateBridgeStateResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFlow(
+    input: UpdateFlowRequest,
+  ): Effect.Effect<
+    UpdateFlowResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFlowEntitlement(
+    input: UpdateFlowEntitlementRequest,
+  ): Effect.Effect<
+    UpdateFlowEntitlementResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFlowMediaStream(
+    input: UpdateFlowMediaStreamRequest,
+  ): Effect.Effect<
+    UpdateFlowMediaStreamResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFlowOutput(
+    input: UpdateFlowOutputRequest,
+  ): Effect.Effect<
+    UpdateFlowOutputResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateFlowSource(
+    input: UpdateFlowSourceRequest,
+  ): Effect.Effect<
+    UpdateFlowSourceResponse,
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
+  updateGatewayInstance(
+    input: UpdateGatewayInstanceRequest,
+  ): Effect.Effect<
+    UpdateGatewayInstanceResponse,
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError
+  >;
 }
 
 export declare class Mediaconnect extends MediaConnect {}
@@ -1347,5 +1931,637 @@ export declare namespace UntagResource {
     | BadRequestException
     | InternalServerErrorException
     | NotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace AddBridgeOutputs {
+  export type Input = AddBridgeOutputsRequest;
+  export type Output = AddBridgeOutputsResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace AddBridgeSources {
+  export type Input = AddBridgeSourcesRequest;
+  export type Output = AddBridgeSourcesResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace AddFlowMediaStreams {
+  export type Input = AddFlowMediaStreamsRequest;
+  export type Output = AddFlowMediaStreamsResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace AddFlowOutputs {
+  export type Input = AddFlowOutputsRequest;
+  export type Output = AddFlowOutputsResponse;
+  export type Error =
+    | AddFlowOutputs420Exception
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace AddFlowSources {
+  export type Input = AddFlowSourcesRequest;
+  export type Output = AddFlowSourcesResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace AddFlowVpcInterfaces {
+  export type Input = AddFlowVpcInterfacesRequest;
+  export type Output = AddFlowVpcInterfacesResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBridge {
+  export type Input = CreateBridgeRequest;
+  export type Output = CreateBridgeResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | CreateBridge420Exception
+    | ForbiddenException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateFlow {
+  export type Input = CreateFlowRequest;
+  export type Output = CreateFlowResponse;
+  export type Error =
+    | BadRequestException
+    | CreateFlow420Exception
+    | ForbiddenException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGateway {
+  export type Input = CreateGatewayRequest;
+  export type Output = CreateGatewayResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | CreateGateway420Exception
+    | ForbiddenException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteBridge {
+  export type Input = DeleteBridgeRequest;
+  export type Output = DeleteBridgeResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteFlow {
+  export type Input = DeleteFlowRequest;
+  export type Output = DeleteFlowResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGateway {
+  export type Input = DeleteGatewayRequest;
+  export type Output = DeleteGatewayResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DeregisterGatewayInstance {
+  export type Input = DeregisterGatewayInstanceRequest;
+  export type Output = DeregisterGatewayInstanceResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeBridge {
+  export type Input = DescribeBridgeRequest;
+  export type Output = DescribeBridgeResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeFlow {
+  export type Input = DescribeFlowRequest;
+  export type Output = DescribeFlowResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeFlowSourceMetadata {
+  export type Input = DescribeFlowSourceMetadataRequest;
+  export type Output = DescribeFlowSourceMetadataResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeFlowSourceThumbnail {
+  export type Input = DescribeFlowSourceThumbnailRequest;
+  export type Output = DescribeFlowSourceThumbnailResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeGateway {
+  export type Input = DescribeGatewayRequest;
+  export type Output = DescribeGatewayResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeGatewayInstance {
+  export type Input = DescribeGatewayInstanceRequest;
+  export type Output = DescribeGatewayInstanceResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeOffering {
+  export type Input = DescribeOfferingRequest;
+  export type Output = DescribeOfferingResponse;
+  export type Error =
+    | BadRequestException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeReservation {
+  export type Input = DescribeReservationRequest;
+  export type Output = DescribeReservationResponse;
+  export type Error =
+    | BadRequestException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace GrantFlowEntitlements {
+  export type Input = GrantFlowEntitlementsRequest;
+  export type Output = GrantFlowEntitlementsResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | GrantFlowEntitlements420Exception
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListBridges {
+  export type Input = ListBridgesRequest;
+  export type Output = ListBridgesResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListFlows {
+  export type Input = ListFlowsRequest;
+  export type Output = ListFlowsResponse;
+  export type Error =
+    | BadRequestException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListGatewayInstances {
+  export type Input = ListGatewayInstancesRequest;
+  export type Output = ListGatewayInstancesResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListGateways {
+  export type Input = ListGatewaysRequest;
+  export type Output = ListGatewaysResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListOfferings {
+  export type Input = ListOfferingsRequest;
+  export type Output = ListOfferingsResponse;
+  export type Error =
+    | BadRequestException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace ListReservations {
+  export type Input = ListReservationsRequest;
+  export type Output = ListReservationsResponse;
+  export type Error =
+    | BadRequestException
+    | InternalServerErrorException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace PurchaseOffering {
+  export type Input = PurchaseOfferingRequest;
+  export type Output = PurchaseOfferingResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveBridgeOutput {
+  export type Input = RemoveBridgeOutputRequest;
+  export type Output = RemoveBridgeOutputResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveBridgeSource {
+  export type Input = RemoveBridgeSourceRequest;
+  export type Output = RemoveBridgeSourceResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveFlowMediaStream {
+  export type Input = RemoveFlowMediaStreamRequest;
+  export type Output = RemoveFlowMediaStreamResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveFlowOutput {
+  export type Input = RemoveFlowOutputRequest;
+  export type Output = RemoveFlowOutputResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveFlowSource {
+  export type Input = RemoveFlowSourceRequest;
+  export type Output = RemoveFlowSourceResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveFlowVpcInterface {
+  export type Input = RemoveFlowVpcInterfaceRequest;
+  export type Output = RemoveFlowVpcInterfaceResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace RevokeFlowEntitlement {
+  export type Input = RevokeFlowEntitlementRequest;
+  export type Output = RevokeFlowEntitlementResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace StartFlow {
+  export type Input = StartFlowRequest;
+  export type Output = StartFlowResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace StopFlow {
+  export type Input = StopFlowRequest;
+  export type Output = StopFlowResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBridge {
+  export type Input = UpdateBridgeRequest;
+  export type Output = UpdateBridgeResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBridgeOutput {
+  export type Input = UpdateBridgeOutputRequest;
+  export type Output = UpdateBridgeOutputResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBridgeSource {
+  export type Input = UpdateBridgeSourceRequest;
+  export type Output = UpdateBridgeSourceResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBridgeState {
+  export type Input = UpdateBridgeStateRequest;
+  export type Output = UpdateBridgeStateResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFlow {
+  export type Input = UpdateFlowRequest;
+  export type Output = UpdateFlowResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFlowEntitlement {
+  export type Input = UpdateFlowEntitlementRequest;
+  export type Output = UpdateFlowEntitlementResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFlowMediaStream {
+  export type Input = UpdateFlowMediaStreamRequest;
+  export type Output = UpdateFlowMediaStreamResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFlowOutput {
+  export type Input = UpdateFlowOutputRequest;
+  export type Output = UpdateFlowOutputResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateFlowSource {
+  export type Input = UpdateFlowSourceRequest;
+  export type Output = UpdateFlowSourceResponse;
+  export type Error =
+    | BadRequestException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGatewayInstance {
+  export type Input = UpdateGatewayInstanceRequest;
+  export type Output = UpdateGatewayInstanceResponse;
+  export type Error =
+    | BadRequestException
+    | ConflictException
+    | ForbiddenException
+    | InternalServerErrorException
+    | NotFoundException
+    | ServiceUnavailableException
+    | TooManyRequestsException
     | CommonAwsError;
 }

--- a/src/services/mediapackagev2/index.ts
+++ b/src/services/mediapackagev2/index.ts
@@ -15,6 +15,318 @@ export declare class MediaPackageV2 extends AWSServiceClient {
   untagResource(
     input: UntagResourceRequest,
   ): Effect.Effect<{}, ValidationException | CommonAwsError>;
+  cancelHarvestJob(
+    input: CancelHarvestJobRequest,
+  ): Effect.Effect<
+    CancelHarvestJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createChannel(
+    input: CreateChannelRequest,
+  ): Effect.Effect<
+    CreateChannelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createChannelGroup(
+    input: CreateChannelGroupRequest,
+  ): Effect.Effect<
+    CreateChannelGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createHarvestJob(
+    input: CreateHarvestJobRequest,
+  ): Effect.Effect<
+    CreateHarvestJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createOriginEndpoint(
+    input: CreateOriginEndpointRequest,
+  ): Effect.Effect<
+    CreateOriginEndpointResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteChannel(
+    input: DeleteChannelRequest,
+  ): Effect.Effect<
+    DeleteChannelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteChannelGroup(
+    input: DeleteChannelGroupRequest,
+  ): Effect.Effect<
+    DeleteChannelGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteChannelPolicy(
+    input: DeleteChannelPolicyRequest,
+  ): Effect.Effect<
+    DeleteChannelPolicyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteOriginEndpoint(
+    input: DeleteOriginEndpointRequest,
+  ): Effect.Effect<
+    DeleteOriginEndpointResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteOriginEndpointPolicy(
+    input: DeleteOriginEndpointPolicyRequest,
+  ): Effect.Effect<
+    DeleteOriginEndpointPolicyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getChannel(
+    input: GetChannelRequest,
+  ): Effect.Effect<
+    GetChannelResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getChannelGroup(
+    input: GetChannelGroupRequest,
+  ): Effect.Effect<
+    GetChannelGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getChannelPolicy(
+    input: GetChannelPolicyRequest,
+  ): Effect.Effect<
+    GetChannelPolicyResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getHarvestJob(
+    input: GetHarvestJobRequest,
+  ): Effect.Effect<
+    GetHarvestJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getOriginEndpoint(
+    input: GetOriginEndpointRequest,
+  ): Effect.Effect<
+    GetOriginEndpointResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getOriginEndpointPolicy(
+    input: GetOriginEndpointPolicyRequest,
+  ): Effect.Effect<
+    GetOriginEndpointPolicyResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listChannelGroups(
+    input: ListChannelGroupsRequest,
+  ): Effect.Effect<
+    ListChannelGroupsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listChannels(
+    input: ListChannelsRequest,
+  ): Effect.Effect<
+    ListChannelsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listHarvestJobs(
+    input: ListHarvestJobsRequest,
+  ): Effect.Effect<
+    ListHarvestJobsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listOriginEndpoints(
+    input: ListOriginEndpointsRequest,
+  ): Effect.Effect<
+    ListOriginEndpointsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putChannelPolicy(
+    input: PutChannelPolicyRequest,
+  ): Effect.Effect<
+    PutChannelPolicyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putOriginEndpointPolicy(
+    input: PutOriginEndpointPolicyRequest,
+  ): Effect.Effect<
+    PutOriginEndpointPolicyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  resetChannelState(
+    input: ResetChannelStateRequest,
+  ): Effect.Effect<
+    ResetChannelStateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  resetOriginEndpointState(
+    input: ResetOriginEndpointStateRequest,
+  ): Effect.Effect<
+    ResetOriginEndpointStateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateChannel(
+    input: UpdateChannelRequest,
+  ): Effect.Effect<
+    UpdateChannelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateChannelGroup(
+    input: UpdateChannelGroupRequest,
+  ): Effect.Effect<
+    UpdateChannelGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateOriginEndpoint(
+    input: UpdateOriginEndpointRequest,
+  ): Effect.Effect<
+    UpdateOriginEndpointResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Mediapackagev2 extends MediaPackageV2 {}
@@ -989,4 +1301,343 @@ export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = {};
   export type Error = ValidationException | CommonAwsError;
+}
+
+export declare namespace CancelHarvestJob {
+  export type Input = CancelHarvestJobRequest;
+  export type Output = CancelHarvestJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateChannel {
+  export type Input = CreateChannelRequest;
+  export type Output = CreateChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateChannelGroup {
+  export type Input = CreateChannelGroupRequest;
+  export type Output = CreateChannelGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateHarvestJob {
+  export type Input = CreateHarvestJobRequest;
+  export type Output = CreateHarvestJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateOriginEndpoint {
+  export type Input = CreateOriginEndpointRequest;
+  export type Output = CreateOriginEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteChannel {
+  export type Input = DeleteChannelRequest;
+  export type Output = DeleteChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteChannelGroup {
+  export type Input = DeleteChannelGroupRequest;
+  export type Output = DeleteChannelGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteChannelPolicy {
+  export type Input = DeleteChannelPolicyRequest;
+  export type Output = DeleteChannelPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteOriginEndpoint {
+  export type Input = DeleteOriginEndpointRequest;
+  export type Output = DeleteOriginEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteOriginEndpointPolicy {
+  export type Input = DeleteOriginEndpointPolicyRequest;
+  export type Output = DeleteOriginEndpointPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetChannel {
+  export type Input = GetChannelRequest;
+  export type Output = GetChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetChannelGroup {
+  export type Input = GetChannelGroupRequest;
+  export type Output = GetChannelGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetChannelPolicy {
+  export type Input = GetChannelPolicyRequest;
+  export type Output = GetChannelPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetHarvestJob {
+  export type Input = GetHarvestJobRequest;
+  export type Output = GetHarvestJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetOriginEndpoint {
+  export type Input = GetOriginEndpointRequest;
+  export type Output = GetOriginEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetOriginEndpointPolicy {
+  export type Input = GetOriginEndpointPolicyRequest;
+  export type Output = GetOriginEndpointPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListChannelGroups {
+  export type Input = ListChannelGroupsRequest;
+  export type Output = ListChannelGroupsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListChannels {
+  export type Input = ListChannelsRequest;
+  export type Output = ListChannelsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListHarvestJobs {
+  export type Input = ListHarvestJobsRequest;
+  export type Output = ListHarvestJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListOriginEndpoints {
+  export type Input = ListOriginEndpointsRequest;
+  export type Output = ListOriginEndpointsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutChannelPolicy {
+  export type Input = PutChannelPolicyRequest;
+  export type Output = PutChannelPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutOriginEndpointPolicy {
+  export type Input = PutOriginEndpointPolicyRequest;
+  export type Output = PutOriginEndpointPolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ResetChannelState {
+  export type Input = ResetChannelStateRequest;
+  export type Output = ResetChannelStateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ResetOriginEndpointState {
+  export type Input = ResetOriginEndpointStateRequest;
+  export type Output = ResetOriginEndpointStateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateChannel {
+  export type Input = UpdateChannelRequest;
+  export type Output = UpdateChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateChannelGroup {
+  export type Input = UpdateChannelGroupRequest;
+  export type Output = UpdateChannelGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateOriginEndpoint {
+  export type Input = UpdateOriginEndpointRequest;
+  export type Output = UpdateOriginEndpointResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
 }

--- a/src/services/mediatailor/index.ts
+++ b/src/services/mediatailor/index.ts
@@ -24,6 +24,123 @@ export declare class MediaTailor extends AWSServiceClient {
   untagResource(
     input: UntagResourceRequest,
   ): Effect.Effect<{}, BadRequestException | CommonAwsError>;
+  configureLogsForChannel(
+    input: ConfigureLogsForChannelRequest,
+  ): Effect.Effect<ConfigureLogsForChannelResponse, CommonAwsError>;
+  createChannel(
+    input: CreateChannelRequest,
+  ): Effect.Effect<CreateChannelResponse, CommonAwsError>;
+  createLiveSource(
+    input: CreateLiveSourceRequest,
+  ): Effect.Effect<CreateLiveSourceResponse, CommonAwsError>;
+  createPrefetchSchedule(
+    input: CreatePrefetchScheduleRequest,
+  ): Effect.Effect<CreatePrefetchScheduleResponse, CommonAwsError>;
+  createProgram(
+    input: CreateProgramRequest,
+  ): Effect.Effect<CreateProgramResponse, CommonAwsError>;
+  createSourceLocation(
+    input: CreateSourceLocationRequest,
+  ): Effect.Effect<CreateSourceLocationResponse, CommonAwsError>;
+  createVodSource(
+    input: CreateVodSourceRequest,
+  ): Effect.Effect<CreateVodSourceResponse, CommonAwsError>;
+  deleteChannel(
+    input: DeleteChannelRequest,
+  ): Effect.Effect<DeleteChannelResponse, CommonAwsError>;
+  deleteChannelPolicy(
+    input: DeleteChannelPolicyRequest,
+  ): Effect.Effect<DeleteChannelPolicyResponse, CommonAwsError>;
+  deleteLiveSource(
+    input: DeleteLiveSourceRequest,
+  ): Effect.Effect<DeleteLiveSourceResponse, CommonAwsError>;
+  deletePlaybackConfiguration(
+    input: DeletePlaybackConfigurationRequest,
+  ): Effect.Effect<DeletePlaybackConfigurationResponse, CommonAwsError>;
+  deletePrefetchSchedule(
+    input: DeletePrefetchScheduleRequest,
+  ): Effect.Effect<DeletePrefetchScheduleResponse, CommonAwsError>;
+  deleteProgram(
+    input: DeleteProgramRequest,
+  ): Effect.Effect<DeleteProgramResponse, CommonAwsError>;
+  deleteSourceLocation(
+    input: DeleteSourceLocationRequest,
+  ): Effect.Effect<DeleteSourceLocationResponse, CommonAwsError>;
+  deleteVodSource(
+    input: DeleteVodSourceRequest,
+  ): Effect.Effect<DeleteVodSourceResponse, CommonAwsError>;
+  describeChannel(
+    input: DescribeChannelRequest,
+  ): Effect.Effect<DescribeChannelResponse, CommonAwsError>;
+  describeLiveSource(
+    input: DescribeLiveSourceRequest,
+  ): Effect.Effect<DescribeLiveSourceResponse, CommonAwsError>;
+  describeProgram(
+    input: DescribeProgramRequest,
+  ): Effect.Effect<DescribeProgramResponse, CommonAwsError>;
+  describeSourceLocation(
+    input: DescribeSourceLocationRequest,
+  ): Effect.Effect<DescribeSourceLocationResponse, CommonAwsError>;
+  describeVodSource(
+    input: DescribeVodSourceRequest,
+  ): Effect.Effect<DescribeVodSourceResponse, CommonAwsError>;
+  getChannelPolicy(
+    input: GetChannelPolicyRequest,
+  ): Effect.Effect<GetChannelPolicyResponse, CommonAwsError>;
+  getChannelSchedule(
+    input: GetChannelScheduleRequest,
+  ): Effect.Effect<GetChannelScheduleResponse, CommonAwsError>;
+  getPlaybackConfiguration(
+    input: GetPlaybackConfigurationRequest,
+  ): Effect.Effect<GetPlaybackConfigurationResponse, CommonAwsError>;
+  getPrefetchSchedule(
+    input: GetPrefetchScheduleRequest,
+  ): Effect.Effect<GetPrefetchScheduleResponse, CommonAwsError>;
+  listChannels(
+    input: ListChannelsRequest,
+  ): Effect.Effect<ListChannelsResponse, CommonAwsError>;
+  listLiveSources(
+    input: ListLiveSourcesRequest,
+  ): Effect.Effect<ListLiveSourcesResponse, CommonAwsError>;
+  listPlaybackConfigurations(
+    input: ListPlaybackConfigurationsRequest,
+  ): Effect.Effect<ListPlaybackConfigurationsResponse, CommonAwsError>;
+  listPrefetchSchedules(
+    input: ListPrefetchSchedulesRequest,
+  ): Effect.Effect<ListPrefetchSchedulesResponse, CommonAwsError>;
+  listSourceLocations(
+    input: ListSourceLocationsRequest,
+  ): Effect.Effect<ListSourceLocationsResponse, CommonAwsError>;
+  listVodSources(
+    input: ListVodSourcesRequest,
+  ): Effect.Effect<ListVodSourcesResponse, CommonAwsError>;
+  putChannelPolicy(
+    input: PutChannelPolicyRequest,
+  ): Effect.Effect<PutChannelPolicyResponse, CommonAwsError>;
+  putPlaybackConfiguration(
+    input: PutPlaybackConfigurationRequest,
+  ): Effect.Effect<PutPlaybackConfigurationResponse, CommonAwsError>;
+  startChannel(
+    input: StartChannelRequest,
+  ): Effect.Effect<StartChannelResponse, CommonAwsError>;
+  stopChannel(
+    input: StopChannelRequest,
+  ): Effect.Effect<StopChannelResponse, CommonAwsError>;
+  updateChannel(
+    input: UpdateChannelRequest,
+  ): Effect.Effect<UpdateChannelResponse, CommonAwsError>;
+  updateLiveSource(
+    input: UpdateLiveSourceRequest,
+  ): Effect.Effect<UpdateLiveSourceResponse, CommonAwsError>;
+  updateProgram(
+    input: UpdateProgramRequest,
+  ): Effect.Effect<UpdateProgramResponse, CommonAwsError>;
+  updateSourceLocation(
+    input: UpdateSourceLocationRequest,
+  ): Effect.Effect<UpdateSourceLocationResponse, CommonAwsError>;
+  updateVodSource(
+    input: UpdateVodSourceRequest,
+  ): Effect.Effect<UpdateVodSourceResponse, CommonAwsError>;
 }
 
 export declare class Mediatailor extends MediaTailor {}
@@ -1060,4 +1177,238 @@ export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = {};
   export type Error = BadRequestException | CommonAwsError;
+}
+
+export declare namespace ConfigureLogsForChannel {
+  export type Input = ConfigureLogsForChannelRequest;
+  export type Output = ConfigureLogsForChannelResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateChannel {
+  export type Input = CreateChannelRequest;
+  export type Output = CreateChannelResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateLiveSource {
+  export type Input = CreateLiveSourceRequest;
+  export type Output = CreateLiveSourceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreatePrefetchSchedule {
+  export type Input = CreatePrefetchScheduleRequest;
+  export type Output = CreatePrefetchScheduleResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateProgram {
+  export type Input = CreateProgramRequest;
+  export type Output = CreateProgramResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateSourceLocation {
+  export type Input = CreateSourceLocationRequest;
+  export type Output = CreateSourceLocationResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateVodSource {
+  export type Input = CreateVodSourceRequest;
+  export type Output = CreateVodSourceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteChannel {
+  export type Input = DeleteChannelRequest;
+  export type Output = DeleteChannelResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteChannelPolicy {
+  export type Input = DeleteChannelPolicyRequest;
+  export type Output = DeleteChannelPolicyResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteLiveSource {
+  export type Input = DeleteLiveSourceRequest;
+  export type Output = DeleteLiveSourceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeletePlaybackConfiguration {
+  export type Input = DeletePlaybackConfigurationRequest;
+  export type Output = DeletePlaybackConfigurationResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeletePrefetchSchedule {
+  export type Input = DeletePrefetchScheduleRequest;
+  export type Output = DeletePrefetchScheduleResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteProgram {
+  export type Input = DeleteProgramRequest;
+  export type Output = DeleteProgramResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteSourceLocation {
+  export type Input = DeleteSourceLocationRequest;
+  export type Output = DeleteSourceLocationResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DeleteVodSource {
+  export type Input = DeleteVodSourceRequest;
+  export type Output = DeleteVodSourceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DescribeChannel {
+  export type Input = DescribeChannelRequest;
+  export type Output = DescribeChannelResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DescribeLiveSource {
+  export type Input = DescribeLiveSourceRequest;
+  export type Output = DescribeLiveSourceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DescribeProgram {
+  export type Input = DescribeProgramRequest;
+  export type Output = DescribeProgramResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DescribeSourceLocation {
+  export type Input = DescribeSourceLocationRequest;
+  export type Output = DescribeSourceLocationResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace DescribeVodSource {
+  export type Input = DescribeVodSourceRequest;
+  export type Output = DescribeVodSourceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetChannelPolicy {
+  export type Input = GetChannelPolicyRequest;
+  export type Output = GetChannelPolicyResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetChannelSchedule {
+  export type Input = GetChannelScheduleRequest;
+  export type Output = GetChannelScheduleResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetPlaybackConfiguration {
+  export type Input = GetPlaybackConfigurationRequest;
+  export type Output = GetPlaybackConfigurationResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetPrefetchSchedule {
+  export type Input = GetPrefetchScheduleRequest;
+  export type Output = GetPrefetchScheduleResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListChannels {
+  export type Input = ListChannelsRequest;
+  export type Output = ListChannelsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListLiveSources {
+  export type Input = ListLiveSourcesRequest;
+  export type Output = ListLiveSourcesResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListPlaybackConfigurations {
+  export type Input = ListPlaybackConfigurationsRequest;
+  export type Output = ListPlaybackConfigurationsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListPrefetchSchedules {
+  export type Input = ListPrefetchSchedulesRequest;
+  export type Output = ListPrefetchSchedulesResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListSourceLocations {
+  export type Input = ListSourceLocationsRequest;
+  export type Output = ListSourceLocationsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListVodSources {
+  export type Input = ListVodSourcesRequest;
+  export type Output = ListVodSourcesResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace PutChannelPolicy {
+  export type Input = PutChannelPolicyRequest;
+  export type Output = PutChannelPolicyResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace PutPlaybackConfiguration {
+  export type Input = PutPlaybackConfigurationRequest;
+  export type Output = PutPlaybackConfigurationResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace StartChannel {
+  export type Input = StartChannelRequest;
+  export type Output = StartChannelResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace StopChannel {
+  export type Input = StopChannelRequest;
+  export type Output = StopChannelResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateChannel {
+  export type Input = UpdateChannelRequest;
+  export type Output = UpdateChannelResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateLiveSource {
+  export type Input = UpdateLiveSourceRequest;
+  export type Output = UpdateLiveSourceResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateProgram {
+  export type Input = UpdateProgramRequest;
+  export type Output = UpdateProgramResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateSourceLocation {
+  export type Input = UpdateSourceLocationRequest;
+  export type Output = UpdateSourceLocationResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateVodSource {
+  export type Input = UpdateVodSourceRequest;
+  export type Output = UpdateVodSourceResponse;
+  export type Error = CommonAwsError;
 }

--- a/src/services/medical-imaging/index.ts
+++ b/src/services/medical-imaging/index.ts
@@ -171,6 +171,51 @@ export declare class MedicalImaging extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createDatastore(
+    input: CreateDatastoreRequest,
+  ): Effect.Effect<
+    CreateDatastoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDatastore(
+    input: DeleteDatastoreRequest,
+  ): Effect.Effect<
+    DeleteDatastoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDatastore(
+    input: GetDatastoreRequest,
+  ): Effect.Effect<
+    GetDatastoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDatastores(
+    input: ListDatastoresRequest,
+  ): Effect.Effect<
+    ListDatastoresResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -835,6 +880,55 @@ export declare namespace UpdateImageSetMetadata {
     | InternalServerException
     | ResourceNotFoundException
     | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDatastore {
+  export type Input = CreateDatastoreRequest;
+  export type Output = CreateDatastoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDatastore {
+  export type Input = DeleteDatastoreRequest;
+  export type Output = DeleteDatastoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDatastore {
+  export type Input = GetDatastoreRequest;
+  export type Output = GetDatastoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDatastores {
+  export type Input = ListDatastoresRequest;
+  export type Output = ListDatastoresResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/mgn/index.ts
+++ b/src/services/mgn/index.ts
@@ -48,6 +48,570 @@ export declare class mgn extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  archiveApplication(
+    input: ArchiveApplicationRequest,
+  ): Effect.Effect<
+    Application,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  archiveWave(
+    input: ArchiveWaveRequest,
+  ): Effect.Effect<
+    Wave,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  associateApplications(
+    input: AssociateApplicationsRequest,
+  ): Effect.Effect<
+    AssociateApplicationsResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  associateSourceServers(
+    input: AssociateSourceServersRequest,
+  ): Effect.Effect<
+    AssociateSourceServersResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  changeServerLifeCycleState(
+    input: ChangeServerLifeCycleStateRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createApplication(
+    input: CreateApplicationRequest,
+  ): Effect.Effect<
+    Application,
+    | ConflictException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  createConnector(
+    input: CreateConnectorRequest,
+  ): Effect.Effect<
+    Connector,
+    UninitializedAccountException | ValidationException | CommonAwsError
+  >;
+  createLaunchConfigurationTemplate(
+    input: CreateLaunchConfigurationTemplateRequest,
+  ): Effect.Effect<
+    LaunchConfigurationTemplate,
+    | AccessDeniedException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createReplicationConfigurationTemplate(
+    input: CreateReplicationConfigurationTemplateRequest,
+  ): Effect.Effect<
+    ReplicationConfigurationTemplate,
+    | AccessDeniedException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWave(
+    input: CreateWaveRequest,
+  ): Effect.Effect<
+    Wave,
+    | ConflictException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteApplication(
+    input: DeleteApplicationRequest,
+  ): Effect.Effect<
+    DeleteApplicationResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteConnector(
+    input: DeleteConnectorRequest,
+  ): Effect.Effect<
+    {},
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteJob(
+    input: DeleteJobRequest,
+  ): Effect.Effect<
+    DeleteJobResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteLaunchConfigurationTemplate(
+    input: DeleteLaunchConfigurationTemplateRequest,
+  ): Effect.Effect<
+    DeleteLaunchConfigurationTemplateResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteReplicationConfigurationTemplate(
+    input: DeleteReplicationConfigurationTemplateRequest,
+  ): Effect.Effect<
+    DeleteReplicationConfigurationTemplateResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteSourceServer(
+    input: DeleteSourceServerRequest,
+  ): Effect.Effect<
+    DeleteSourceServerResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  deleteVcenterClient(
+    input: DeleteVcenterClientRequest,
+  ): Effect.Effect<
+    {},
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWave(
+    input: DeleteWaveRequest,
+  ): Effect.Effect<
+    DeleteWaveResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  describeJobLogItems(
+    input: DescribeJobLogItemsRequest,
+  ): Effect.Effect<
+    DescribeJobLogItemsResponse,
+    UninitializedAccountException | ValidationException | CommonAwsError
+  >;
+  describeJobs(
+    input: DescribeJobsRequest,
+  ): Effect.Effect<
+    DescribeJobsResponse,
+    UninitializedAccountException | ValidationException | CommonAwsError
+  >;
+  describeLaunchConfigurationTemplates(
+    input: DescribeLaunchConfigurationTemplatesRequest,
+  ): Effect.Effect<
+    DescribeLaunchConfigurationTemplatesResponse,
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeReplicationConfigurationTemplates(
+    input: DescribeReplicationConfigurationTemplatesRequest,
+  ): Effect.Effect<
+    DescribeReplicationConfigurationTemplatesResponse,
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeSourceServers(
+    input: DescribeSourceServersRequest,
+  ): Effect.Effect<
+    DescribeSourceServersResponse,
+    UninitializedAccountException | ValidationException | CommonAwsError
+  >;
+  describeVcenterClients(
+    input: DescribeVcenterClientsRequest,
+  ): Effect.Effect<
+    DescribeVcenterClientsResponse,
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateApplications(
+    input: DisassociateApplicationsRequest,
+  ): Effect.Effect<
+    DisassociateApplicationsResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  disassociateSourceServers(
+    input: DisassociateSourceServersRequest,
+  ): Effect.Effect<
+    DisassociateSourceServersResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  disconnectFromService(
+    input: DisconnectFromServiceRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  finalizeCutover(
+    input: FinalizeCutoverRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getLaunchConfiguration(
+    input: GetLaunchConfigurationRequest,
+  ): Effect.Effect<
+    LaunchConfiguration,
+    ResourceNotFoundException | UninitializedAccountException | CommonAwsError
+  >;
+  getReplicationConfiguration(
+    input: GetReplicationConfigurationRequest,
+  ): Effect.Effect<
+    ReplicationConfiguration,
+    ResourceNotFoundException | UninitializedAccountException | CommonAwsError
+  >;
+  listApplications(
+    input: ListApplicationsRequest,
+  ): Effect.Effect<
+    ListApplicationsResponse,
+    UninitializedAccountException | CommonAwsError
+  >;
+  listConnectors(
+    input: ListConnectorsRequest,
+  ): Effect.Effect<
+    ListConnectorsResponse,
+    UninitializedAccountException | ValidationException | CommonAwsError
+  >;
+  listExportErrors(
+    input: ListExportErrorsRequest,
+  ): Effect.Effect<
+    ListExportErrorsResponse,
+    UninitializedAccountException | ValidationException | CommonAwsError
+  >;
+  listExports(
+    input: ListExportsRequest,
+  ): Effect.Effect<
+    ListExportsResponse,
+    UninitializedAccountException | CommonAwsError
+  >;
+  listImportErrors(
+    input: ListImportErrorsRequest,
+  ): Effect.Effect<
+    ListImportErrorsResponse,
+    UninitializedAccountException | ValidationException | CommonAwsError
+  >;
+  listImports(
+    input: ListImportsRequest,
+  ): Effect.Effect<
+    ListImportsResponse,
+    UninitializedAccountException | ValidationException | CommonAwsError
+  >;
+  listSourceServerActions(
+    input: ListSourceServerActionsRequest,
+  ): Effect.Effect<
+    ListSourceServerActionsResponse,
+    ResourceNotFoundException | UninitializedAccountException | CommonAwsError
+  >;
+  listTemplateActions(
+    input: ListTemplateActionsRequest,
+  ): Effect.Effect<
+    ListTemplateActionsResponse,
+    ResourceNotFoundException | UninitializedAccountException | CommonAwsError
+  >;
+  listWaves(
+    input: ListWavesRequest,
+  ): Effect.Effect<
+    ListWavesResponse,
+    UninitializedAccountException | CommonAwsError
+  >;
+  markAsArchived(
+    input: MarkAsArchivedRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  pauseReplication(
+    input: PauseReplicationRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putSourceServerAction(
+    input: PutSourceServerActionRequest,
+  ): Effect.Effect<
+    SourceServerActionDocument,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putTemplateAction(
+    input: PutTemplateActionRequest,
+  ): Effect.Effect<
+    TemplateActionDocument,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  removeSourceServerAction(
+    input: RemoveSourceServerActionRequest,
+  ): Effect.Effect<
+    RemoveSourceServerActionResponse,
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  removeTemplateAction(
+    input: RemoveTemplateActionRequest,
+  ): Effect.Effect<
+    RemoveTemplateActionResponse,
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  resumeReplication(
+    input: ResumeReplicationRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  retryDataReplication(
+    input: RetryDataReplicationRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startCutover(
+    input: StartCutoverRequest,
+  ): Effect.Effect<
+    StartCutoverResponse,
+    | ConflictException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startExport(
+    input: StartExportRequest,
+  ): Effect.Effect<
+    StartExportResponse,
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startImport(
+    input: StartImportRequest,
+  ): Effect.Effect<
+    StartImportResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startReplication(
+    input: StartReplicationRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startTest(
+    input: StartTestRequest,
+  ): Effect.Effect<
+    StartTestResponse,
+    | ConflictException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopReplication(
+    input: StopReplicationRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  terminateTargetInstances(
+    input: TerminateTargetInstancesRequest,
+  ): Effect.Effect<
+    TerminateTargetInstancesResponse,
+    | ConflictException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  unarchiveApplication(
+    input: UnarchiveApplicationRequest,
+  ): Effect.Effect<
+    Application,
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  unarchiveWave(
+    input: UnarchiveWaveRequest,
+  ): Effect.Effect<
+    Wave,
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  updateApplication(
+    input: UpdateApplicationRequest,
+  ): Effect.Effect<
+    Application,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  updateConnector(
+    input: UpdateConnectorRequest,
+  ): Effect.Effect<
+    Connector,
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLaunchConfiguration(
+    input: UpdateLaunchConfigurationRequest,
+  ): Effect.Effect<
+    LaunchConfiguration,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLaunchConfigurationTemplate(
+    input: UpdateLaunchConfigurationTemplateRequest,
+  ): Effect.Effect<
+    LaunchConfigurationTemplate,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateReplicationConfiguration(
+    input: UpdateReplicationConfigurationRequest,
+  ): Effect.Effect<
+    ReplicationConfiguration,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateReplicationConfigurationTemplate(
+    input: UpdateReplicationConfigurationTemplateRequest,
+  ): Effect.Effect<
+    ReplicationConfigurationTemplate,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSourceServer(
+    input: UpdateSourceServerRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
+  updateSourceServerReplicationType(
+    input: UpdateSourceServerReplicationTypeRequest,
+  ): Effect.Effect<
+    SourceServer,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWave(
+    input: UpdateWaveRequest,
+  ): Effect.Effect<
+    Wave,
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError
+  >;
 }
 
 export declare class Mgn extends mgn {}
@@ -1401,5 +1965,655 @@ export declare namespace UntagResource {
     | ResourceNotFoundException
     | ThrottlingException
     | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ArchiveApplication {
+  export type Input = ArchiveApplicationRequest;
+  export type Output = Application;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace ArchiveWave {
+  export type Input = ArchiveWaveRequest;
+  export type Output = Wave;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateApplications {
+  export type Input = AssociateApplicationsRequest;
+  export type Output = AssociateApplicationsResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateSourceServers {
+  export type Input = AssociateSourceServersRequest;
+  export type Output = AssociateSourceServersResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace ChangeServerLifeCycleState {
+  export type Input = ChangeServerLifeCycleStateRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateApplication {
+  export type Input = CreateApplicationRequest;
+  export type Output = Application;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConnector {
+  export type Input = CreateConnectorRequest;
+  export type Output = Connector;
+  export type Error =
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateLaunchConfigurationTemplate {
+  export type Input = CreateLaunchConfigurationTemplateRequest;
+  export type Output = LaunchConfigurationTemplate;
+  export type Error =
+    | AccessDeniedException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateReplicationConfigurationTemplate {
+  export type Input = CreateReplicationConfigurationTemplateRequest;
+  export type Output = ReplicationConfigurationTemplate;
+  export type Error =
+    | AccessDeniedException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWave {
+  export type Input = CreateWaveRequest;
+  export type Output = Wave;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplication {
+  export type Input = DeleteApplicationRequest;
+  export type Output = DeleteApplicationResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConnector {
+  export type Input = DeleteConnectorRequest;
+  export type Output = {};
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteJob {
+  export type Input = DeleteJobRequest;
+  export type Output = DeleteJobResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLaunchConfigurationTemplate {
+  export type Input = DeleteLaunchConfigurationTemplateRequest;
+  export type Output = DeleteLaunchConfigurationTemplateResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteReplicationConfigurationTemplate {
+  export type Input = DeleteReplicationConfigurationTemplateRequest;
+  export type Output = DeleteReplicationConfigurationTemplateResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSourceServer {
+  export type Input = DeleteSourceServerRequest;
+  export type Output = DeleteSourceServerResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVcenterClient {
+  export type Input = DeleteVcenterClientRequest;
+  export type Output = {};
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWave {
+  export type Input = DeleteWaveRequest;
+  export type Output = DeleteWaveResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeJobLogItems {
+  export type Input = DescribeJobLogItemsRequest;
+  export type Output = DescribeJobLogItemsResponse;
+  export type Error =
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeJobs {
+  export type Input = DescribeJobsRequest;
+  export type Output = DescribeJobsResponse;
+  export type Error =
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeLaunchConfigurationTemplates {
+  export type Input = DescribeLaunchConfigurationTemplatesRequest;
+  export type Output = DescribeLaunchConfigurationTemplatesResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeReplicationConfigurationTemplates {
+  export type Input = DescribeReplicationConfigurationTemplatesRequest;
+  export type Output = DescribeReplicationConfigurationTemplatesResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeSourceServers {
+  export type Input = DescribeSourceServersRequest;
+  export type Output = DescribeSourceServersResponse;
+  export type Error =
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeVcenterClients {
+  export type Input = DescribeVcenterClientsRequest;
+  export type Output = DescribeVcenterClientsResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateApplications {
+  export type Input = DisassociateApplicationsRequest;
+  export type Output = DisassociateApplicationsResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateSourceServers {
+  export type Input = DisassociateSourceServersRequest;
+  export type Output = DisassociateSourceServersResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace DisconnectFromService {
+  export type Input = DisconnectFromServiceRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace FinalizeCutover {
+  export type Input = FinalizeCutoverRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetLaunchConfiguration {
+  export type Input = GetLaunchConfigurationRequest;
+  export type Output = LaunchConfiguration;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace GetReplicationConfiguration {
+  export type Input = GetReplicationConfigurationRequest;
+  export type Output = ReplicationConfiguration;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplications {
+  export type Input = ListApplicationsRequest;
+  export type Output = ListApplicationsResponse;
+  export type Error = UninitializedAccountException | CommonAwsError;
+}
+
+export declare namespace ListConnectors {
+  export type Input = ListConnectorsRequest;
+  export type Output = ListConnectorsResponse;
+  export type Error =
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListExportErrors {
+  export type Input = ListExportErrorsRequest;
+  export type Output = ListExportErrorsResponse;
+  export type Error =
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListExports {
+  export type Input = ListExportsRequest;
+  export type Output = ListExportsResponse;
+  export type Error = UninitializedAccountException | CommonAwsError;
+}
+
+export declare namespace ListImportErrors {
+  export type Input = ListImportErrorsRequest;
+  export type Output = ListImportErrorsResponse;
+  export type Error =
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListImports {
+  export type Input = ListImportsRequest;
+  export type Output = ListImportsResponse;
+  export type Error =
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSourceServerActions {
+  export type Input = ListSourceServerActionsRequest;
+  export type Output = ListSourceServerActionsResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace ListTemplateActions {
+  export type Input = ListTemplateActionsRequest;
+  export type Output = ListTemplateActionsResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace ListWaves {
+  export type Input = ListWavesRequest;
+  export type Output = ListWavesResponse;
+  export type Error = UninitializedAccountException | CommonAwsError;
+}
+
+export declare namespace MarkAsArchived {
+  export type Input = MarkAsArchivedRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace PauseReplication {
+  export type Input = PauseReplicationRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutSourceServerAction {
+  export type Input = PutSourceServerActionRequest;
+  export type Output = SourceServerActionDocument;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutTemplateAction {
+  export type Input = PutTemplateActionRequest;
+  export type Output = TemplateActionDocument;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveSourceServerAction {
+  export type Input = RemoveSourceServerActionRequest;
+  export type Output = RemoveSourceServerActionResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveTemplateAction {
+  export type Input = RemoveTemplateActionRequest;
+  export type Output = RemoveTemplateActionResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ResumeReplication {
+  export type Input = ResumeReplicationRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RetryDataReplication {
+  export type Input = RetryDataReplicationRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartCutover {
+  export type Input = StartCutoverRequest;
+  export type Output = StartCutoverResponse;
+  export type Error =
+    | ConflictException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartExport {
+  export type Input = StartExportRequest;
+  export type Output = StartExportResponse;
+  export type Error =
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartImport {
+  export type Input = StartImportRequest;
+  export type Output = StartImportResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartReplication {
+  export type Input = StartReplicationRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartTest {
+  export type Input = StartTestRequest;
+  export type Output = StartTestResponse;
+  export type Error =
+    | ConflictException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopReplication {
+  export type Input = StopReplicationRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace TerminateTargetInstances {
+  export type Input = TerminateTargetInstancesRequest;
+  export type Output = TerminateTargetInstancesResponse;
+  export type Error =
+    | ConflictException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UnarchiveApplication {
+  export type Input = UnarchiveApplicationRequest;
+  export type Output = Application;
+  export type Error =
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace UnarchiveWave {
+  export type Input = UnarchiveWaveRequest;
+  export type Output = Wave;
+  export type Error =
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateApplication {
+  export type Input = UpdateApplicationRequest;
+  export type Output = Application;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConnector {
+  export type Input = UpdateConnectorRequest;
+  export type Output = Connector;
+  export type Error =
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLaunchConfiguration {
+  export type Input = UpdateLaunchConfigurationRequest;
+  export type Output = LaunchConfiguration;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLaunchConfigurationTemplate {
+  export type Input = UpdateLaunchConfigurationTemplateRequest;
+  export type Output = LaunchConfigurationTemplate;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateReplicationConfiguration {
+  export type Input = UpdateReplicationConfigurationRequest;
+  export type Output = ReplicationConfiguration;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateReplicationConfigurationTemplate {
+  export type Input = UpdateReplicationConfigurationTemplateRequest;
+  export type Output = ReplicationConfigurationTemplate;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSourceServer {
+  export type Input = UpdateSourceServerRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSourceServerReplicationType {
+  export type Input = UpdateSourceServerReplicationTypeRequest;
+  export type Output = SourceServer;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWave {
+  export type Input = UpdateWaveRequest;
+  export type Output = Wave;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | UninitializedAccountException
     | CommonAwsError;
 }

--- a/src/services/migrationhuborchestrator/index.ts
+++ b/src/services/migrationhuborchestrator/index.ts
@@ -21,6 +21,301 @@ export declare class MigrationHubOrchestrator extends AWSServiceClient {
     UntagResourceResponse,
     ResourceNotFoundException | ValidationException | CommonAwsError
   >;
+  createTemplate(
+    input: CreateTemplateRequest,
+  ): Effect.Effect<
+    CreateTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkflow(
+    input: CreateMigrationWorkflowRequest,
+  ): Effect.Effect<
+    CreateMigrationWorkflowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkflowStep(
+    input: CreateWorkflowStepRequest,
+  ): Effect.Effect<
+    CreateWorkflowStepResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkflowStepGroup(
+    input: CreateWorkflowStepGroupRequest,
+  ): Effect.Effect<
+    CreateWorkflowStepGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTemplate(
+    input: DeleteTemplateRequest,
+  ): Effect.Effect<
+    DeleteTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkflow(
+    input: DeleteMigrationWorkflowRequest,
+  ): Effect.Effect<
+    DeleteMigrationWorkflowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkflowStep(
+    input: DeleteWorkflowStepRequest,
+  ): Effect.Effect<
+    DeleteWorkflowStepResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkflowStepGroup(
+    input: DeleteWorkflowStepGroupRequest,
+  ): Effect.Effect<
+    DeleteWorkflowStepGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTemplate(
+    input: GetMigrationWorkflowTemplateRequest,
+  ): Effect.Effect<
+    GetMigrationWorkflowTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getTemplateStep(
+    input: GetTemplateStepRequest,
+  ): Effect.Effect<
+    GetTemplateStepResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTemplateStepGroup(
+    input: GetTemplateStepGroupRequest,
+  ): Effect.Effect<
+    GetTemplateStepGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorkflow(
+    input: GetMigrationWorkflowRequest,
+  ): Effect.Effect<
+    GetMigrationWorkflowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorkflowStep(
+    input: GetWorkflowStepRequest,
+  ): Effect.Effect<
+    GetWorkflowStepResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getWorkflowStepGroup(
+    input: GetWorkflowStepGroupRequest,
+  ): Effect.Effect<
+    GetWorkflowStepGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPlugins(
+    input: ListPluginsRequest,
+  ): Effect.Effect<
+    ListPluginsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTemplateStepGroups(
+    input: ListTemplateStepGroupsRequest,
+  ): Effect.Effect<
+    ListTemplateStepGroupsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  listTemplateSteps(
+    input: ListTemplateStepsRequest,
+  ): Effect.Effect<
+    ListTemplateStepsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTemplates(
+    input: ListMigrationWorkflowTemplatesRequest,
+  ): Effect.Effect<
+    ListMigrationWorkflowTemplatesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  listWorkflowStepGroups(
+    input: ListWorkflowStepGroupsRequest,
+  ): Effect.Effect<
+    ListWorkflowStepGroupsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkflowSteps(
+    input: ListWorkflowStepsRequest,
+  ): Effect.Effect<
+    ListWorkflowStepsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkflows(
+    input: ListMigrationWorkflowsRequest,
+  ): Effect.Effect<
+    ListMigrationWorkflowsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  retryWorkflowStep(
+    input: RetryWorkflowStepRequest,
+  ): Effect.Effect<
+    RetryWorkflowStepResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  startWorkflow(
+    input: StartMigrationWorkflowRequest,
+  ): Effect.Effect<
+    StartMigrationWorkflowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopWorkflow(
+    input: StopMigrationWorkflowRequest,
+  ): Effect.Effect<
+    StopMigrationWorkflowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTemplate(
+    input: UpdateTemplateRequest,
+  ): Effect.Effect<
+    UpdateTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkflow(
+    input: UpdateMigrationWorkflowRequest,
+  ): Effect.Effect<
+    UpdateMigrationWorkflowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkflowStep(
+    input: UpdateWorkflowStepRequest,
+  ): Effect.Effect<
+    UpdateWorkflowStepResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkflowStepGroup(
+    input: UpdateWorkflowStepGroupRequest,
+  ): Effect.Effect<
+    UpdateWorkflowStepGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Migrationhuborchestrator extends MigrationHubOrchestrator {}
@@ -710,6 +1005,329 @@ export declare namespace UntagResource {
   export type Output = UntagResourceResponse;
   export type Error =
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTemplate {
+  export type Input = CreateTemplateRequest;
+  export type Output = CreateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkflow {
+  export type Input = CreateMigrationWorkflowRequest;
+  export type Output = CreateMigrationWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkflowStep {
+  export type Input = CreateWorkflowStepRequest;
+  export type Output = CreateWorkflowStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkflowStepGroup {
+  export type Input = CreateWorkflowStepGroupRequest;
+  export type Output = CreateWorkflowStepGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTemplate {
+  export type Input = DeleteTemplateRequest;
+  export type Output = DeleteTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkflow {
+  export type Input = DeleteMigrationWorkflowRequest;
+  export type Output = DeleteMigrationWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkflowStep {
+  export type Input = DeleteWorkflowStepRequest;
+  export type Output = DeleteWorkflowStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkflowStepGroup {
+  export type Input = DeleteWorkflowStepGroupRequest;
+  export type Output = DeleteWorkflowStepGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTemplate {
+  export type Input = GetMigrationWorkflowTemplateRequest;
+  export type Output = GetMigrationWorkflowTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetTemplateStep {
+  export type Input = GetTemplateStepRequest;
+  export type Output = GetTemplateStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTemplateStepGroup {
+  export type Input = GetTemplateStepGroupRequest;
+  export type Output = GetTemplateStepGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkflow {
+  export type Input = GetMigrationWorkflowRequest;
+  export type Output = GetMigrationWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkflowStep {
+  export type Input = GetWorkflowStepRequest;
+  export type Output = GetWorkflowStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkflowStepGroup {
+  export type Input = GetWorkflowStepGroupRequest;
+  export type Output = GetWorkflowStepGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPlugins {
+  export type Input = ListPluginsRequest;
+  export type Output = ListPluginsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTemplateStepGroups {
+  export type Input = ListTemplateStepGroupsRequest;
+  export type Output = ListTemplateStepGroupsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace ListTemplateSteps {
+  export type Input = ListTemplateStepsRequest;
+  export type Output = ListTemplateStepsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTemplates {
+  export type Input = ListMigrationWorkflowTemplatesRequest;
+  export type Output = ListMigrationWorkflowTemplatesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkflowStepGroups {
+  export type Input = ListWorkflowStepGroupsRequest;
+  export type Output = ListWorkflowStepGroupsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkflowSteps {
+  export type Input = ListWorkflowStepsRequest;
+  export type Output = ListWorkflowStepsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkflows {
+  export type Input = ListMigrationWorkflowsRequest;
+  export type Output = ListMigrationWorkflowsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RetryWorkflowStep {
+  export type Input = RetryWorkflowStepRequest;
+  export type Output = RetryWorkflowStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace StartWorkflow {
+  export type Input = StartMigrationWorkflowRequest;
+  export type Output = StartMigrationWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopWorkflow {
+  export type Input = StopMigrationWorkflowRequest;
+  export type Output = StopMigrationWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTemplate {
+  export type Input = UpdateTemplateRequest;
+  export type Output = UpdateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkflow {
+  export type Input = UpdateMigrationWorkflowRequest;
+  export type Output = UpdateMigrationWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkflowStep {
+  export type Input = UpdateWorkflowStepRequest;
+  export type Output = UpdateWorkflowStepResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkflowStepGroup {
+  export type Input = UpdateWorkflowStepGroupRequest;
+  export type Output = UpdateWorkflowStepGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/mpa/index.ts
+++ b/src/services/mpa/index.ts
@@ -91,6 +91,153 @@ export declare class MPA extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  cancelSession(
+    input: CancelSessionRequest,
+  ): Effect.Effect<
+    CancelSessionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createApprovalTeam(
+    input: CreateApprovalTeamRequest,
+  ): Effect.Effect<
+    CreateApprovalTeamResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createIdentitySource(
+    input: CreateIdentitySourceRequest,
+  ): Effect.Effect<
+    CreateIdentitySourceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteIdentitySource(
+    input: DeleteIdentitySourceRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteInactiveApprovalTeamVersion(
+    input: DeleteInactiveApprovalTeamVersionRequest,
+  ): Effect.Effect<
+    DeleteInactiveApprovalTeamVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApprovalTeam(
+    input: GetApprovalTeamRequest,
+  ): Effect.Effect<
+    GetApprovalTeamResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getIdentitySource(
+    input: GetIdentitySourceRequest,
+  ): Effect.Effect<
+    GetIdentitySourceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSession(
+    input: GetSessionRequest,
+  ): Effect.Effect<
+    GetSessionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApprovalTeams(
+    input: ListApprovalTeamsRequest,
+  ): Effect.Effect<
+    ListApprovalTeamsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIdentitySources(
+    input: ListIdentitySourcesRequest,
+  ): Effect.Effect<
+    ListIdentitySourcesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSessions(
+    input: ListSessionsRequest,
+  ): Effect.Effect<
+    ListSessionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startActiveApprovalTeamDeletion(
+    input: StartActiveApprovalTeamDeletionRequest,
+  ): Effect.Effect<
+    StartActiveApprovalTeamDeletionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateApprovalTeam(
+    input: UpdateApprovalTeamRequest,
+  ): Effect.Effect<
+    UpdateApprovalTeamResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Mpa extends MPA {}
@@ -715,6 +862,166 @@ export declare namespace UntagResource {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelSession {
+  export type Input = CancelSessionRequest;
+  export type Output = CancelSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateApprovalTeam {
+  export type Input = CreateApprovalTeamRequest;
+  export type Output = CreateApprovalTeamResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateIdentitySource {
+  export type Input = CreateIdentitySourceRequest;
+  export type Output = CreateIdentitySourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIdentitySource {
+  export type Input = DeleteIdentitySourceRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteInactiveApprovalTeamVersion {
+  export type Input = DeleteInactiveApprovalTeamVersionRequest;
+  export type Output = DeleteInactiveApprovalTeamVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApprovalTeam {
+  export type Input = GetApprovalTeamRequest;
+  export type Output = GetApprovalTeamResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetIdentitySource {
+  export type Input = GetIdentitySourceRequest;
+  export type Output = GetIdentitySourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSession {
+  export type Input = GetSessionRequest;
+  export type Output = GetSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApprovalTeams {
+  export type Input = ListApprovalTeamsRequest;
+  export type Output = ListApprovalTeamsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIdentitySources {
+  export type Input = ListIdentitySourcesRequest;
+  export type Output = ListIdentitySourcesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSessions {
+  export type Input = ListSessionsRequest;
+  export type Output = ListSessionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartActiveApprovalTeamDeletion {
+  export type Input = StartActiveApprovalTeamDeletionRequest;
+  export type Output = StartActiveApprovalTeamDeletionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateApprovalTeam {
+  export type Input = UpdateApprovalTeamRequest;
+  export type Output = UpdateApprovalTeamResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/neptune-graph/index.ts
+++ b/src/services/neptune-graph/index.ts
@@ -89,6 +89,262 @@ export declare class NeptuneGraph extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  cancelExportTask(
+    input: CancelExportTaskInput,
+  ): Effect.Effect<
+    CancelExportTaskOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  cancelImportTask(
+    input: CancelImportTaskInput,
+  ): Effect.Effect<
+    CancelImportTaskOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createGraph(
+    input: CreateGraphInput,
+  ): Effect.Effect<
+    CreateGraphOutput,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createGraphSnapshot(
+    input: CreateGraphSnapshotInput,
+  ): Effect.Effect<
+    CreateGraphSnapshotOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createGraphUsingImportTask(
+    input: CreateGraphUsingImportTaskInput,
+  ): Effect.Effect<
+    CreateGraphUsingImportTaskOutput,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPrivateGraphEndpoint(
+    input: CreatePrivateGraphEndpointInput,
+  ): Effect.Effect<
+    CreatePrivateGraphEndpointOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteGraph(
+    input: DeleteGraphInput,
+  ): Effect.Effect<
+    DeleteGraphOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteGraphSnapshot(
+    input: DeleteGraphSnapshotInput,
+  ): Effect.Effect<
+    DeleteGraphSnapshotOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePrivateGraphEndpoint(
+    input: DeletePrivateGraphEndpointInput,
+  ): Effect.Effect<
+    DeletePrivateGraphEndpointOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getExportTask(
+    input: GetExportTaskInput,
+  ): Effect.Effect<
+    GetExportTaskOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getGraph(
+    input: GetGraphInput,
+  ): Effect.Effect<
+    GetGraphOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getGraphSnapshot(
+    input: GetGraphSnapshotInput,
+  ): Effect.Effect<
+    GetGraphSnapshotOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getImportTask(
+    input: GetImportTaskInput,
+  ): Effect.Effect<
+    GetImportTaskOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getPrivateGraphEndpoint(
+    input: GetPrivateGraphEndpointInput,
+  ): Effect.Effect<
+    GetPrivateGraphEndpointOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listExportTasks(
+    input: ListExportTasksInput,
+  ): Effect.Effect<
+    ListExportTasksOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listGraphSnapshots(
+    input: ListGraphSnapshotsInput,
+  ): Effect.Effect<
+    ListGraphSnapshotsOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listGraphs(
+    input: ListGraphsInput,
+  ): Effect.Effect<
+    ListGraphsOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  listImportTasks(
+    input: ListImportTasksInput,
+  ): Effect.Effect<
+    ListImportTasksOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPrivateGraphEndpoints(
+    input: ListPrivateGraphEndpointsInput,
+  ): Effect.Effect<
+    ListPrivateGraphEndpointsOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  resetGraph(
+    input: ResetGraphInput,
+  ): Effect.Effect<
+    ResetGraphOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  restoreGraphFromSnapshot(
+    input: RestoreGraphFromSnapshotInput,
+  ): Effect.Effect<
+    RestoreGraphFromSnapshotOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startExportTask(
+    input: StartExportTaskInput,
+  ): Effect.Effect<
+    StartExportTaskOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startImportTask(
+    input: StartImportTaskInput,
+  ): Effect.Effect<
+    StartImportTaskOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateGraph(
+    input: UpdateGraphInput,
+  ): Effect.Effect<
+    UpdateGraphOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -926,6 +1182,286 @@ export declare namespace UntagResource {
   export type Input = UntagResourceInput;
   export type Output = UntagResourceOutput;
   export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelExportTask {
+  export type Input = CancelExportTaskInput;
+  export type Output = CancelExportTaskOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelImportTask {
+  export type Input = CancelImportTaskInput;
+  export type Output = CancelImportTaskOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGraph {
+  export type Input = CreateGraphInput;
+  export type Output = CreateGraphOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGraphSnapshot {
+  export type Input = CreateGraphSnapshotInput;
+  export type Output = CreateGraphSnapshotOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateGraphUsingImportTask {
+  export type Input = CreateGraphUsingImportTaskInput;
+  export type Output = CreateGraphUsingImportTaskOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePrivateGraphEndpoint {
+  export type Input = CreatePrivateGraphEndpointInput;
+  export type Output = CreatePrivateGraphEndpointOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGraph {
+  export type Input = DeleteGraphInput;
+  export type Output = DeleteGraphOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteGraphSnapshot {
+  export type Input = DeleteGraphSnapshotInput;
+  export type Output = DeleteGraphSnapshotOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePrivateGraphEndpoint {
+  export type Input = DeletePrivateGraphEndpointInput;
+  export type Output = DeletePrivateGraphEndpointOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetExportTask {
+  export type Input = GetExportTaskInput;
+  export type Output = GetExportTaskOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetGraph {
+  export type Input = GetGraphInput;
+  export type Output = GetGraphOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetGraphSnapshot {
+  export type Input = GetGraphSnapshotInput;
+  export type Output = GetGraphSnapshotOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetImportTask {
+  export type Input = GetImportTaskInput;
+  export type Output = GetImportTaskOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetPrivateGraphEndpoint {
+  export type Input = GetPrivateGraphEndpointInput;
+  export type Output = GetPrivateGraphEndpointOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListExportTasks {
+  export type Input = ListExportTasksInput;
+  export type Output = ListExportTasksOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListGraphSnapshots {
+  export type Input = ListGraphSnapshotsInput;
+  export type Output = ListGraphSnapshotsOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListGraphs {
+  export type Input = ListGraphsInput;
+  export type Output = ListGraphsOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace ListImportTasks {
+  export type Input = ListImportTasksInput;
+  export type Output = ListImportTasksOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPrivateGraphEndpoints {
+  export type Input = ListPrivateGraphEndpointsInput;
+  export type Output = ListPrivateGraphEndpointsOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ResetGraph {
+  export type Input = ResetGraphInput;
+  export type Output = ResetGraphOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RestoreGraphFromSnapshot {
+  export type Input = RestoreGraphFromSnapshotInput;
+  export type Output = RestoreGraphFromSnapshotOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartExportTask {
+  export type Input = StartExportTaskInput;
+  export type Output = StartExportTaskOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartImportTask {
+  export type Input = StartImportTaskInput;
+  export type Output = StartImportTaskOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateGraph {
+  export type Input = UpdateGraphInput;
+  export type Output = UpdateGraphOutput;
+  export type Error =
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/networkflowmonitor/index.ts
+++ b/src/services/networkflowmonitor/index.ts
@@ -39,6 +39,257 @@ export declare class NetworkFlowMonitor extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createMonitor(
+    input: CreateMonitorInput,
+  ): Effect.Effect<
+    CreateMonitorOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createScope(
+    input: CreateScopeInput,
+  ): Effect.Effect<
+    CreateScopeOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMonitor(
+    input: DeleteMonitorInput,
+  ): Effect.Effect<
+    DeleteMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteScope(
+    input: DeleteScopeInput,
+  ): Effect.Effect<
+    DeleteScopeOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMonitor(
+    input: GetMonitorInput,
+  ): Effect.Effect<
+    GetMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueryResultsMonitorTopContributors(
+    input: GetQueryResultsMonitorTopContributorsInput,
+  ): Effect.Effect<
+    GetQueryResultsMonitorTopContributorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueryResultsWorkloadInsightsTopContributors(
+    input: GetQueryResultsWorkloadInsightsTopContributorsInput,
+  ): Effect.Effect<
+    GetQueryResultsWorkloadInsightsTopContributorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueryResultsWorkloadInsightsTopContributorsData(
+    input: GetQueryResultsWorkloadInsightsTopContributorsDataInput,
+  ): Effect.Effect<
+    GetQueryResultsWorkloadInsightsTopContributorsDataOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueryStatusMonitorTopContributors(
+    input: GetQueryStatusMonitorTopContributorsInput,
+  ): Effect.Effect<
+    GetQueryStatusMonitorTopContributorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueryStatusWorkloadInsightsTopContributors(
+    input: GetQueryStatusWorkloadInsightsTopContributorsInput,
+  ): Effect.Effect<
+    GetQueryStatusWorkloadInsightsTopContributorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueryStatusWorkloadInsightsTopContributorsData(
+    input: GetQueryStatusWorkloadInsightsTopContributorsDataInput,
+  ): Effect.Effect<
+    GetQueryStatusWorkloadInsightsTopContributorsDataOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getScope(
+    input: GetScopeInput,
+  ): Effect.Effect<
+    GetScopeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMonitors(
+    input: ListMonitorsInput,
+  ): Effect.Effect<
+    ListMonitorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listScopes(
+    input: ListScopesInput,
+  ): Effect.Effect<
+    ListScopesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startQueryMonitorTopContributors(
+    input: StartQueryMonitorTopContributorsInput,
+  ): Effect.Effect<
+    StartQueryMonitorTopContributorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startQueryWorkloadInsightsTopContributors(
+    input: StartQueryWorkloadInsightsTopContributorsInput,
+  ): Effect.Effect<
+    StartQueryWorkloadInsightsTopContributorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startQueryWorkloadInsightsTopContributorsData(
+    input: StartQueryWorkloadInsightsTopContributorsDataInput,
+  ): Effect.Effect<
+    StartQueryWorkloadInsightsTopContributorsDataOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopQueryMonitorTopContributors(
+    input: StopQueryMonitorTopContributorsInput,
+  ): Effect.Effect<
+    StopQueryMonitorTopContributorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopQueryWorkloadInsightsTopContributors(
+    input: StopQueryWorkloadInsightsTopContributorsInput,
+  ): Effect.Effect<
+    StopQueryWorkloadInsightsTopContributorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopQueryWorkloadInsightsTopContributorsData(
+    input: StopQueryWorkloadInsightsTopContributorsDataInput,
+  ): Effect.Effect<
+    StopQueryWorkloadInsightsTopContributorsDataOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateMonitor(
+    input: UpdateMonitorInput,
+  ): Effect.Effect<
+    UpdateMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateScope(
+    input: UpdateScopeInput,
+  ): Effect.Effect<
+    UpdateScopeOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Networkflowmonitor extends NetworkFlowMonitor {}
@@ -550,6 +801,279 @@ export declare namespace UntagResource {
     | ConflictException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMonitor {
+  export type Input = CreateMonitorInput;
+  export type Output = CreateMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateScope {
+  export type Input = CreateScopeInput;
+  export type Output = CreateScopeOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMonitor {
+  export type Input = DeleteMonitorInput;
+  export type Output = DeleteMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteScope {
+  export type Input = DeleteScopeInput;
+  export type Output = DeleteScopeOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMonitor {
+  export type Input = GetMonitorInput;
+  export type Output = GetMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueryResultsMonitorTopContributors {
+  export type Input = GetQueryResultsMonitorTopContributorsInput;
+  export type Output = GetQueryResultsMonitorTopContributorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueryResultsWorkloadInsightsTopContributors {
+  export type Input = GetQueryResultsWorkloadInsightsTopContributorsInput;
+  export type Output = GetQueryResultsWorkloadInsightsTopContributorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueryResultsWorkloadInsightsTopContributorsData {
+  export type Input = GetQueryResultsWorkloadInsightsTopContributorsDataInput;
+  export type Output = GetQueryResultsWorkloadInsightsTopContributorsDataOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueryStatusMonitorTopContributors {
+  export type Input = GetQueryStatusMonitorTopContributorsInput;
+  export type Output = GetQueryStatusMonitorTopContributorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueryStatusWorkloadInsightsTopContributors {
+  export type Input = GetQueryStatusWorkloadInsightsTopContributorsInput;
+  export type Output = GetQueryStatusWorkloadInsightsTopContributorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueryStatusWorkloadInsightsTopContributorsData {
+  export type Input = GetQueryStatusWorkloadInsightsTopContributorsDataInput;
+  export type Output = GetQueryStatusWorkloadInsightsTopContributorsDataOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetScope {
+  export type Input = GetScopeInput;
+  export type Output = GetScopeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMonitors {
+  export type Input = ListMonitorsInput;
+  export type Output = ListMonitorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListScopes {
+  export type Input = ListScopesInput;
+  export type Output = ListScopesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartQueryMonitorTopContributors {
+  export type Input = StartQueryMonitorTopContributorsInput;
+  export type Output = StartQueryMonitorTopContributorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartQueryWorkloadInsightsTopContributors {
+  export type Input = StartQueryWorkloadInsightsTopContributorsInput;
+  export type Output = StartQueryWorkloadInsightsTopContributorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartQueryWorkloadInsightsTopContributorsData {
+  export type Input = StartQueryWorkloadInsightsTopContributorsDataInput;
+  export type Output = StartQueryWorkloadInsightsTopContributorsDataOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopQueryMonitorTopContributors {
+  export type Input = StopQueryMonitorTopContributorsInput;
+  export type Output = StopQueryMonitorTopContributorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopQueryWorkloadInsightsTopContributors {
+  export type Input = StopQueryWorkloadInsightsTopContributorsInput;
+  export type Output = StopQueryWorkloadInsightsTopContributorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopQueryWorkloadInsightsTopContributorsData {
+  export type Input = StopQueryWorkloadInsightsTopContributorsDataInput;
+  export type Output = StopQueryWorkloadInsightsTopContributorsDataOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMonitor {
+  export type Input = UpdateMonitorInput;
+  export type Output = UpdateMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateScope {
+  export type Input = UpdateScopeInput;
+  export type Output = UpdateScopeOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/networkmonitor/index.ts
+++ b/src/services/networkmonitor/index.ts
@@ -39,6 +39,109 @@ export declare class NetworkMonitor extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createMonitor(
+    input: CreateMonitorInput,
+  ): Effect.Effect<
+    CreateMonitorOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createProbe(
+    input: CreateProbeInput,
+  ): Effect.Effect<
+    CreateProbeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMonitor(
+    input: DeleteMonitorInput,
+  ): Effect.Effect<
+    DeleteMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteProbe(
+    input: DeleteProbeInput,
+  ): Effect.Effect<
+    DeleteProbeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMonitor(
+    input: GetMonitorInput,
+  ): Effect.Effect<
+    GetMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getProbe(
+    input: GetProbeInput,
+  ): Effect.Effect<
+    GetProbeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMonitors(
+    input: ListMonitorsInput,
+  ): Effect.Effect<
+    ListMonitorsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateMonitor(
+    input: UpdateMonitorInput,
+  ): Effect.Effect<
+    UpdateMonitorOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateProbe(
+    input: UpdateProbeInput,
+  ): Effect.Effect<
+    UpdateProbeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Networkmonitor extends NetworkMonitor {}
@@ -334,6 +437,118 @@ export declare namespace UntagResource {
     | ConflictException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMonitor {
+  export type Input = CreateMonitorInput;
+  export type Output = CreateMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateProbe {
+  export type Input = CreateProbeInput;
+  export type Output = CreateProbeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMonitor {
+  export type Input = DeleteMonitorInput;
+  export type Output = DeleteMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteProbe {
+  export type Input = DeleteProbeInput;
+  export type Output = DeleteProbeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMonitor {
+  export type Input = GetMonitorInput;
+  export type Output = GetMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetProbe {
+  export type Input = GetProbeInput;
+  export type Output = GetProbeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMonitors {
+  export type Input = ListMonitorsInput;
+  export type Output = ListMonitorsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMonitor {
+  export type Input = UpdateMonitorInput;
+  export type Output = UpdateMonitorOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProbe {
+  export type Input = UpdateProbeInput;
+  export type Output = UpdateProbeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -47,6 +47,360 @@ export declare class Notifications extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateChannel(
+    input: AssociateChannelRequest,
+  ): Effect.Effect<
+    AssociateChannelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateManagedNotificationAccountContact(
+    input: AssociateManagedNotificationAccountContactRequest,
+  ): Effect.Effect<
+    AssociateManagedNotificationAccountContactResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateManagedNotificationAdditionalChannel(
+    input: AssociateManagedNotificationAdditionalChannelRequest,
+  ): Effect.Effect<
+    AssociateManagedNotificationAdditionalChannelResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEventRule(
+    input: CreateEventRuleRequest,
+  ): Effect.Effect<
+    CreateEventRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createNotificationConfiguration(
+    input: CreateNotificationConfigurationRequest,
+  ): Effect.Effect<
+    CreateNotificationConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEventRule(
+    input: DeleteEventRuleRequest,
+  ): Effect.Effect<
+    DeleteEventRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteNotificationConfiguration(
+    input: DeleteNotificationConfigurationRequest,
+  ): Effect.Effect<
+    DeleteNotificationConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deregisterNotificationHub(
+    input: DeregisterNotificationHubRequest,
+  ): Effect.Effect<
+    DeregisterNotificationHubResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disableNotificationsAccessForOrganization(
+    input: DisableNotificationsAccessForOrganizationRequest,
+  ): Effect.Effect<
+    DisableNotificationsAccessForOrganizationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateChannel(
+    input: DisassociateChannelRequest,
+  ): Effect.Effect<
+    DisassociateChannelResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateManagedNotificationAccountContact(
+    input: DisassociateManagedNotificationAccountContactRequest,
+  ): Effect.Effect<
+    DisassociateManagedNotificationAccountContactResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateManagedNotificationAdditionalChannel(
+    input: DisassociateManagedNotificationAdditionalChannelRequest,
+  ): Effect.Effect<
+    DisassociateManagedNotificationAdditionalChannelResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  enableNotificationsAccessForOrganization(
+    input: EnableNotificationsAccessForOrganizationRequest,
+  ): Effect.Effect<
+    EnableNotificationsAccessForOrganizationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEventRule(
+    input: GetEventRuleRequest,
+  ): Effect.Effect<
+    GetEventRuleResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getManagedNotificationChildEvent(
+    input: GetManagedNotificationChildEventRequest,
+  ): Effect.Effect<
+    GetManagedNotificationChildEventResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getManagedNotificationConfiguration(
+    input: GetManagedNotificationConfigurationRequest,
+  ): Effect.Effect<
+    GetManagedNotificationConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getManagedNotificationEvent(
+    input: GetManagedNotificationEventRequest,
+  ): Effect.Effect<
+    GetManagedNotificationEventResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getNotificationConfiguration(
+    input: GetNotificationConfigurationRequest,
+  ): Effect.Effect<
+    GetNotificationConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getNotificationEvent(
+    input: GetNotificationEventRequest,
+  ): Effect.Effect<
+    GetNotificationEventResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getNotificationsAccessForOrganization(
+    input: GetNotificationsAccessForOrganizationRequest,
+  ): Effect.Effect<
+    GetNotificationsAccessForOrganizationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listChannels(
+    input: ListChannelsRequest,
+  ): Effect.Effect<
+    ListChannelsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEventRules(
+    input: ListEventRulesRequest,
+  ): Effect.Effect<
+    ListEventRulesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listManagedNotificationChildEvents(
+    input: ListManagedNotificationChildEventsRequest,
+  ): Effect.Effect<
+    ListManagedNotificationChildEventsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listManagedNotificationConfigurations(
+    input: ListManagedNotificationConfigurationsRequest,
+  ): Effect.Effect<
+    ListManagedNotificationConfigurationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listManagedNotificationEvents(
+    input: ListManagedNotificationEventsRequest,
+  ): Effect.Effect<
+    ListManagedNotificationEventsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listNotificationConfigurations(
+    input: ListNotificationConfigurationsRequest,
+  ): Effect.Effect<
+    ListNotificationConfigurationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listNotificationEvents(
+    input: ListNotificationEventsRequest,
+  ): Effect.Effect<
+    ListNotificationEventsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listNotificationHubs(
+    input: ListNotificationHubsRequest,
+  ): Effect.Effect<
+    ListNotificationHubsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  registerNotificationHub(
+    input: RegisterNotificationHubRequest,
+  ): Effect.Effect<
+    RegisterNotificationHubResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEventRule(
+    input: UpdateEventRuleRequest,
+  ): Effect.Effect<
+    UpdateEventRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateNotificationConfiguration(
+    input: UpdateNotificationConfigurationRequest,
+  ): Effect.Effect<
+    UpdateNotificationConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -777,6 +1131,391 @@ export declare namespace UntagResource {
   export type Output = UntagResourceResponse;
   export type Error =
     | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateChannel {
+  export type Input = AssociateChannelRequest;
+  export type Output = AssociateChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateManagedNotificationAccountContact {
+  export type Input = AssociateManagedNotificationAccountContactRequest;
+  export type Output = AssociateManagedNotificationAccountContactResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateManagedNotificationAdditionalChannel {
+  export type Input = AssociateManagedNotificationAdditionalChannelRequest;
+  export type Output = AssociateManagedNotificationAdditionalChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEventRule {
+  export type Input = CreateEventRuleRequest;
+  export type Output = CreateEventRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateNotificationConfiguration {
+  export type Input = CreateNotificationConfigurationRequest;
+  export type Output = CreateNotificationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEventRule {
+  export type Input = DeleteEventRuleRequest;
+  export type Output = DeleteEventRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteNotificationConfiguration {
+  export type Input = DeleteNotificationConfigurationRequest;
+  export type Output = DeleteNotificationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeregisterNotificationHub {
+  export type Input = DeregisterNotificationHubRequest;
+  export type Output = DeregisterNotificationHubResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisableNotificationsAccessForOrganization {
+  export type Input = DisableNotificationsAccessForOrganizationRequest;
+  export type Output = DisableNotificationsAccessForOrganizationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateChannel {
+  export type Input = DisassociateChannelRequest;
+  export type Output = DisassociateChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateManagedNotificationAccountContact {
+  export type Input = DisassociateManagedNotificationAccountContactRequest;
+  export type Output = DisassociateManagedNotificationAccountContactResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateManagedNotificationAdditionalChannel {
+  export type Input = DisassociateManagedNotificationAdditionalChannelRequest;
+  export type Output = DisassociateManagedNotificationAdditionalChannelResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace EnableNotificationsAccessForOrganization {
+  export type Input = EnableNotificationsAccessForOrganizationRequest;
+  export type Output = EnableNotificationsAccessForOrganizationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEventRule {
+  export type Input = GetEventRuleRequest;
+  export type Output = GetEventRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetManagedNotificationChildEvent {
+  export type Input = GetManagedNotificationChildEventRequest;
+  export type Output = GetManagedNotificationChildEventResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetManagedNotificationConfiguration {
+  export type Input = GetManagedNotificationConfigurationRequest;
+  export type Output = GetManagedNotificationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetManagedNotificationEvent {
+  export type Input = GetManagedNotificationEventRequest;
+  export type Output = GetManagedNotificationEventResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetNotificationConfiguration {
+  export type Input = GetNotificationConfigurationRequest;
+  export type Output = GetNotificationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetNotificationEvent {
+  export type Input = GetNotificationEventRequest;
+  export type Output = GetNotificationEventResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetNotificationsAccessForOrganization {
+  export type Input = GetNotificationsAccessForOrganizationRequest;
+  export type Output = GetNotificationsAccessForOrganizationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListChannels {
+  export type Input = ListChannelsRequest;
+  export type Output = ListChannelsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEventRules {
+  export type Input = ListEventRulesRequest;
+  export type Output = ListEventRulesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListManagedNotificationChildEvents {
+  export type Input = ListManagedNotificationChildEventsRequest;
+  export type Output = ListManagedNotificationChildEventsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListManagedNotificationConfigurations {
+  export type Input = ListManagedNotificationConfigurationsRequest;
+  export type Output = ListManagedNotificationConfigurationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListManagedNotificationEvents {
+  export type Input = ListManagedNotificationEventsRequest;
+  export type Output = ListManagedNotificationEventsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListNotificationConfigurations {
+  export type Input = ListNotificationConfigurationsRequest;
+  export type Output = ListNotificationConfigurationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListNotificationEvents {
+  export type Input = ListNotificationEventsRequest;
+  export type Output = ListNotificationEventsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListNotificationHubs {
+  export type Input = ListNotificationHubsRequest;
+  export type Output = ListNotificationHubsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RegisterNotificationHub {
+  export type Input = RegisterNotificationHubRequest;
+  export type Output = RegisterNotificationHubResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEventRule {
+  export type Input = UpdateEventRuleRequest;
+  export type Output = UpdateEventRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateNotificationConfiguration {
+  export type Input = UpdateNotificationConfigurationRequest;
+  export type Output = UpdateNotificationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/notificationscontacts/index.ts
+++ b/src/services/notificationscontacts/index.ts
@@ -36,6 +36,75 @@ export declare class NotificationsContacts extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  activateEmailContact(
+    input: ActivateEmailContactRequest,
+  ): Effect.Effect<
+    ActivateEmailContactResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEmailContact(
+    input: CreateEmailContactRequest,
+  ): Effect.Effect<
+    CreateEmailContactResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEmailContact(
+    input: DeleteEmailContactRequest,
+  ): Effect.Effect<
+    DeleteEmailContactResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEmailContact(
+    input: GetEmailContactRequest,
+  ): Effect.Effect<
+    GetEmailContactResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEmailContacts(
+    input: ListEmailContactsRequest,
+  ): Effect.Effect<
+    ListEmailContactsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  sendActivationCode(
+    input: SendActivationCodeRequest,
+  ): Effect.Effect<
+    SendActivationCodeResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Notificationscontacts extends NotificationsContacts {}
@@ -215,6 +284,81 @@ export declare namespace UntagResource {
   export type Output = UntagResourceResponse;
   export type Error =
     | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ActivateEmailContact {
+  export type Input = ActivateEmailContactRequest;
+  export type Output = ActivateEmailContactResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEmailContact {
+  export type Input = CreateEmailContactRequest;
+  export type Output = CreateEmailContactResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEmailContact {
+  export type Input = DeleteEmailContactRequest;
+  export type Output = DeleteEmailContactResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEmailContact {
+  export type Input = GetEmailContactRequest;
+  export type Output = GetEmailContactResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEmailContacts {
+  export type Input = ListEmailContactsRequest;
+  export type Output = ListEmailContactsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SendActivationCode {
+  export type Input = SendActivationCodeRequest;
+  export type Output = SendActivationCodeResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/odb/index.ts
+++ b/src/services/odb/index.ts
@@ -83,6 +83,355 @@ export declare class odb extends AWSServiceClient {
     UntagResourceResponse,
     ResourceNotFoundException | CommonAwsError
   >;
+  createCloudAutonomousVmCluster(
+    input: CreateCloudAutonomousVmClusterInput,
+  ): Effect.Effect<
+    CreateCloudAutonomousVmClusterOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCloudExadataInfrastructure(
+    input: CreateCloudExadataInfrastructureInput,
+  ): Effect.Effect<
+    CreateCloudExadataInfrastructureOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCloudVmCluster(
+    input: CreateCloudVmClusterInput,
+  ): Effect.Effect<
+    CreateCloudVmClusterOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createOdbNetwork(
+    input: CreateOdbNetworkInput,
+  ): Effect.Effect<
+    CreateOdbNetworkOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createOdbPeeringConnection(
+    input: CreateOdbPeeringConnectionInput,
+  ): Effect.Effect<
+    CreateOdbPeeringConnectionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCloudAutonomousVmCluster(
+    input: DeleteCloudAutonomousVmClusterInput,
+  ): Effect.Effect<
+    DeleteCloudAutonomousVmClusterOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCloudExadataInfrastructure(
+    input: DeleteCloudExadataInfrastructureInput,
+  ): Effect.Effect<
+    DeleteCloudExadataInfrastructureOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCloudVmCluster(
+    input: DeleteCloudVmClusterInput,
+  ): Effect.Effect<
+    DeleteCloudVmClusterOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteOdbNetwork(
+    input: DeleteOdbNetworkInput,
+  ): Effect.Effect<
+    DeleteOdbNetworkOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteOdbPeeringConnection(
+    input: DeleteOdbPeeringConnectionInput,
+  ): Effect.Effect<
+    DeleteOdbPeeringConnectionOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCloudAutonomousVmCluster(
+    input: GetCloudAutonomousVmClusterInput,
+  ): Effect.Effect<
+    GetCloudAutonomousVmClusterOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCloudExadataInfrastructure(
+    input: GetCloudExadataInfrastructureInput,
+  ): Effect.Effect<
+    GetCloudExadataInfrastructureOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCloudExadataInfrastructureUnallocatedResources(
+    input: GetCloudExadataInfrastructureUnallocatedResourcesInput,
+  ): Effect.Effect<
+    GetCloudExadataInfrastructureUnallocatedResourcesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCloudVmCluster(
+    input: GetCloudVmClusterInput,
+  ): Effect.Effect<
+    GetCloudVmClusterOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDbNode(
+    input: GetDbNodeInput,
+  ): Effect.Effect<
+    GetDbNodeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDbServer(
+    input: GetDbServerInput,
+  ): Effect.Effect<
+    GetDbServerOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getOdbNetwork(
+    input: GetOdbNetworkInput,
+  ): Effect.Effect<
+    GetOdbNetworkOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getOdbPeeringConnection(
+    input: GetOdbPeeringConnectionInput,
+  ): Effect.Effect<
+    GetOdbPeeringConnectionOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAutonomousVirtualMachines(
+    input: ListAutonomousVirtualMachinesInput,
+  ): Effect.Effect<
+    ListAutonomousVirtualMachinesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCloudAutonomousVmClusters(
+    input: ListCloudAutonomousVmClustersInput,
+  ): Effect.Effect<
+    ListCloudAutonomousVmClustersOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCloudExadataInfrastructures(
+    input: ListCloudExadataInfrastructuresInput,
+  ): Effect.Effect<
+    ListCloudExadataInfrastructuresOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listCloudVmClusters(
+    input: ListCloudVmClustersInput,
+  ): Effect.Effect<
+    ListCloudVmClustersOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDbNodes(
+    input: ListDbNodesInput,
+  ): Effect.Effect<
+    ListDbNodesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDbServers(
+    input: ListDbServersInput,
+  ): Effect.Effect<
+    ListDbServersOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listOdbNetworks(
+    input: ListOdbNetworksInput,
+  ): Effect.Effect<
+    ListOdbNetworksOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listOdbPeeringConnections(
+    input: ListOdbPeeringConnectionsInput,
+  ): Effect.Effect<
+    ListOdbPeeringConnectionsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  rebootDbNode(
+    input: RebootDbNodeInput,
+  ): Effect.Effect<
+    RebootDbNodeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startDbNode(
+    input: StartDbNodeInput,
+  ): Effect.Effect<
+    StartDbNodeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopDbNode(
+    input: StopDbNodeInput,
+  ): Effect.Effect<
+    StopDbNodeOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCloudExadataInfrastructure(
+    input: UpdateCloudExadataInfrastructureInput,
+  ): Effect.Effect<
+    UpdateCloudExadataInfrastructureOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateOdbNetwork(
+    input: UpdateOdbNetworkInput,
+  ): Effect.Effect<
+    UpdateOdbNetworkOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export interface AcceptMarketplaceRegistrationInput {
@@ -1289,4 +1638,384 @@ export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
   export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace CreateCloudAutonomousVmCluster {
+  export type Input = CreateCloudAutonomousVmClusterInput;
+  export type Output = CreateCloudAutonomousVmClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCloudExadataInfrastructure {
+  export type Input = CreateCloudExadataInfrastructureInput;
+  export type Output = CreateCloudExadataInfrastructureOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCloudVmCluster {
+  export type Input = CreateCloudVmClusterInput;
+  export type Output = CreateCloudVmClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateOdbNetwork {
+  export type Input = CreateOdbNetworkInput;
+  export type Output = CreateOdbNetworkOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateOdbPeeringConnection {
+  export type Input = CreateOdbPeeringConnectionInput;
+  export type Output = CreateOdbPeeringConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCloudAutonomousVmCluster {
+  export type Input = DeleteCloudAutonomousVmClusterInput;
+  export type Output = DeleteCloudAutonomousVmClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCloudExadataInfrastructure {
+  export type Input = DeleteCloudExadataInfrastructureInput;
+  export type Output = DeleteCloudExadataInfrastructureOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCloudVmCluster {
+  export type Input = DeleteCloudVmClusterInput;
+  export type Output = DeleteCloudVmClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteOdbNetwork {
+  export type Input = DeleteOdbNetworkInput;
+  export type Output = DeleteOdbNetworkOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteOdbPeeringConnection {
+  export type Input = DeleteOdbPeeringConnectionInput;
+  export type Output = DeleteOdbPeeringConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCloudAutonomousVmCluster {
+  export type Input = GetCloudAutonomousVmClusterInput;
+  export type Output = GetCloudAutonomousVmClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCloudExadataInfrastructure {
+  export type Input = GetCloudExadataInfrastructureInput;
+  export type Output = GetCloudExadataInfrastructureOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCloudExadataInfrastructureUnallocatedResources {
+  export type Input = GetCloudExadataInfrastructureUnallocatedResourcesInput;
+  export type Output = GetCloudExadataInfrastructureUnallocatedResourcesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCloudVmCluster {
+  export type Input = GetCloudVmClusterInput;
+  export type Output = GetCloudVmClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDbNode {
+  export type Input = GetDbNodeInput;
+  export type Output = GetDbNodeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDbServer {
+  export type Input = GetDbServerInput;
+  export type Output = GetDbServerOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetOdbNetwork {
+  export type Input = GetOdbNetworkInput;
+  export type Output = GetOdbNetworkOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetOdbPeeringConnection {
+  export type Input = GetOdbPeeringConnectionInput;
+  export type Output = GetOdbPeeringConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAutonomousVirtualMachines {
+  export type Input = ListAutonomousVirtualMachinesInput;
+  export type Output = ListAutonomousVirtualMachinesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCloudAutonomousVmClusters {
+  export type Input = ListCloudAutonomousVmClustersInput;
+  export type Output = ListCloudAutonomousVmClustersOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCloudExadataInfrastructures {
+  export type Input = ListCloudExadataInfrastructuresInput;
+  export type Output = ListCloudExadataInfrastructuresOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCloudVmClusters {
+  export type Input = ListCloudVmClustersInput;
+  export type Output = ListCloudVmClustersOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDbNodes {
+  export type Input = ListDbNodesInput;
+  export type Output = ListDbNodesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDbServers {
+  export type Input = ListDbServersInput;
+  export type Output = ListDbServersOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListOdbNetworks {
+  export type Input = ListOdbNetworksInput;
+  export type Output = ListOdbNetworksOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListOdbPeeringConnections {
+  export type Input = ListOdbPeeringConnectionsInput;
+  export type Output = ListOdbPeeringConnectionsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RebootDbNode {
+  export type Input = RebootDbNodeInput;
+  export type Output = RebootDbNodeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartDbNode {
+  export type Input = StartDbNodeInput;
+  export type Output = StartDbNodeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopDbNode {
+  export type Input = StopDbNodeInput;
+  export type Output = StopDbNodeOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCloudExadataInfrastructure {
+  export type Input = UpdateCloudExadataInfrastructureInput;
+  export type Output = UpdateCloudExadataInfrastructureOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateOdbNetwork {
+  export type Input = UpdateOdbNetworkInput;
+  export type Output = UpdateOdbNetworkOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
 }

--- a/src/services/omics/index.ts
+++ b/src/services/omics/index.ts
@@ -1,4 +1,6 @@
 import type { Effect, Stream, Data as EffectData } from "effect";
+import type { ResponseError } from "@effect/platform/HttpClientError";
+import type { Buffer } from "node:buffer";
 import type { CommonAwsError } from "../../error.ts";
 import { AWSServiceClient } from "../../client.ts";
 
@@ -39,6 +41,1196 @@ export declare class Omics extends AWSServiceClient {
     | NotSupportedOperationException
     | RequestTimeoutException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  abortMultipartReadSetUpload(
+    input: AbortMultipartReadSetUploadRequest,
+  ): Effect.Effect<
+    AbortMultipartReadSetUploadResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  acceptShare(
+    input: AcceptShareRequest,
+  ): Effect.Effect<
+    AcceptShareResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchDeleteReadSet(
+    input: BatchDeleteReadSetRequest,
+  ): Effect.Effect<
+    BatchDeleteReadSetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  cancelAnnotationImportJob(
+    input: CancelAnnotationImportRequest,
+  ): Effect.Effect<
+    CancelAnnotationImportResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  cancelRun(
+    input: CancelRunRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  cancelVariantImportJob(
+    input: CancelVariantImportRequest,
+  ): Effect.Effect<
+    CancelVariantImportResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  completeMultipartReadSetUpload(
+    input: CompleteMultipartReadSetUploadRequest,
+  ): Effect.Effect<
+    CompleteMultipartReadSetUploadResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAnnotationStore(
+    input: CreateAnnotationStoreRequest,
+  ): Effect.Effect<
+    CreateAnnotationStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAnnotationStoreVersion(
+    input: CreateAnnotationStoreVersionRequest,
+  ): Effect.Effect<
+    CreateAnnotationStoreVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createMultipartReadSetUpload(
+    input: CreateMultipartReadSetUploadRequest,
+  ): Effect.Effect<
+    CreateMultipartReadSetUploadResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createReferenceStore(
+    input: CreateReferenceStoreRequest,
+  ): Effect.Effect<
+    CreateReferenceStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRunCache(
+    input: CreateRunCacheRequest,
+  ): Effect.Effect<
+    CreateRunCacheResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRunGroup(
+    input: CreateRunGroupRequest,
+  ): Effect.Effect<
+    CreateRunGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSequenceStore(
+    input: CreateSequenceStoreRequest,
+  ): Effect.Effect<
+    CreateSequenceStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createShare(
+    input: CreateShareRequest,
+  ): Effect.Effect<
+    CreateShareResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createVariantStore(
+    input: CreateVariantStoreRequest,
+  ): Effect.Effect<
+    CreateVariantStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkflow(
+    input: CreateWorkflowRequest,
+  ): Effect.Effect<
+    CreateWorkflowResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkflowVersion(
+    input: CreateWorkflowVersionRequest,
+  ): Effect.Effect<
+    CreateWorkflowVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAnnotationStore(
+    input: DeleteAnnotationStoreRequest,
+  ): Effect.Effect<
+    DeleteAnnotationStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAnnotationStoreVersions(
+    input: DeleteAnnotationStoreVersionsRequest,
+  ): Effect.Effect<
+    DeleteAnnotationStoreVersionsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteReference(
+    input: DeleteReferenceRequest,
+  ): Effect.Effect<
+    DeleteReferenceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteReferenceStore(
+    input: DeleteReferenceStoreRequest,
+  ): Effect.Effect<
+    DeleteReferenceStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRun(
+    input: DeleteRunRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRunCache(
+    input: DeleteRunCacheRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRunGroup(
+    input: DeleteRunGroupRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSequenceStore(
+    input: DeleteSequenceStoreRequest,
+  ): Effect.Effect<
+    DeleteSequenceStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteShare(
+    input: DeleteShareRequest,
+  ): Effect.Effect<
+    DeleteShareResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteVariantStore(
+    input: DeleteVariantStoreRequest,
+  ): Effect.Effect<
+    DeleteVariantStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkflow(
+    input: DeleteWorkflowRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkflowVersion(
+    input: DeleteWorkflowVersionRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAnnotationImportJob(
+    input: GetAnnotationImportRequest,
+  ): Effect.Effect<
+    GetAnnotationImportResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAnnotationStore(
+    input: GetAnnotationStoreRequest,
+  ): Effect.Effect<
+    GetAnnotationStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAnnotationStoreVersion(
+    input: GetAnnotationStoreVersionRequest,
+  ): Effect.Effect<
+    GetAnnotationStoreVersionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReadSet(
+    input: GetReadSetRequest,
+  ): Effect.Effect<
+    GetReadSetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RangeNotSatisfiableException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReadSetActivationJob(
+    input: GetReadSetActivationJobRequest,
+  ): Effect.Effect<
+    GetReadSetActivationJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReadSetExportJob(
+    input: GetReadSetExportJobRequest,
+  ): Effect.Effect<
+    GetReadSetExportJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReadSetImportJob(
+    input: GetReadSetImportJobRequest,
+  ): Effect.Effect<
+    GetReadSetImportJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReadSetMetadata(
+    input: GetReadSetMetadataRequest,
+  ): Effect.Effect<
+    GetReadSetMetadataResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReference(
+    input: GetReferenceRequest,
+  ): Effect.Effect<
+    GetReferenceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RangeNotSatisfiableException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReferenceImportJob(
+    input: GetReferenceImportJobRequest,
+  ): Effect.Effect<
+    GetReferenceImportJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReferenceMetadata(
+    input: GetReferenceMetadataRequest,
+  ): Effect.Effect<
+    GetReferenceMetadataResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReferenceStore(
+    input: GetReferenceStoreRequest,
+  ): Effect.Effect<
+    GetReferenceStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRun(
+    input: GetRunRequest,
+  ): Effect.Effect<
+    GetRunResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRunCache(
+    input: GetRunCacheRequest,
+  ): Effect.Effect<
+    GetRunCacheResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRunGroup(
+    input: GetRunGroupRequest,
+  ): Effect.Effect<
+    GetRunGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRunTask(
+    input: GetRunTaskRequest,
+  ): Effect.Effect<
+    GetRunTaskResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSequenceStore(
+    input: GetSequenceStoreRequest,
+  ): Effect.Effect<
+    GetSequenceStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getShare(
+    input: GetShareRequest,
+  ): Effect.Effect<
+    GetShareResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getVariantImportJob(
+    input: GetVariantImportRequest,
+  ): Effect.Effect<
+    GetVariantImportResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getVariantStore(
+    input: GetVariantStoreRequest,
+  ): Effect.Effect<
+    GetVariantStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorkflow(
+    input: GetWorkflowRequest,
+  ): Effect.Effect<
+    GetWorkflowResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorkflowVersion(
+    input: GetWorkflowVersionRequest,
+  ): Effect.Effect<
+    GetWorkflowVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAnnotationImportJobs(
+    input: ListAnnotationImportJobsRequest,
+  ): Effect.Effect<
+    ListAnnotationImportJobsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAnnotationStoreVersions(
+    input: ListAnnotationStoreVersionsRequest,
+  ): Effect.Effect<
+    ListAnnotationStoreVersionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAnnotationStores(
+    input: ListAnnotationStoresRequest,
+  ): Effect.Effect<
+    ListAnnotationStoresResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMultipartReadSetUploads(
+    input: ListMultipartReadSetUploadsRequest,
+  ): Effect.Effect<
+    ListMultipartReadSetUploadsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReadSetActivationJobs(
+    input: ListReadSetActivationJobsRequest,
+  ): Effect.Effect<
+    ListReadSetActivationJobsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReadSetExportJobs(
+    input: ListReadSetExportJobsRequest,
+  ): Effect.Effect<
+    ListReadSetExportJobsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReadSetImportJobs(
+    input: ListReadSetImportJobsRequest,
+  ): Effect.Effect<
+    ListReadSetImportJobsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReadSetUploadParts(
+    input: ListReadSetUploadPartsRequest,
+  ): Effect.Effect<
+    ListReadSetUploadPartsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReadSets(
+    input: ListReadSetsRequest,
+  ): Effect.Effect<
+    ListReadSetsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReferenceImportJobs(
+    input: ListReferenceImportJobsRequest,
+  ): Effect.Effect<
+    ListReferenceImportJobsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReferenceStores(
+    input: ListReferenceStoresRequest,
+  ): Effect.Effect<
+    ListReferenceStoresResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReferences(
+    input: ListReferencesRequest,
+  ): Effect.Effect<
+    ListReferencesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRunCaches(
+    input: ListRunCachesRequest,
+  ): Effect.Effect<
+    ListRunCachesResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRunGroups(
+    input: ListRunGroupsRequest,
+  ): Effect.Effect<
+    ListRunGroupsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRunTasks(
+    input: ListRunTasksRequest,
+  ): Effect.Effect<
+    ListRunTasksResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRuns(
+    input: ListRunsRequest,
+  ): Effect.Effect<
+    ListRunsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSequenceStores(
+    input: ListSequenceStoresRequest,
+  ): Effect.Effect<
+    ListSequenceStoresResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listShares(
+    input: ListSharesRequest,
+  ): Effect.Effect<
+    ListSharesResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTagsForResource(
+    input: ListTagsForResourceRequest,
+  ): Effect.Effect<
+    ListTagsForResourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listVariantImportJobs(
+    input: ListVariantImportJobsRequest,
+  ): Effect.Effect<
+    ListVariantImportJobsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listVariantStores(
+    input: ListVariantStoresRequest,
+  ): Effect.Effect<
+    ListVariantStoresResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkflowVersions(
+    input: ListWorkflowVersionsRequest,
+  ): Effect.Effect<
+    ListWorkflowVersionsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkflows(
+    input: ListWorkflowsRequest,
+  ): Effect.Effect<
+    ListWorkflowsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startAnnotationImportJob(
+    input: StartAnnotationImportRequest,
+  ): Effect.Effect<
+    StartAnnotationImportResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startReadSetActivationJob(
+    input: StartReadSetActivationJobRequest,
+  ): Effect.Effect<
+    StartReadSetActivationJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startReadSetExportJob(
+    input: StartReadSetExportJobRequest,
+  ): Effect.Effect<
+    StartReadSetExportJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startReadSetImportJob(
+    input: StartReadSetImportJobRequest,
+  ): Effect.Effect<
+    StartReadSetImportJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startReferenceImportJob(
+    input: StartReferenceImportJobRequest,
+  ): Effect.Effect<
+    StartReferenceImportJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startRun(
+    input: StartRunRequest,
+  ): Effect.Effect<
+    StartRunResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startVariantImportJob(
+    input: StartVariantImportRequest,
+  ): Effect.Effect<
+    StartVariantImportResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  tagResource(
+    input: TagResourceRequest,
+  ): Effect.Effect<
+    TagResourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  untagResource(
+    input: UntagResourceRequest,
+  ): Effect.Effect<
+    UntagResourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAnnotationStore(
+    input: UpdateAnnotationStoreRequest,
+  ): Effect.Effect<
+    UpdateAnnotationStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAnnotationStoreVersion(
+    input: UpdateAnnotationStoreVersionRequest,
+  ): Effect.Effect<
+    UpdateAnnotationStoreVersionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateRunCache(
+    input: UpdateRunCacheRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateRunGroup(
+    input: UpdateRunGroupRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSequenceStore(
+    input: UpdateSequenceStoreRequest,
+  ): Effect.Effect<
+    UpdateSequenceStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateVariantStore(
+    input: UpdateVariantStoreRequest,
+  ): Effect.Effect<
+    UpdateVariantStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkflow(
+    input: UpdateWorkflowRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkflowVersion(
+    input: UpdateWorkflowVersionRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  uploadReadSetPart(
+    input: UploadReadSetPartRequest,
+  ): Effect.Effect<
+    UploadReadSetPartResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError
@@ -691,7 +1883,7 @@ export interface GetReadSetRequest {
   partNumber: number;
 }
 export interface GetReadSetResponse {
-  payload?: Uint8Array | string | Stream.Stream<Uint8Array>;
+  payload?: Stream.Stream<Uint8Array, ResponseError>;
 }
 export interface GetReferenceImportJobRequest {
   id: string;
@@ -733,7 +1925,7 @@ export interface GetReferenceRequest {
   file?: string;
 }
 export interface GetReferenceResponse {
-  payload?: Uint8Array | string | Stream.Stream<Uint8Array>;
+  payload?: Stream.Stream<Uint8Array, ResponseError>;
 }
 export interface GetReferenceStoreRequest {
   id: string;
@@ -2063,7 +3255,7 @@ export interface UploadReadSetPartRequest {
   uploadId: string;
   partSource: string;
   partNumber: number;
-  payload: Uint8Array | string | Stream.Stream<Uint8Array>;
+  payload: Uint8Array | string | Buffer | Stream.Stream<Uint8Array>;
 }
 export interface UploadReadSetPartResponse {
   checksum: string;
@@ -2254,6 +3446,1289 @@ export declare namespace PutS3AccessPolicy {
     | NotSupportedOperationException
     | RequestTimeoutException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AbortMultipartReadSetUpload {
+  export type Input = AbortMultipartReadSetUploadRequest;
+  export type Output = AbortMultipartReadSetUploadResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AcceptShare {
+  export type Input = AcceptShareRequest;
+  export type Output = AcceptShareResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchDeleteReadSet {
+  export type Input = BatchDeleteReadSetRequest;
+  export type Output = BatchDeleteReadSetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelAnnotationImportJob {
+  export type Input = CancelAnnotationImportRequest;
+  export type Output = CancelAnnotationImportResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelRun {
+  export type Input = CancelRunRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelVariantImportJob {
+  export type Input = CancelVariantImportRequest;
+  export type Output = CancelVariantImportResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CompleteMultipartReadSetUpload {
+  export type Input = CompleteMultipartReadSetUploadRequest;
+  export type Output = CompleteMultipartReadSetUploadResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAnnotationStore {
+  export type Input = CreateAnnotationStoreRequest;
+  export type Output = CreateAnnotationStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAnnotationStoreVersion {
+  export type Input = CreateAnnotationStoreVersionRequest;
+  export type Output = CreateAnnotationStoreVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMultipartReadSetUpload {
+  export type Input = CreateMultipartReadSetUploadRequest;
+  export type Output = CreateMultipartReadSetUploadResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateReferenceStore {
+  export type Input = CreateReferenceStoreRequest;
+  export type Output = CreateReferenceStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRunCache {
+  export type Input = CreateRunCacheRequest;
+  export type Output = CreateRunCacheResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRunGroup {
+  export type Input = CreateRunGroupRequest;
+  export type Output = CreateRunGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSequenceStore {
+  export type Input = CreateSequenceStoreRequest;
+  export type Output = CreateSequenceStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateShare {
+  export type Input = CreateShareRequest;
+  export type Output = CreateShareResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateVariantStore {
+  export type Input = CreateVariantStoreRequest;
+  export type Output = CreateVariantStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkflow {
+  export type Input = CreateWorkflowRequest;
+  export type Output = CreateWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkflowVersion {
+  export type Input = CreateWorkflowVersionRequest;
+  export type Output = CreateWorkflowVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAnnotationStore {
+  export type Input = DeleteAnnotationStoreRequest;
+  export type Output = DeleteAnnotationStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAnnotationStoreVersions {
+  export type Input = DeleteAnnotationStoreVersionsRequest;
+  export type Output = DeleteAnnotationStoreVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteReference {
+  export type Input = DeleteReferenceRequest;
+  export type Output = DeleteReferenceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteReferenceStore {
+  export type Input = DeleteReferenceStoreRequest;
+  export type Output = DeleteReferenceStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRun {
+  export type Input = DeleteRunRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRunCache {
+  export type Input = DeleteRunCacheRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRunGroup {
+  export type Input = DeleteRunGroupRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSequenceStore {
+  export type Input = DeleteSequenceStoreRequest;
+  export type Output = DeleteSequenceStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteShare {
+  export type Input = DeleteShareRequest;
+  export type Output = DeleteShareResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVariantStore {
+  export type Input = DeleteVariantStoreRequest;
+  export type Output = DeleteVariantStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkflow {
+  export type Input = DeleteWorkflowRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkflowVersion {
+  export type Input = DeleteWorkflowVersionRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAnnotationImportJob {
+  export type Input = GetAnnotationImportRequest;
+  export type Output = GetAnnotationImportResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAnnotationStore {
+  export type Input = GetAnnotationStoreRequest;
+  export type Output = GetAnnotationStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAnnotationStoreVersion {
+  export type Input = GetAnnotationStoreVersionRequest;
+  export type Output = GetAnnotationStoreVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReadSet {
+  export type Input = GetReadSetRequest;
+  export type Output = GetReadSetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RangeNotSatisfiableException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReadSetActivationJob {
+  export type Input = GetReadSetActivationJobRequest;
+  export type Output = GetReadSetActivationJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReadSetExportJob {
+  export type Input = GetReadSetExportJobRequest;
+  export type Output = GetReadSetExportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReadSetImportJob {
+  export type Input = GetReadSetImportJobRequest;
+  export type Output = GetReadSetImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReadSetMetadata {
+  export type Input = GetReadSetMetadataRequest;
+  export type Output = GetReadSetMetadataResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReference {
+  export type Input = GetReferenceRequest;
+  export type Output = GetReferenceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RangeNotSatisfiableException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReferenceImportJob {
+  export type Input = GetReferenceImportJobRequest;
+  export type Output = GetReferenceImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReferenceMetadata {
+  export type Input = GetReferenceMetadataRequest;
+  export type Output = GetReferenceMetadataResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReferenceStore {
+  export type Input = GetReferenceStoreRequest;
+  export type Output = GetReferenceStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRun {
+  export type Input = GetRunRequest;
+  export type Output = GetRunResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRunCache {
+  export type Input = GetRunCacheRequest;
+  export type Output = GetRunCacheResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRunGroup {
+  export type Input = GetRunGroupRequest;
+  export type Output = GetRunGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRunTask {
+  export type Input = GetRunTaskRequest;
+  export type Output = GetRunTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSequenceStore {
+  export type Input = GetSequenceStoreRequest;
+  export type Output = GetSequenceStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetShare {
+  export type Input = GetShareRequest;
+  export type Output = GetShareResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetVariantImportJob {
+  export type Input = GetVariantImportRequest;
+  export type Output = GetVariantImportResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetVariantStore {
+  export type Input = GetVariantStoreRequest;
+  export type Output = GetVariantStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkflow {
+  export type Input = GetWorkflowRequest;
+  export type Output = GetWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkflowVersion {
+  export type Input = GetWorkflowVersionRequest;
+  export type Output = GetWorkflowVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAnnotationImportJobs {
+  export type Input = ListAnnotationImportJobsRequest;
+  export type Output = ListAnnotationImportJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAnnotationStoreVersions {
+  export type Input = ListAnnotationStoreVersionsRequest;
+  export type Output = ListAnnotationStoreVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAnnotationStores {
+  export type Input = ListAnnotationStoresRequest;
+  export type Output = ListAnnotationStoresResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMultipartReadSetUploads {
+  export type Input = ListMultipartReadSetUploadsRequest;
+  export type Output = ListMultipartReadSetUploadsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReadSetActivationJobs {
+  export type Input = ListReadSetActivationJobsRequest;
+  export type Output = ListReadSetActivationJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReadSetExportJobs {
+  export type Input = ListReadSetExportJobsRequest;
+  export type Output = ListReadSetExportJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReadSetImportJobs {
+  export type Input = ListReadSetImportJobsRequest;
+  export type Output = ListReadSetImportJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReadSetUploadParts {
+  export type Input = ListReadSetUploadPartsRequest;
+  export type Output = ListReadSetUploadPartsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReadSets {
+  export type Input = ListReadSetsRequest;
+  export type Output = ListReadSetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReferenceImportJobs {
+  export type Input = ListReferenceImportJobsRequest;
+  export type Output = ListReferenceImportJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReferenceStores {
+  export type Input = ListReferenceStoresRequest;
+  export type Output = ListReferenceStoresResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReferences {
+  export type Input = ListReferencesRequest;
+  export type Output = ListReferencesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRunCaches {
+  export type Input = ListRunCachesRequest;
+  export type Output = ListRunCachesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRunGroups {
+  export type Input = ListRunGroupsRequest;
+  export type Output = ListRunGroupsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRunTasks {
+  export type Input = ListRunTasksRequest;
+  export type Output = ListRunTasksResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRuns {
+  export type Input = ListRunsRequest;
+  export type Output = ListRunsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSequenceStores {
+  export type Input = ListSequenceStoresRequest;
+  export type Output = ListSequenceStoresResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListShares {
+  export type Input = ListSharesRequest;
+  export type Output = ListSharesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTagsForResource {
+  export type Input = ListTagsForResourceRequest;
+  export type Output = ListTagsForResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListVariantImportJobs {
+  export type Input = ListVariantImportJobsRequest;
+  export type Output = ListVariantImportJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListVariantStores {
+  export type Input = ListVariantStoresRequest;
+  export type Output = ListVariantStoresResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkflowVersions {
+  export type Input = ListWorkflowVersionsRequest;
+  export type Output = ListWorkflowVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkflows {
+  export type Input = ListWorkflowsRequest;
+  export type Output = ListWorkflowsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartAnnotationImportJob {
+  export type Input = StartAnnotationImportRequest;
+  export type Output = StartAnnotationImportResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartReadSetActivationJob {
+  export type Input = StartReadSetActivationJobRequest;
+  export type Output = StartReadSetActivationJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartReadSetExportJob {
+  export type Input = StartReadSetExportJobRequest;
+  export type Output = StartReadSetExportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartReadSetImportJob {
+  export type Input = StartReadSetImportJobRequest;
+  export type Output = StartReadSetImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartReferenceImportJob {
+  export type Input = StartReferenceImportJobRequest;
+  export type Output = StartReferenceImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartRun {
+  export type Input = StartRunRequest;
+  export type Output = StartRunResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartVariantImportJob {
+  export type Input = StartVariantImportRequest;
+  export type Output = StartVariantImportResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace TagResource {
+  export type Input = TagResourceRequest;
+  export type Output = TagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UntagResource {
+  export type Input = UntagResourceRequest;
+  export type Output = UntagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAnnotationStore {
+  export type Input = UpdateAnnotationStoreRequest;
+  export type Output = UpdateAnnotationStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAnnotationStoreVersion {
+  export type Input = UpdateAnnotationStoreVersionRequest;
+  export type Output = UpdateAnnotationStoreVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRunCache {
+  export type Input = UpdateRunCacheRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRunGroup {
+  export type Input = UpdateRunGroupRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSequenceStore {
+  export type Input = UpdateSequenceStoreRequest;
+  export type Output = UpdateSequenceStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateVariantStore {
+  export type Input = UpdateVariantStoreRequest;
+  export type Output = UpdateVariantStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkflow {
+  export type Input = UpdateWorkflowRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkflowVersion {
+  export type Input = UpdateWorkflowVersionRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UploadReadSetPart {
+  export type Input = UploadReadSetPartRequest;
+  export type Output = UploadReadSetPartResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | NotSupportedOperationException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/opensearchserverless/index.ts
+++ b/src/services/opensearchserverless/index.ts
@@ -104,6 +104,221 @@ export declare class OpenSearchServerless extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createAccessPolicy(
+    input: CreateAccessPolicyRequest,
+  ): Effect.Effect<
+    CreateAccessPolicyResponse,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createCollection(
+    input: CreateCollectionRequest,
+  ): Effect.Effect<
+    CreateCollectionResponse,
+    | ConflictException
+    | InternalServerException
+    | OcuLimitExceededException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSecurityConfig(
+    input: CreateSecurityConfigRequest,
+  ): Effect.Effect<
+    CreateSecurityConfigResponse,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createVpcEndpoint(
+    input: CreateVpcEndpointRequest,
+  ): Effect.Effect<
+    CreateVpcEndpointResponse,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAccessPolicy(
+    input: DeleteAccessPolicyRequest,
+  ): Effect.Effect<
+    DeleteAccessPolicyResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCollection(
+    input: DeleteCollectionRequest,
+  ): Effect.Effect<
+    DeleteCollectionResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteLifecyclePolicy(
+    input: DeleteLifecyclePolicyRequest,
+  ): Effect.Effect<
+    DeleteLifecyclePolicyResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSecurityConfig(
+    input: DeleteSecurityConfigRequest,
+  ): Effect.Effect<
+    DeleteSecurityConfigResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSecurityPolicy(
+    input: DeleteSecurityPolicyRequest,
+  ): Effect.Effect<
+    DeleteSecurityPolicyResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteVpcEndpoint(
+    input: DeleteVpcEndpointRequest,
+  ): Effect.Effect<
+    DeleteVpcEndpointResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAccessPolicy(
+    input: GetAccessPolicyRequest,
+  ): Effect.Effect<
+    GetAccessPolicyResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSecurityConfig(
+    input: GetSecurityConfigRequest,
+  ): Effect.Effect<
+    GetSecurityConfigResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSecurityPolicy(
+    input: GetSecurityPolicyRequest,
+  ): Effect.Effect<
+    GetSecurityPolicyResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAccessPolicies(
+    input: ListAccessPoliciesRequest,
+  ): Effect.Effect<
+    ListAccessPoliciesResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listCollections(
+    input: ListCollectionsRequest,
+  ): Effect.Effect<
+    ListCollectionsResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listLifecyclePolicies(
+    input: ListLifecyclePoliciesRequest,
+  ): Effect.Effect<
+    ListLifecyclePoliciesResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listSecurityConfigs(
+    input: ListSecurityConfigsRequest,
+  ): Effect.Effect<
+    ListSecurityConfigsResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listSecurityPolicies(
+    input: ListSecurityPoliciesRequest,
+  ): Effect.Effect<
+    ListSecurityPoliciesResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listVpcEndpoints(
+    input: ListVpcEndpointsRequest,
+  ): Effect.Effect<
+    ListVpcEndpointsResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  updateAccessPolicy(
+    input: UpdateAccessPolicyRequest,
+  ): Effect.Effect<
+    UpdateAccessPolicyResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCollection(
+    input: UpdateCollectionRequest,
+  ): Effect.Effect<
+    UpdateCollectionResponse,
+    | ConflictException
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateLifecyclePolicy(
+    input: UpdateLifecyclePolicyRequest,
+  ): Effect.Effect<
+    UpdateLifecyclePolicyResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSecurityConfig(
+    input: UpdateSecurityConfigRequest,
+  ): Effect.Effect<
+    UpdateSecurityConfigResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSecurityPolicy(
+    input: UpdateSecurityPolicyRequest,
+  ): Effect.Effect<
+    UpdateSecurityPolicyResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Opensearchserverless extends OpenSearchServerless {}
@@ -930,6 +1145,257 @@ export declare namespace UpdateVpcEndpoint {
   export type Error =
     | ConflictException
     | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAccessPolicy {
+  export type Input = CreateAccessPolicyRequest;
+  export type Output = CreateAccessPolicyResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCollection {
+  export type Input = CreateCollectionRequest;
+  export type Output = CreateCollectionResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | OcuLimitExceededException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSecurityConfig {
+  export type Input = CreateSecurityConfigRequest;
+  export type Output = CreateSecurityConfigResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateVpcEndpoint {
+  export type Input = CreateVpcEndpointRequest;
+  export type Output = CreateVpcEndpointResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAccessPolicy {
+  export type Input = DeleteAccessPolicyRequest;
+  export type Output = DeleteAccessPolicyResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCollection {
+  export type Input = DeleteCollectionRequest;
+  export type Output = DeleteCollectionResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteLifecyclePolicy {
+  export type Input = DeleteLifecyclePolicyRequest;
+  export type Output = DeleteLifecyclePolicyResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSecurityConfig {
+  export type Input = DeleteSecurityConfigRequest;
+  export type Output = DeleteSecurityConfigResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSecurityPolicy {
+  export type Input = DeleteSecurityPolicyRequest;
+  export type Output = DeleteSecurityPolicyResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVpcEndpoint {
+  export type Input = DeleteVpcEndpointRequest;
+  export type Output = DeleteVpcEndpointResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAccessPolicy {
+  export type Input = GetAccessPolicyRequest;
+  export type Output = GetAccessPolicyResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSecurityConfig {
+  export type Input = GetSecurityConfigRequest;
+  export type Output = GetSecurityConfigResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSecurityPolicy {
+  export type Input = GetSecurityPolicyRequest;
+  export type Output = GetSecurityPolicyResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAccessPolicies {
+  export type Input = ListAccessPoliciesRequest;
+  export type Output = ListAccessPoliciesResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCollections {
+  export type Input = ListCollectionsRequest;
+  export type Output = ListCollectionsResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListLifecyclePolicies {
+  export type Input = ListLifecyclePoliciesRequest;
+  export type Output = ListLifecyclePoliciesResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSecurityConfigs {
+  export type Input = ListSecurityConfigsRequest;
+  export type Output = ListSecurityConfigsResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSecurityPolicies {
+  export type Input = ListSecurityPoliciesRequest;
+  export type Output = ListSecurityPoliciesResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListVpcEndpoints {
+  export type Input = ListVpcEndpointsRequest;
+  export type Output = ListVpcEndpointsResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAccessPolicy {
+  export type Input = UpdateAccessPolicyRequest;
+  export type Output = UpdateAccessPolicyResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCollection {
+  export type Input = UpdateCollectionRequest;
+  export type Output = UpdateCollectionResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateLifecyclePolicy {
+  export type Input = UpdateLifecyclePolicyRequest;
+  export type Output = UpdateLifecyclePolicyResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSecurityConfig {
+  export type Input = UpdateSecurityConfigRequest;
+  export type Output = UpdateSecurityConfigResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSecurityPolicy {
+  export type Input = UpdateSecurityPolicyRequest;
+  export type Output = UpdateSecurityPolicyResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/partnercentral-selling/index.ts
+++ b/src/services/partnercentral-selling/index.ts
@@ -58,6 +58,368 @@ export declare class PartnerCentralSelling extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  acceptEngagementInvitation(
+    input: AcceptEngagementInvitationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  assignOpportunity(
+    input: AssignOpportunityRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateOpportunity(
+    input: AssociateOpportunityRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEngagement(
+    input: CreateEngagementRequest,
+  ): Effect.Effect<
+    CreateEngagementResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEngagementInvitation(
+    input: CreateEngagementInvitationRequest,
+  ): Effect.Effect<
+    CreateEngagementInvitationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createOpportunity(
+    input: CreateOpportunityRequest,
+  ): Effect.Effect<
+    CreateOpportunityResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createResourceSnapshot(
+    input: CreateResourceSnapshotRequest,
+  ): Effect.Effect<
+    CreateResourceSnapshotResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createResourceSnapshotJob(
+    input: CreateResourceSnapshotJobRequest,
+  ): Effect.Effect<
+    CreateResourceSnapshotJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteResourceSnapshotJob(
+    input: DeleteResourceSnapshotJobRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateOpportunity(
+    input: DisassociateOpportunityRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAwsOpportunitySummary(
+    input: GetAwsOpportunitySummaryRequest,
+  ): Effect.Effect<
+    GetAwsOpportunitySummaryResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEngagement(
+    input: GetEngagementRequest,
+  ): Effect.Effect<
+    GetEngagementResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEngagementInvitation(
+    input: GetEngagementInvitationRequest,
+  ): Effect.Effect<
+    GetEngagementInvitationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getOpportunity(
+    input: GetOpportunityRequest,
+  ): Effect.Effect<
+    GetOpportunityResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getResourceSnapshot(
+    input: GetResourceSnapshotRequest,
+  ): Effect.Effect<
+    GetResourceSnapshotResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getResourceSnapshotJob(
+    input: GetResourceSnapshotJobRequest,
+  ): Effect.Effect<
+    GetResourceSnapshotJobResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEngagementByAcceptingInvitationTasks(
+    input: ListEngagementByAcceptingInvitationTasksRequest,
+  ): Effect.Effect<
+    ListEngagementByAcceptingInvitationTasksResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEngagementFromOpportunityTasks(
+    input: ListEngagementFromOpportunityTasksRequest,
+  ): Effect.Effect<
+    ListEngagementFromOpportunityTasksResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEngagementInvitations(
+    input: ListEngagementInvitationsRequest,
+  ): Effect.Effect<
+    ListEngagementInvitationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEngagementMembers(
+    input: ListEngagementMembersRequest,
+  ): Effect.Effect<
+    ListEngagementMembersResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEngagementResourceAssociations(
+    input: ListEngagementResourceAssociationsRequest,
+  ): Effect.Effect<
+    ListEngagementResourceAssociationsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEngagements(
+    input: ListEngagementsRequest,
+  ): Effect.Effect<
+    ListEngagementsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listOpportunities(
+    input: ListOpportunitiesRequest,
+  ): Effect.Effect<
+    ListOpportunitiesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listResourceSnapshotJobs(
+    input: ListResourceSnapshotJobsRequest,
+  ): Effect.Effect<
+    ListResourceSnapshotJobsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listResourceSnapshots(
+    input: ListResourceSnapshotsRequest,
+  ): Effect.Effect<
+    ListResourceSnapshotsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSolutions(
+    input: ListSolutionsRequest,
+  ): Effect.Effect<
+    ListSolutionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  rejectEngagementInvitation(
+    input: RejectEngagementInvitationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startEngagementByAcceptingInvitationTask(
+    input: StartEngagementByAcceptingInvitationTaskRequest,
+  ): Effect.Effect<
+    StartEngagementByAcceptingInvitationTaskResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startEngagementFromOpportunityTask(
+    input: StartEngagementFromOpportunityTaskRequest,
+  ): Effect.Effect<
+    StartEngagementFromOpportunityTaskResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startResourceSnapshotJob(
+    input: StartResourceSnapshotJobRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopResourceSnapshotJob(
+    input: StopResourceSnapshotJobRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  submitOpportunity(
+    input: SubmitOpportunityRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateOpportunity(
+    input: UpdateOpportunityRequest,
+  ): Effect.Effect<
+    UpdateOpportunityResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class PartnercentralSelling extends PartnerCentralSelling {}
@@ -1834,6 +2196,401 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AcceptEngagementInvitation {
+  export type Input = AcceptEngagementInvitationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssignOpportunity {
+  export type Input = AssignOpportunityRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateOpportunity {
+  export type Input = AssociateOpportunityRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEngagement {
+  export type Input = CreateEngagementRequest;
+  export type Output = CreateEngagementResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEngagementInvitation {
+  export type Input = CreateEngagementInvitationRequest;
+  export type Output = CreateEngagementInvitationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateOpportunity {
+  export type Input = CreateOpportunityRequest;
+  export type Output = CreateOpportunityResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateResourceSnapshot {
+  export type Input = CreateResourceSnapshotRequest;
+  export type Output = CreateResourceSnapshotResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateResourceSnapshotJob {
+  export type Input = CreateResourceSnapshotJobRequest;
+  export type Output = CreateResourceSnapshotJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteResourceSnapshotJob {
+  export type Input = DeleteResourceSnapshotJobRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateOpportunity {
+  export type Input = DisassociateOpportunityRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAwsOpportunitySummary {
+  export type Input = GetAwsOpportunitySummaryRequest;
+  export type Output = GetAwsOpportunitySummaryResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEngagement {
+  export type Input = GetEngagementRequest;
+  export type Output = GetEngagementResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEngagementInvitation {
+  export type Input = GetEngagementInvitationRequest;
+  export type Output = GetEngagementInvitationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetOpportunity {
+  export type Input = GetOpportunityRequest;
+  export type Output = GetOpportunityResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetResourceSnapshot {
+  export type Input = GetResourceSnapshotRequest;
+  export type Output = GetResourceSnapshotResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetResourceSnapshotJob {
+  export type Input = GetResourceSnapshotJobRequest;
+  export type Output = GetResourceSnapshotJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEngagementByAcceptingInvitationTasks {
+  export type Input = ListEngagementByAcceptingInvitationTasksRequest;
+  export type Output = ListEngagementByAcceptingInvitationTasksResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEngagementFromOpportunityTasks {
+  export type Input = ListEngagementFromOpportunityTasksRequest;
+  export type Output = ListEngagementFromOpportunityTasksResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEngagementInvitations {
+  export type Input = ListEngagementInvitationsRequest;
+  export type Output = ListEngagementInvitationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEngagementMembers {
+  export type Input = ListEngagementMembersRequest;
+  export type Output = ListEngagementMembersResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEngagementResourceAssociations {
+  export type Input = ListEngagementResourceAssociationsRequest;
+  export type Output = ListEngagementResourceAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEngagements {
+  export type Input = ListEngagementsRequest;
+  export type Output = ListEngagementsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListOpportunities {
+  export type Input = ListOpportunitiesRequest;
+  export type Output = ListOpportunitiesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListResourceSnapshotJobs {
+  export type Input = ListResourceSnapshotJobsRequest;
+  export type Output = ListResourceSnapshotJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListResourceSnapshots {
+  export type Input = ListResourceSnapshotsRequest;
+  export type Output = ListResourceSnapshotsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSolutions {
+  export type Input = ListSolutionsRequest;
+  export type Output = ListSolutionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RejectEngagementInvitation {
+  export type Input = RejectEngagementInvitationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartEngagementByAcceptingInvitationTask {
+  export type Input = StartEngagementByAcceptingInvitationTaskRequest;
+  export type Output = StartEngagementByAcceptingInvitationTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartEngagementFromOpportunityTask {
+  export type Input = StartEngagementFromOpportunityTaskRequest;
+  export type Output = StartEngagementFromOpportunityTaskResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartResourceSnapshotJob {
+  export type Input = StartResourceSnapshotJobRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopResourceSnapshotJob {
+  export type Input = StopResourceSnapshotJobRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SubmitOpportunity {
+  export type Input = SubmitOpportunityRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateOpportunity {
+  export type Input = UpdateOpportunityRequest;
+  export type Output = UpdateOpportunityResponse;
   export type Error =
     | AccessDeniedException
     | ConflictException

--- a/src/services/payment-cryptography/index.ts
+++ b/src/services/payment-cryptography/index.ts
@@ -109,6 +109,163 @@ export declare class PaymentCryptography extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createAlias(
+    input: CreateAliasInput,
+  ): Effect.Effect<
+    CreateAliasOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createKey(
+    input: CreateKeyInput,
+  ): Effect.Effect<
+    CreateKeyOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAlias(
+    input: DeleteAliasInput,
+  ): Effect.Effect<
+    DeleteAliasOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteKey(
+    input: DeleteKeyInput,
+  ): Effect.Effect<
+    DeleteKeyOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAlias(
+    input: GetAliasInput,
+  ): Effect.Effect<
+    GetAliasOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getKey(
+    input: GetKeyInput,
+  ): Effect.Effect<
+    GetKeyOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAliases(
+    input: ListAliasesInput,
+  ): Effect.Effect<
+    ListAliasesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listKeys(
+    input: ListKeysInput,
+  ): Effect.Effect<
+    ListKeysOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  restoreKey(
+    input: RestoreKeyInput,
+  ): Effect.Effect<
+    RestoreKeyOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startKeyUsage(
+    input: StartKeyUsageInput,
+  ): Effect.Effect<
+    StartKeyUsageOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopKeyUsage(
+    input: StopKeyUsageInput,
+  ): Effect.Effect<
+    StopKeyUsageOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAlias(
+    input: UpdateAliasInput,
+  ): Effect.Effect<
+    UpdateAliasOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -667,6 +824,175 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceInput;
   export type Output = UntagResourceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAlias {
+  export type Input = CreateAliasInput;
+  export type Output = CreateAliasOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateKey {
+  export type Input = CreateKeyInput;
+  export type Output = CreateKeyOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAlias {
+  export type Input = DeleteAliasInput;
+  export type Output = DeleteAliasOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteKey {
+  export type Input = DeleteKeyInput;
+  export type Output = DeleteKeyOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAlias {
+  export type Input = GetAliasInput;
+  export type Output = GetAliasOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetKey {
+  export type Input = GetKeyInput;
+  export type Output = GetKeyOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAliases {
+  export type Input = ListAliasesInput;
+  export type Output = ListAliasesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListKeys {
+  export type Input = ListKeysInput;
+  export type Output = ListKeysOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RestoreKey {
+  export type Input = RestoreKeyInput;
+  export type Output = RestoreKeyOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartKeyUsage {
+  export type Input = StartKeyUsageInput;
+  export type Output = StartKeyUsageOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopKeyUsage {
+  export type Input = StopKeyUsageInput;
+  export type Output = StopKeyUsageOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAlias {
+  export type Input = UpdateAliasInput;
+  export type Output = UpdateAliasOutput;
   export type Error =
     | AccessDeniedException
     | ConflictException

--- a/src/services/pca-connector-ad/index.ts
+++ b/src/services/pca-connector-ad/index.ts
@@ -36,6 +36,259 @@ export declare class PcaConnectorAd extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createConnector(
+    input: CreateConnectorRequest,
+  ): Effect.Effect<
+    CreateConnectorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDirectoryRegistration(
+    input: CreateDirectoryRegistrationRequest,
+  ): Effect.Effect<
+    CreateDirectoryRegistrationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServicePrincipalName(
+    input: CreateServicePrincipalNameRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTemplate(
+    input: CreateTemplateRequest,
+  ): Effect.Effect<
+    CreateTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTemplateGroupAccessControlEntry(
+    input: CreateTemplateGroupAccessControlEntryRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConnector(
+    input: DeleteConnectorRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDirectoryRegistration(
+    input: DeleteDirectoryRegistrationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServicePrincipalName(
+    input: DeleteServicePrincipalNameRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTemplate(
+    input: DeleteTemplateRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTemplateGroupAccessControlEntry(
+    input: DeleteTemplateGroupAccessControlEntryRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConnector(
+    input: GetConnectorRequest,
+  ): Effect.Effect<
+    GetConnectorResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDirectoryRegistration(
+    input: GetDirectoryRegistrationRequest,
+  ): Effect.Effect<
+    GetDirectoryRegistrationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServicePrincipalName(
+    input: GetServicePrincipalNameRequest,
+  ): Effect.Effect<
+    GetServicePrincipalNameResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTemplate(
+    input: GetTemplateRequest,
+  ): Effect.Effect<
+    GetTemplateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTemplateGroupAccessControlEntry(
+    input: GetTemplateGroupAccessControlEntryRequest,
+  ): Effect.Effect<
+    GetTemplateGroupAccessControlEntryResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listConnectors(
+    input: ListConnectorsRequest,
+  ): Effect.Effect<
+    ListConnectorsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDirectoryRegistrations(
+    input: ListDirectoryRegistrationsRequest,
+  ): Effect.Effect<
+    ListDirectoryRegistrationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServicePrincipalNames(
+    input: ListServicePrincipalNamesRequest,
+  ): Effect.Effect<
+    ListServicePrincipalNamesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTemplateGroupAccessControlEntries(
+    input: ListTemplateGroupAccessControlEntriesRequest,
+  ): Effect.Effect<
+    ListTemplateGroupAccessControlEntriesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTemplates(
+    input: ListTemplatesRequest,
+  ): Effect.Effect<
+    ListTemplatesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTemplate(
+    input: UpdateTemplateRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTemplateGroupAccessControlEntry(
+    input: UpdateTemplateGroupAccessControlEntryRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export interface AccessControlEntry {
@@ -767,6 +1020,281 @@ export declare namespace UntagResource {
   export type Output = {};
   export type Error =
     | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConnector {
+  export type Input = CreateConnectorRequest;
+  export type Output = CreateConnectorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDirectoryRegistration {
+  export type Input = CreateDirectoryRegistrationRequest;
+  export type Output = CreateDirectoryRegistrationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServicePrincipalName {
+  export type Input = CreateServicePrincipalNameRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTemplate {
+  export type Input = CreateTemplateRequest;
+  export type Output = CreateTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTemplateGroupAccessControlEntry {
+  export type Input = CreateTemplateGroupAccessControlEntryRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConnector {
+  export type Input = DeleteConnectorRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDirectoryRegistration {
+  export type Input = DeleteDirectoryRegistrationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServicePrincipalName {
+  export type Input = DeleteServicePrincipalNameRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTemplate {
+  export type Input = DeleteTemplateRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTemplateGroupAccessControlEntry {
+  export type Input = DeleteTemplateGroupAccessControlEntryRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConnector {
+  export type Input = GetConnectorRequest;
+  export type Output = GetConnectorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDirectoryRegistration {
+  export type Input = GetDirectoryRegistrationRequest;
+  export type Output = GetDirectoryRegistrationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServicePrincipalName {
+  export type Input = GetServicePrincipalNameRequest;
+  export type Output = GetServicePrincipalNameResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTemplate {
+  export type Input = GetTemplateRequest;
+  export type Output = GetTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTemplateGroupAccessControlEntry {
+  export type Input = GetTemplateGroupAccessControlEntryRequest;
+  export type Output = GetTemplateGroupAccessControlEntryResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConnectors {
+  export type Input = ListConnectorsRequest;
+  export type Output = ListConnectorsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDirectoryRegistrations {
+  export type Input = ListDirectoryRegistrationsRequest;
+  export type Output = ListDirectoryRegistrationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServicePrincipalNames {
+  export type Input = ListServicePrincipalNamesRequest;
+  export type Output = ListServicePrincipalNamesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTemplateGroupAccessControlEntries {
+  export type Input = ListTemplateGroupAccessControlEntriesRequest;
+  export type Output = ListTemplateGroupAccessControlEntriesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTemplates {
+  export type Input = ListTemplatesRequest;
+  export type Output = ListTemplatesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTemplate {
+  export type Input = UpdateTemplateRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTemplateGroupAccessControlEntry {
+  export type Input = UpdateTemplateGroupAccessControlEntryRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/pca-connector-scep/index.ts
+++ b/src/services/pca-connector-scep/index.ts
@@ -36,6 +36,111 @@ export declare class PcaConnectorScep extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createChallenge(
+    input: CreateChallengeRequest,
+  ): Effect.Effect<
+    CreateChallengeResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createConnector(
+    input: CreateConnectorRequest,
+  ): Effect.Effect<
+    CreateConnectorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteChallenge(
+    input: DeleteChallengeRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteConnector(
+    input: DeleteConnectorRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getChallengeMetadata(
+    input: GetChallengeMetadataRequest,
+  ): Effect.Effect<
+    GetChallengeMetadataResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getChallengePassword(
+    input: GetChallengePasswordRequest,
+  ): Effect.Effect<
+    GetChallengePasswordResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getConnector(
+    input: GetConnectorRequest,
+  ): Effect.Effect<
+    GetConnectorResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listChallengeMetadata(
+    input: ListChallengeMetadataRequest,
+  ): Effect.Effect<
+    ListChallengeMetadataResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listConnectors(
+    input: ListConnectorsRequest,
+  ): Effect.Effect<
+    ListConnectorsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -285,6 +390,120 @@ export declare namespace UntagResource {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateChallenge {
+  export type Input = CreateChallengeRequest;
+  export type Output = CreateChallengeResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConnector {
+  export type Input = CreateConnectorRequest;
+  export type Output = CreateConnectorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteChallenge {
+  export type Input = DeleteChallengeRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConnector {
+  export type Input = DeleteConnectorRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetChallengeMetadata {
+  export type Input = GetChallengeMetadataRequest;
+  export type Output = GetChallengeMetadataResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetChallengePassword {
+  export type Input = GetChallengePasswordRequest;
+  export type Output = GetChallengePasswordResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetConnector {
+  export type Input = GetConnectorRequest;
+  export type Output = GetConnectorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListChallengeMetadata {
+  export type Input = ListChallengeMetadataRequest;
+  export type Output = ListChallengeMetadataResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListConnectors {
+  export type Input = ListConnectorsRequest;
+  export type Output = ListConnectorsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/pcs/index.ts
+++ b/src/services/pcs/index.ts
@@ -18,6 +18,184 @@ export declare class PCS extends AWSServiceClient {
   untagResource(
     input: UntagResourceRequest,
   ): Effect.Effect<{}, ResourceNotFoundException | CommonAwsError>;
+  createCluster(
+    input: CreateClusterRequest,
+  ): Effect.Effect<
+    CreateClusterResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createComputeNodeGroup(
+    input: CreateComputeNodeGroupRequest,
+  ): Effect.Effect<
+    CreateComputeNodeGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createQueue(
+    input: CreateQueueRequest,
+  ): Effect.Effect<
+    CreateQueueResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCluster(
+    input: DeleteClusterRequest,
+  ): Effect.Effect<
+    DeleteClusterResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteComputeNodeGroup(
+    input: DeleteComputeNodeGroupRequest,
+  ): Effect.Effect<
+    DeleteComputeNodeGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteQueue(
+    input: DeleteQueueRequest,
+  ): Effect.Effect<
+    DeleteQueueResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getCluster(
+    input: GetClusterRequest,
+  ): Effect.Effect<
+    GetClusterResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getComputeNodeGroup(
+    input: GetComputeNodeGroupRequest,
+  ): Effect.Effect<
+    GetComputeNodeGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQueue(
+    input: GetQueueRequest,
+  ): Effect.Effect<
+    GetQueueResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listClusters(
+    input: ListClustersRequest,
+  ): Effect.Effect<
+    ListClustersResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listComputeNodeGroups(
+    input: ListComputeNodeGroupsRequest,
+  ): Effect.Effect<
+    ListComputeNodeGroupsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listQueues(
+    input: ListQueuesRequest,
+  ): Effect.Effect<
+    ListQueuesResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  registerComputeNodeGroupInstance(
+    input: RegisterComputeNodeGroupInstanceRequest,
+  ): Effect.Effect<
+    RegisterComputeNodeGroupInstanceResponse,
+    AccessDeniedException | InternalServerException | CommonAwsError
+  >;
+  updateComputeNodeGroup(
+    input: UpdateComputeNodeGroupRequest,
+  ): Effect.Effect<
+    UpdateComputeNodeGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateQueue(
+    input: UpdateQueueRequest,
+  ): Effect.Effect<
+    UpdateQueueResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Pcs extends PCS {}
@@ -494,4 +672,199 @@ export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = {};
   export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace CreateCluster {
+  export type Input = CreateClusterRequest;
+  export type Output = CreateClusterResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateComputeNodeGroup {
+  export type Input = CreateComputeNodeGroupRequest;
+  export type Output = CreateComputeNodeGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateQueue {
+  export type Input = CreateQueueRequest;
+  export type Output = CreateQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCluster {
+  export type Input = DeleteClusterRequest;
+  export type Output = DeleteClusterResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteComputeNodeGroup {
+  export type Input = DeleteComputeNodeGroupRequest;
+  export type Output = DeleteComputeNodeGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteQueue {
+  export type Input = DeleteQueueRequest;
+  export type Output = DeleteQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetCluster {
+  export type Input = GetClusterRequest;
+  export type Output = GetClusterResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetComputeNodeGroup {
+  export type Input = GetComputeNodeGroupRequest;
+  export type Output = GetComputeNodeGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQueue {
+  export type Input = GetQueueRequest;
+  export type Output = GetQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListClusters {
+  export type Input = ListClustersRequest;
+  export type Output = ListClustersResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListComputeNodeGroups {
+  export type Input = ListComputeNodeGroupsRequest;
+  export type Output = ListComputeNodeGroupsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListQueues {
+  export type Input = ListQueuesRequest;
+  export type Output = ListQueuesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RegisterComputeNodeGroupInstance {
+  export type Input = RegisterComputeNodeGroupInstanceRequest;
+  export type Output = RegisterComputeNodeGroupInstanceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateComputeNodeGroup {
+  export type Input = UpdateComputeNodeGroupRequest;
+  export type Output = UpdateComputeNodeGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateQueue {
+  export type Input = UpdateQueueRequest;
+  export type Output = UpdateQueueResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
 }

--- a/src/services/pipes/index.ts
+++ b/src/services/pipes/index.ts
@@ -21,6 +21,81 @@ export declare class Pipes extends AWSServiceClient {
     UntagResourceResponse,
     InternalException | NotFoundException | ValidationException | CommonAwsError
   >;
+  createPipe(
+    input: CreatePipeRequest,
+  ): Effect.Effect<
+    CreatePipeResponse,
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePipe(
+    input: DeletePipeRequest,
+  ): Effect.Effect<
+    DeletePipeResponse,
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describePipe(
+    input: DescribePipeRequest,
+  ): Effect.Effect<
+    DescribePipeResponse,
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPipes(
+    input: ListPipesRequest,
+  ): Effect.Effect<
+    ListPipesResponse,
+    | InternalException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startPipe(
+    input: StartPipeRequest,
+  ): Effect.Effect<
+    StartPipeResponse,
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopPipe(
+    input: StopPipeRequest,
+  ): Effect.Effect<
+    StopPipeResponse,
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updatePipe(
+    input: UpdatePipeRequest,
+  ): Effect.Effect<
+    UpdatePipeResponse,
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export type Arn = string;
@@ -888,6 +963,88 @@ export declare namespace UntagResource {
   export type Error =
     | InternalException
     | NotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePipe {
+  export type Input = CreatePipeRequest;
+  export type Output = CreatePipeResponse;
+  export type Error =
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePipe {
+  export type Input = DeletePipeRequest;
+  export type Output = DeletePipeResponse;
+  export type Error =
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribePipe {
+  export type Input = DescribePipeRequest;
+  export type Output = DescribePipeResponse;
+  export type Error =
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPipes {
+  export type Input = ListPipesRequest;
+  export type Output = ListPipesResponse;
+  export type Error =
+    | InternalException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartPipe {
+  export type Input = StartPipeRequest;
+  export type Output = StartPipeResponse;
+  export type Error =
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopPipe {
+  export type Input = StopPipeRequest;
+  export type Output = StopPipeResponse;
+  export type Error =
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePipe {
+  export type Input = UpdatePipeRequest;
+  export type Output = UpdatePipeResponse;
+  export type Error =
+    | ConflictException
+    | InternalException
+    | NotFoundException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/proton/index.ts
+++ b/src/services/proton/index.ts
@@ -152,6 +152,860 @@ export declare class Proton extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  acceptEnvironmentAccountConnection(
+    input: AcceptEnvironmentAccountConnectionInput,
+  ): Effect.Effect<
+    AcceptEnvironmentAccountConnectionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createComponent(
+    input: CreateComponentInput,
+  ): Effect.Effect<
+    CreateComponentOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEnvironment(
+    input: CreateEnvironmentInput,
+  ): Effect.Effect<
+    CreateEnvironmentOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEnvironmentAccountConnection(
+    input: CreateEnvironmentAccountConnectionInput,
+  ): Effect.Effect<
+    CreateEnvironmentAccountConnectionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEnvironmentTemplate(
+    input: CreateEnvironmentTemplateInput,
+  ): Effect.Effect<
+    CreateEnvironmentTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEnvironmentTemplateVersion(
+    input: CreateEnvironmentTemplateVersionInput,
+  ): Effect.Effect<
+    CreateEnvironmentTemplateVersionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRepository(
+    input: CreateRepositoryInput,
+  ): Effect.Effect<
+    CreateRepositoryOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createService(
+    input: CreateServiceInput,
+  ): Effect.Effect<
+    CreateServiceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServiceInstance(
+    input: CreateServiceInstanceInput,
+  ): Effect.Effect<
+    CreateServiceInstanceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServiceSyncConfig(
+    input: CreateServiceSyncConfigInput,
+  ): Effect.Effect<
+    CreateServiceSyncConfigOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServiceTemplate(
+    input: CreateServiceTemplateInput,
+  ): Effect.Effect<
+    CreateServiceTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServiceTemplateVersion(
+    input: CreateServiceTemplateVersionInput,
+  ): Effect.Effect<
+    CreateServiceTemplateVersionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTemplateSyncConfig(
+    input: CreateTemplateSyncConfigInput,
+  ): Effect.Effect<
+    CreateTemplateSyncConfigOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteComponent(
+    input: DeleteComponentInput,
+  ): Effect.Effect<
+    DeleteComponentOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDeployment(
+    input: DeleteDeploymentInput,
+  ): Effect.Effect<
+    DeleteDeploymentOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEnvironment(
+    input: DeleteEnvironmentInput,
+  ): Effect.Effect<
+    DeleteEnvironmentOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEnvironmentAccountConnection(
+    input: DeleteEnvironmentAccountConnectionInput,
+  ): Effect.Effect<
+    DeleteEnvironmentAccountConnectionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEnvironmentTemplate(
+    input: DeleteEnvironmentTemplateInput,
+  ): Effect.Effect<
+    DeleteEnvironmentTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEnvironmentTemplateVersion(
+    input: DeleteEnvironmentTemplateVersionInput,
+  ): Effect.Effect<
+    DeleteEnvironmentTemplateVersionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRepository(
+    input: DeleteRepositoryInput,
+  ): Effect.Effect<
+    DeleteRepositoryOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteService(
+    input: DeleteServiceInput,
+  ): Effect.Effect<
+    DeleteServiceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServiceSyncConfig(
+    input: DeleteServiceSyncConfigInput,
+  ): Effect.Effect<
+    DeleteServiceSyncConfigOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServiceTemplate(
+    input: DeleteServiceTemplateInput,
+  ): Effect.Effect<
+    DeleteServiceTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServiceTemplateVersion(
+    input: DeleteServiceTemplateVersionInput,
+  ): Effect.Effect<
+    DeleteServiceTemplateVersionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTemplateSyncConfig(
+    input: DeleteTemplateSyncConfigInput,
+  ): Effect.Effect<
+    DeleteTemplateSyncConfigOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAccountSettings(
+    input: GetAccountSettingsInput,
+  ): Effect.Effect<
+    GetAccountSettingsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getComponent(
+    input: GetComponentInput,
+  ): Effect.Effect<
+    GetComponentOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDeployment(
+    input: GetDeploymentInput,
+  ): Effect.Effect<
+    GetDeploymentOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEnvironment(
+    input: GetEnvironmentInput,
+  ): Effect.Effect<
+    GetEnvironmentOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEnvironmentAccountConnection(
+    input: GetEnvironmentAccountConnectionInput,
+  ): Effect.Effect<
+    GetEnvironmentAccountConnectionOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEnvironmentTemplate(
+    input: GetEnvironmentTemplateInput,
+  ): Effect.Effect<
+    GetEnvironmentTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEnvironmentTemplateVersion(
+    input: GetEnvironmentTemplateVersionInput,
+  ): Effect.Effect<
+    GetEnvironmentTemplateVersionOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRepository(
+    input: GetRepositoryInput,
+  ): Effect.Effect<
+    GetRepositoryOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getService(
+    input: GetServiceInput,
+  ): Effect.Effect<
+    GetServiceOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceInstance(
+    input: GetServiceInstanceInput,
+  ): Effect.Effect<
+    GetServiceInstanceOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceSyncBlockerSummary(
+    input: GetServiceSyncBlockerSummaryInput,
+  ): Effect.Effect<
+    GetServiceSyncBlockerSummaryOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceSyncConfig(
+    input: GetServiceSyncConfigInput,
+  ): Effect.Effect<
+    GetServiceSyncConfigOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceTemplate(
+    input: GetServiceTemplateInput,
+  ): Effect.Effect<
+    GetServiceTemplateOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceTemplateVersion(
+    input: GetServiceTemplateVersionInput,
+  ): Effect.Effect<
+    GetServiceTemplateVersionOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTemplateSyncConfig(
+    input: GetTemplateSyncConfigInput,
+  ): Effect.Effect<
+    GetTemplateSyncConfigOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listComponentOutputs(
+    input: ListComponentOutputsInput,
+  ): Effect.Effect<
+    ListComponentOutputsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listComponentProvisionedResources(
+    input: ListComponentProvisionedResourcesInput,
+  ): Effect.Effect<
+    ListComponentProvisionedResourcesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listComponents(
+    input: ListComponentsInput,
+  ): Effect.Effect<
+    ListComponentsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDeployments(
+    input: ListDeploymentsInput,
+  ): Effect.Effect<
+    ListDeploymentsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnvironmentAccountConnections(
+    input: ListEnvironmentAccountConnectionsInput,
+  ): Effect.Effect<
+    ListEnvironmentAccountConnectionsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnvironmentOutputs(
+    input: ListEnvironmentOutputsInput,
+  ): Effect.Effect<
+    ListEnvironmentOutputsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnvironmentProvisionedResources(
+    input: ListEnvironmentProvisionedResourcesInput,
+  ): Effect.Effect<
+    ListEnvironmentProvisionedResourcesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnvironmentTemplateVersions(
+    input: ListEnvironmentTemplateVersionsInput,
+  ): Effect.Effect<
+    ListEnvironmentTemplateVersionsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnvironmentTemplates(
+    input: ListEnvironmentTemplatesInput,
+  ): Effect.Effect<
+    ListEnvironmentTemplatesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEnvironments(
+    input: ListEnvironmentsInput,
+  ): Effect.Effect<
+    ListEnvironmentsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRepositories(
+    input: ListRepositoriesInput,
+  ): Effect.Effect<
+    ListRepositoriesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceInstanceOutputs(
+    input: ListServiceInstanceOutputsInput,
+  ): Effect.Effect<
+    ListServiceInstanceOutputsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceInstanceProvisionedResources(
+    input: ListServiceInstanceProvisionedResourcesInput,
+  ): Effect.Effect<
+    ListServiceInstanceProvisionedResourcesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceInstances(
+    input: ListServiceInstancesInput,
+  ): Effect.Effect<
+    ListServiceInstancesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServicePipelineOutputs(
+    input: ListServicePipelineOutputsInput,
+  ): Effect.Effect<
+    ListServicePipelineOutputsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServicePipelineProvisionedResources(
+    input: ListServicePipelineProvisionedResourcesInput,
+  ): Effect.Effect<
+    ListServicePipelineProvisionedResourcesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceTemplateVersions(
+    input: ListServiceTemplateVersionsInput,
+  ): Effect.Effect<
+    ListServiceTemplateVersionsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceTemplates(
+    input: ListServiceTemplatesInput,
+  ): Effect.Effect<
+    ListServiceTemplatesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServices(
+    input: ListServicesInput,
+  ): Effect.Effect<
+    ListServicesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  rejectEnvironmentAccountConnection(
+    input: RejectEnvironmentAccountConnectionInput,
+  ): Effect.Effect<
+    RejectEnvironmentAccountConnectionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAccountSettings(
+    input: UpdateAccountSettingsInput,
+  ): Effect.Effect<
+    UpdateAccountSettingsOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateComponent(
+    input: UpdateComponentInput,
+  ): Effect.Effect<
+    UpdateComponentOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEnvironment(
+    input: UpdateEnvironmentInput,
+  ): Effect.Effect<
+    UpdateEnvironmentOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEnvironmentAccountConnection(
+    input: UpdateEnvironmentAccountConnectionInput,
+  ): Effect.Effect<
+    UpdateEnvironmentAccountConnectionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEnvironmentTemplate(
+    input: UpdateEnvironmentTemplateInput,
+  ): Effect.Effect<
+    UpdateEnvironmentTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEnvironmentTemplateVersion(
+    input: UpdateEnvironmentTemplateVersionInput,
+  ): Effect.Effect<
+    UpdateEnvironmentTemplateVersionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateService(
+    input: UpdateServiceInput,
+  ): Effect.Effect<
+    UpdateServiceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateServiceInstance(
+    input: UpdateServiceInstanceInput,
+  ): Effect.Effect<
+    UpdateServiceInstanceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateServicePipeline(
+    input: UpdateServicePipelineInput,
+  ): Effect.Effect<
+    UpdateServicePipelineOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateServiceSyncBlocker(
+    input: UpdateServiceSyncBlockerInput,
+  ): Effect.Effect<
+    UpdateServiceSyncBlockerOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateServiceSyncConfig(
+    input: UpdateServiceSyncConfigInput,
+  ): Effect.Effect<
+    UpdateServiceSyncConfigOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateServiceTemplate(
+    input: UpdateServiceTemplateInput,
+  ): Effect.Effect<
+    UpdateServiceTemplateOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateServiceTemplateVersion(
+    input: UpdateServiceTemplateVersionInput,
+  ): Effect.Effect<
+    UpdateServiceTemplateVersionOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTemplateSyncConfig(
+    input: UpdateTemplateSyncConfigInput,
+  ): Effect.Effect<
+    UpdateTemplateSyncConfigOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export interface AcceptEnvironmentAccountConnectionInput {
@@ -1768,6 +2622,934 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceInput;
   export type Output = UntagResourceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AcceptEnvironmentAccountConnection {
+  export type Input = AcceptEnvironmentAccountConnectionInput;
+  export type Output = AcceptEnvironmentAccountConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateComponent {
+  export type Input = CreateComponentInput;
+  export type Output = CreateComponentOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEnvironment {
+  export type Input = CreateEnvironmentInput;
+  export type Output = CreateEnvironmentOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEnvironmentAccountConnection {
+  export type Input = CreateEnvironmentAccountConnectionInput;
+  export type Output = CreateEnvironmentAccountConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEnvironmentTemplate {
+  export type Input = CreateEnvironmentTemplateInput;
+  export type Output = CreateEnvironmentTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEnvironmentTemplateVersion {
+  export type Input = CreateEnvironmentTemplateVersionInput;
+  export type Output = CreateEnvironmentTemplateVersionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRepository {
+  export type Input = CreateRepositoryInput;
+  export type Output = CreateRepositoryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateService {
+  export type Input = CreateServiceInput;
+  export type Output = CreateServiceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceInstance {
+  export type Input = CreateServiceInstanceInput;
+  export type Output = CreateServiceInstanceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceSyncConfig {
+  export type Input = CreateServiceSyncConfigInput;
+  export type Output = CreateServiceSyncConfigOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceTemplate {
+  export type Input = CreateServiceTemplateInput;
+  export type Output = CreateServiceTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceTemplateVersion {
+  export type Input = CreateServiceTemplateVersionInput;
+  export type Output = CreateServiceTemplateVersionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTemplateSyncConfig {
+  export type Input = CreateTemplateSyncConfigInput;
+  export type Output = CreateTemplateSyncConfigOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteComponent {
+  export type Input = DeleteComponentInput;
+  export type Output = DeleteComponentOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDeployment {
+  export type Input = DeleteDeploymentInput;
+  export type Output = DeleteDeploymentOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEnvironment {
+  export type Input = DeleteEnvironmentInput;
+  export type Output = DeleteEnvironmentOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEnvironmentAccountConnection {
+  export type Input = DeleteEnvironmentAccountConnectionInput;
+  export type Output = DeleteEnvironmentAccountConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEnvironmentTemplate {
+  export type Input = DeleteEnvironmentTemplateInput;
+  export type Output = DeleteEnvironmentTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEnvironmentTemplateVersion {
+  export type Input = DeleteEnvironmentTemplateVersionInput;
+  export type Output = DeleteEnvironmentTemplateVersionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRepository {
+  export type Input = DeleteRepositoryInput;
+  export type Output = DeleteRepositoryOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteService {
+  export type Input = DeleteServiceInput;
+  export type Output = DeleteServiceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServiceSyncConfig {
+  export type Input = DeleteServiceSyncConfigInput;
+  export type Output = DeleteServiceSyncConfigOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServiceTemplate {
+  export type Input = DeleteServiceTemplateInput;
+  export type Output = DeleteServiceTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServiceTemplateVersion {
+  export type Input = DeleteServiceTemplateVersionInput;
+  export type Output = DeleteServiceTemplateVersionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTemplateSyncConfig {
+  export type Input = DeleteTemplateSyncConfigInput;
+  export type Output = DeleteTemplateSyncConfigOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAccountSettings {
+  export type Input = GetAccountSettingsInput;
+  export type Output = GetAccountSettingsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetComponent {
+  export type Input = GetComponentInput;
+  export type Output = GetComponentOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDeployment {
+  export type Input = GetDeploymentInput;
+  export type Output = GetDeploymentOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnvironment {
+  export type Input = GetEnvironmentInput;
+  export type Output = GetEnvironmentOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnvironmentAccountConnection {
+  export type Input = GetEnvironmentAccountConnectionInput;
+  export type Output = GetEnvironmentAccountConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnvironmentTemplate {
+  export type Input = GetEnvironmentTemplateInput;
+  export type Output = GetEnvironmentTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEnvironmentTemplateVersion {
+  export type Input = GetEnvironmentTemplateVersionInput;
+  export type Output = GetEnvironmentTemplateVersionOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRepository {
+  export type Input = GetRepositoryInput;
+  export type Output = GetRepositoryOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetService {
+  export type Input = GetServiceInput;
+  export type Output = GetServiceOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceInstance {
+  export type Input = GetServiceInstanceInput;
+  export type Output = GetServiceInstanceOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceSyncBlockerSummary {
+  export type Input = GetServiceSyncBlockerSummaryInput;
+  export type Output = GetServiceSyncBlockerSummaryOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceSyncConfig {
+  export type Input = GetServiceSyncConfigInput;
+  export type Output = GetServiceSyncConfigOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceTemplate {
+  export type Input = GetServiceTemplateInput;
+  export type Output = GetServiceTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceTemplateVersion {
+  export type Input = GetServiceTemplateVersionInput;
+  export type Output = GetServiceTemplateVersionOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTemplateSyncConfig {
+  export type Input = GetTemplateSyncConfigInput;
+  export type Output = GetTemplateSyncConfigOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListComponentOutputs {
+  export type Input = ListComponentOutputsInput;
+  export type Output = ListComponentOutputsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListComponentProvisionedResources {
+  export type Input = ListComponentProvisionedResourcesInput;
+  export type Output = ListComponentProvisionedResourcesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListComponents {
+  export type Input = ListComponentsInput;
+  export type Output = ListComponentsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDeployments {
+  export type Input = ListDeploymentsInput;
+  export type Output = ListDeploymentsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironmentAccountConnections {
+  export type Input = ListEnvironmentAccountConnectionsInput;
+  export type Output = ListEnvironmentAccountConnectionsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironmentOutputs {
+  export type Input = ListEnvironmentOutputsInput;
+  export type Output = ListEnvironmentOutputsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironmentProvisionedResources {
+  export type Input = ListEnvironmentProvisionedResourcesInput;
+  export type Output = ListEnvironmentProvisionedResourcesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironmentTemplateVersions {
+  export type Input = ListEnvironmentTemplateVersionsInput;
+  export type Output = ListEnvironmentTemplateVersionsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironmentTemplates {
+  export type Input = ListEnvironmentTemplatesInput;
+  export type Output = ListEnvironmentTemplatesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEnvironments {
+  export type Input = ListEnvironmentsInput;
+  export type Output = ListEnvironmentsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRepositories {
+  export type Input = ListRepositoriesInput;
+  export type Output = ListRepositoriesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceInstanceOutputs {
+  export type Input = ListServiceInstanceOutputsInput;
+  export type Output = ListServiceInstanceOutputsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceInstanceProvisionedResources {
+  export type Input = ListServiceInstanceProvisionedResourcesInput;
+  export type Output = ListServiceInstanceProvisionedResourcesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceInstances {
+  export type Input = ListServiceInstancesInput;
+  export type Output = ListServiceInstancesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServicePipelineOutputs {
+  export type Input = ListServicePipelineOutputsInput;
+  export type Output = ListServicePipelineOutputsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServicePipelineProvisionedResources {
+  export type Input = ListServicePipelineProvisionedResourcesInput;
+  export type Output = ListServicePipelineProvisionedResourcesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceTemplateVersions {
+  export type Input = ListServiceTemplateVersionsInput;
+  export type Output = ListServiceTemplateVersionsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceTemplates {
+  export type Input = ListServiceTemplatesInput;
+  export type Output = ListServiceTemplatesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServices {
+  export type Input = ListServicesInput;
+  export type Output = ListServicesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RejectEnvironmentAccountConnection {
+  export type Input = RejectEnvironmentAccountConnectionInput;
+  export type Output = RejectEnvironmentAccountConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAccountSettings {
+  export type Input = UpdateAccountSettingsInput;
+  export type Output = UpdateAccountSettingsOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateComponent {
+  export type Input = UpdateComponentInput;
+  export type Output = UpdateComponentOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEnvironment {
+  export type Input = UpdateEnvironmentInput;
+  export type Output = UpdateEnvironmentOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEnvironmentAccountConnection {
+  export type Input = UpdateEnvironmentAccountConnectionInput;
+  export type Output = UpdateEnvironmentAccountConnectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEnvironmentTemplate {
+  export type Input = UpdateEnvironmentTemplateInput;
+  export type Output = UpdateEnvironmentTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEnvironmentTemplateVersion {
+  export type Input = UpdateEnvironmentTemplateVersionInput;
+  export type Output = UpdateEnvironmentTemplateVersionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateService {
+  export type Input = UpdateServiceInput;
+  export type Output = UpdateServiceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServiceInstance {
+  export type Input = UpdateServiceInstanceInput;
+  export type Output = UpdateServiceInstanceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServicePipeline {
+  export type Input = UpdateServicePipelineInput;
+  export type Output = UpdateServicePipelineOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServiceSyncBlocker {
+  export type Input = UpdateServiceSyncBlockerInput;
+  export type Output = UpdateServiceSyncBlockerOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServiceSyncConfig {
+  export type Input = UpdateServiceSyncConfigInput;
+  export type Output = UpdateServiceSyncConfigOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServiceTemplate {
+  export type Input = UpdateServiceTemplateInput;
+  export type Output = UpdateServiceTemplateOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServiceTemplateVersion {
+  export type Input = UpdateServiceTemplateVersionInput;
+  export type Output = UpdateServiceTemplateVersionOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTemplateSyncConfig {
+  export type Input = UpdateTemplateSyncConfigInput;
+  export type Output = UpdateTemplateSyncConfigOutput;
   export type Error =
     | AccessDeniedException
     | ConflictException

--- a/src/services/qbusiness/index.ts
+++ b/src/services/qbusiness/index.ts
@@ -564,6 +564,421 @@ export declare class QBusiness extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createApplication(
+    input: CreateApplicationRequest,
+  ): Effect.Effect<
+    CreateApplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataAccessor(
+    input: CreateDataAccessorRequest,
+  ): Effect.Effect<
+    CreateDataAccessorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataSource(
+    input: CreateDataSourceRequest,
+  ): Effect.Effect<
+    CreateDataSourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createIndex(
+    input: CreateIndexRequest,
+  ): Effect.Effect<
+    CreateIndexResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPlugin(
+    input: CreatePluginRequest,
+  ): Effect.Effect<
+    CreatePluginResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRetriever(
+    input: CreateRetrieverRequest,
+  ): Effect.Effect<
+    CreateRetrieverResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWebExperience(
+    input: CreateWebExperienceRequest,
+  ): Effect.Effect<
+    CreateWebExperienceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteApplication(
+    input: DeleteApplicationRequest,
+  ): Effect.Effect<
+    DeleteApplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataAccessor(
+    input: DeleteDataAccessorRequest,
+  ): Effect.Effect<
+    DeleteDataAccessorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataSource(
+    input: DeleteDataSourceRequest,
+  ): Effect.Effect<
+    DeleteDataSourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteIndex(
+    input: DeleteIndexRequest,
+  ): Effect.Effect<
+    DeleteIndexResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePlugin(
+    input: DeletePluginRequest,
+  ): Effect.Effect<
+    DeletePluginResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRetriever(
+    input: DeleteRetrieverRequest,
+  ): Effect.Effect<
+    DeleteRetrieverResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWebExperience(
+    input: DeleteWebExperienceRequest,
+  ): Effect.Effect<
+    DeleteWebExperienceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApplication(
+    input: GetApplicationRequest,
+  ): Effect.Effect<
+    GetApplicationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataAccessor(
+    input: GetDataAccessorRequest,
+  ): Effect.Effect<
+    GetDataAccessorResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataSource(
+    input: GetDataSourceRequest,
+  ): Effect.Effect<
+    GetDataSourceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getIndex(
+    input: GetIndexRequest,
+  ): Effect.Effect<
+    GetIndexResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getPlugin(
+    input: GetPluginRequest,
+  ): Effect.Effect<
+    GetPluginResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRetriever(
+    input: GetRetrieverRequest,
+  ): Effect.Effect<
+    GetRetrieverResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWebExperience(
+    input: GetWebExperienceRequest,
+  ): Effect.Effect<
+    GetWebExperienceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApplications(
+    input: ListApplicationsRequest,
+  ): Effect.Effect<
+    ListApplicationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataAccessors(
+    input: ListDataAccessorsRequest,
+  ): Effect.Effect<
+    ListDataAccessorsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataSources(
+    input: ListDataSourcesRequest,
+  ): Effect.Effect<
+    ListDataSourcesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIndices(
+    input: ListIndicesRequest,
+  ): Effect.Effect<
+    ListIndicesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPlugins(
+    input: ListPluginsRequest,
+  ): Effect.Effect<
+    ListPluginsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRetrievers(
+    input: ListRetrieversRequest,
+  ): Effect.Effect<
+    ListRetrieversResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWebExperiences(
+    input: ListWebExperiencesRequest,
+  ): Effect.Effect<
+    ListWebExperiencesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateApplication(
+    input: UpdateApplicationRequest,
+  ): Effect.Effect<
+    UpdateApplicationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataAccessor(
+    input: UpdateDataAccessorRequest,
+  ): Effect.Effect<
+    UpdateDataAccessorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataSource(
+    input: UpdateDataSourceRequest,
+  ): Effect.Effect<
+    UpdateDataSourceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateIndex(
+    input: UpdateIndexRequest,
+  ): Effect.Effect<
+    UpdateIndexResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updatePlugin(
+    input: UpdatePluginRequest,
+  ): Effect.Effect<
+    UpdatePluginResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateRetriever(
+    input: UpdateRetrieverRequest,
+  ): Effect.Effect<
+    UpdateRetrieverResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWebExperience(
+    input: UpdateWebExperienceRequest,
+  ): Effect.Effect<
+    UpdateWebExperienceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Qbusiness extends QBusiness {}
@@ -3523,6 +3938,456 @@ export declare namespace UpdateUser {
     | InternalServerException
     | ResourceNotFoundException
     | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateApplication {
+  export type Input = CreateApplicationRequest;
+  export type Output = CreateApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataAccessor {
+  export type Input = CreateDataAccessorRequest;
+  export type Output = CreateDataAccessorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataSource {
+  export type Input = CreateDataSourceRequest;
+  export type Output = CreateDataSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateIndex {
+  export type Input = CreateIndexRequest;
+  export type Output = CreateIndexResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePlugin {
+  export type Input = CreatePluginRequest;
+  export type Output = CreatePluginResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRetriever {
+  export type Input = CreateRetrieverRequest;
+  export type Output = CreateRetrieverResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWebExperience {
+  export type Input = CreateWebExperienceRequest;
+  export type Output = CreateWebExperienceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplication {
+  export type Input = DeleteApplicationRequest;
+  export type Output = DeleteApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataAccessor {
+  export type Input = DeleteDataAccessorRequest;
+  export type Output = DeleteDataAccessorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataSource {
+  export type Input = DeleteDataSourceRequest;
+  export type Output = DeleteDataSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIndex {
+  export type Input = DeleteIndexRequest;
+  export type Output = DeleteIndexResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePlugin {
+  export type Input = DeletePluginRequest;
+  export type Output = DeletePluginResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRetriever {
+  export type Input = DeleteRetrieverRequest;
+  export type Output = DeleteRetrieverResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWebExperience {
+  export type Input = DeleteWebExperienceRequest;
+  export type Output = DeleteWebExperienceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApplication {
+  export type Input = GetApplicationRequest;
+  export type Output = GetApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataAccessor {
+  export type Input = GetDataAccessorRequest;
+  export type Output = GetDataAccessorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataSource {
+  export type Input = GetDataSourceRequest;
+  export type Output = GetDataSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetIndex {
+  export type Input = GetIndexRequest;
+  export type Output = GetIndexResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetPlugin {
+  export type Input = GetPluginRequest;
+  export type Output = GetPluginResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRetriever {
+  export type Input = GetRetrieverRequest;
+  export type Output = GetRetrieverResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWebExperience {
+  export type Input = GetWebExperienceRequest;
+  export type Output = GetWebExperienceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplications {
+  export type Input = ListApplicationsRequest;
+  export type Output = ListApplicationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataAccessors {
+  export type Input = ListDataAccessorsRequest;
+  export type Output = ListDataAccessorsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataSources {
+  export type Input = ListDataSourcesRequest;
+  export type Output = ListDataSourcesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIndices {
+  export type Input = ListIndicesRequest;
+  export type Output = ListIndicesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPlugins {
+  export type Input = ListPluginsRequest;
+  export type Output = ListPluginsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRetrievers {
+  export type Input = ListRetrieversRequest;
+  export type Output = ListRetrieversResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWebExperiences {
+  export type Input = ListWebExperiencesRequest;
+  export type Output = ListWebExperiencesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateApplication {
+  export type Input = UpdateApplicationRequest;
+  export type Output = UpdateApplicationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataAccessor {
+  export type Input = UpdateDataAccessorRequest;
+  export type Output = UpdateDataAccessorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataSource {
+  export type Input = UpdateDataSourceRequest;
+  export type Output = UpdateDataSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateIndex {
+  export type Input = UpdateIndexRequest;
+  export type Output = UpdateIndexResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePlugin {
+  export type Input = UpdatePluginRequest;
+  export type Output = UpdatePluginResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRetriever {
+  export type Input = UpdateRetrieverRequest;
+  export type Output = UpdateRetrieverResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWebExperience {
+  export type Input = UpdateWebExperienceRequest;
+  export type Output = UpdateWebExperienceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
     | ThrottlingException
     | ValidationException
     | CommonAwsError;

--- a/src/services/qconnect/index.ts
+++ b/src/services/qconnect/index.ts
@@ -21,6 +21,946 @@ export declare class QConnect extends AWSServiceClient {
     UntagResourceResponse,
     ResourceNotFoundException | CommonAwsError
   >;
+  activateMessageTemplate(
+    input: ActivateMessageTemplateRequest,
+  ): Effect.Effect<
+    ActivateMessageTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAIAgent(
+    input: CreateAIAgentRequest,
+  ): Effect.Effect<
+    CreateAIAgentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAIAgentVersion(
+    input: CreateAIAgentVersionRequest,
+  ): Effect.Effect<
+    CreateAIAgentVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAIGuardrail(
+    input: CreateAIGuardrailRequest,
+  ): Effect.Effect<
+    CreateAIGuardrailResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAIGuardrailVersion(
+    input: CreateAIGuardrailVersionRequest,
+  ): Effect.Effect<
+    CreateAIGuardrailVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAIPrompt(
+    input: CreateAIPromptRequest,
+  ): Effect.Effect<
+    CreateAIPromptResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAIPromptVersion(
+    input: CreateAIPromptVersionRequest,
+  ): Effect.Effect<
+    CreateAIPromptVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAssistant(
+    input: CreateAssistantRequest,
+  ): Effect.Effect<
+    CreateAssistantResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAssistantAssociation(
+    input: CreateAssistantAssociationRequest,
+  ): Effect.Effect<
+    CreateAssistantAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createContent(
+    input: CreateContentRequest,
+  ): Effect.Effect<
+    CreateContentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createContentAssociation(
+    input: CreateContentAssociationRequest,
+  ): Effect.Effect<
+    CreateContentAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createKnowledgeBase(
+    input: CreateKnowledgeBaseRequest,
+  ): Effect.Effect<
+    CreateKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createMessageTemplate(
+    input: CreateMessageTemplateRequest,
+  ): Effect.Effect<
+    CreateMessageTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createMessageTemplateAttachment(
+    input: CreateMessageTemplateAttachmentRequest,
+  ): Effect.Effect<
+    CreateMessageTemplateAttachmentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createMessageTemplateVersion(
+    input: CreateMessageTemplateVersionRequest,
+  ): Effect.Effect<
+    CreateMessageTemplateVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createQuickResponse(
+    input: CreateQuickResponseRequest,
+  ): Effect.Effect<
+    CreateQuickResponseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSession(
+    input: CreateSessionRequest,
+  ): Effect.Effect<
+    CreateSessionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deactivateMessageTemplate(
+    input: DeactivateMessageTemplateRequest,
+  ): Effect.Effect<
+    DeactivateMessageTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAIAgent(
+    input: DeleteAIAgentRequest,
+  ): Effect.Effect<
+    DeleteAIAgentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAIAgentVersion(
+    input: DeleteAIAgentVersionRequest,
+  ): Effect.Effect<
+    DeleteAIAgentVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAIGuardrail(
+    input: DeleteAIGuardrailRequest,
+  ): Effect.Effect<
+    DeleteAIGuardrailResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAIGuardrailVersion(
+    input: DeleteAIGuardrailVersionRequest,
+  ): Effect.Effect<
+    DeleteAIGuardrailVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAIPrompt(
+    input: DeleteAIPromptRequest,
+  ): Effect.Effect<
+    DeleteAIPromptResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAIPromptVersion(
+    input: DeleteAIPromptVersionRequest,
+  ): Effect.Effect<
+    DeleteAIPromptVersionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAssistant(
+    input: DeleteAssistantRequest,
+  ): Effect.Effect<
+    DeleteAssistantResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAssistantAssociation(
+    input: DeleteAssistantAssociationRequest,
+  ): Effect.Effect<
+    DeleteAssistantAssociationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteContent(
+    input: DeleteContentRequest,
+  ): Effect.Effect<
+    DeleteContentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteContentAssociation(
+    input: DeleteContentAssociationRequest,
+  ): Effect.Effect<
+    DeleteContentAssociationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteImportJob(
+    input: DeleteImportJobRequest,
+  ): Effect.Effect<
+    DeleteImportJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteKnowledgeBase(
+    input: DeleteKnowledgeBaseRequest,
+  ): Effect.Effect<
+    DeleteKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMessageTemplate(
+    input: DeleteMessageTemplateRequest,
+  ): Effect.Effect<
+    DeleteMessageTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteMessageTemplateAttachment(
+    input: DeleteMessageTemplateAttachmentRequest,
+  ): Effect.Effect<
+    DeleteMessageTemplateAttachmentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteQuickResponse(
+    input: DeleteQuickResponseRequest,
+  ): Effect.Effect<
+    DeleteQuickResponseResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAIAgent(
+    input: GetAIAgentRequest,
+  ): Effect.Effect<
+    GetAIAgentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAIGuardrail(
+    input: GetAIGuardrailRequest,
+  ): Effect.Effect<
+    GetAIGuardrailResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAIPrompt(
+    input: GetAIPromptRequest,
+  ): Effect.Effect<
+    GetAIPromptResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAssistant(
+    input: GetAssistantRequest,
+  ): Effect.Effect<
+    GetAssistantResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAssistantAssociation(
+    input: GetAssistantAssociationRequest,
+  ): Effect.Effect<
+    GetAssistantAssociationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getContent(
+    input: GetContentRequest,
+  ): Effect.Effect<
+    GetContentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getContentAssociation(
+    input: GetContentAssociationRequest,
+  ): Effect.Effect<
+    GetContentAssociationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getContentSummary(
+    input: GetContentSummaryRequest,
+  ): Effect.Effect<
+    GetContentSummaryResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getImportJob(
+    input: GetImportJobRequest,
+  ): Effect.Effect<
+    GetImportJobResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getKnowledgeBase(
+    input: GetKnowledgeBaseRequest,
+  ): Effect.Effect<
+    GetKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getMessageTemplate(
+    input: GetMessageTemplateRequest,
+  ): Effect.Effect<
+    GetMessageTemplateResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getNextMessage(
+    input: GetNextMessageRequest,
+  ): Effect.Effect<
+    GetNextMessageResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQuickResponse(
+    input: GetQuickResponseRequest,
+  ): Effect.Effect<
+    GetQuickResponseResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRecommendations(
+    input: GetRecommendationsRequest,
+  ): Effect.Effect<
+    GetRecommendationsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSession(
+    input: GetSessionRequest,
+  ): Effect.Effect<
+    GetSessionResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAIAgentVersions(
+    input: ListAIAgentVersionsRequest,
+  ): Effect.Effect<
+    ListAIAgentVersionsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAIAgents(
+    input: ListAIAgentsRequest,
+  ): Effect.Effect<
+    ListAIAgentsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAIGuardrailVersions(
+    input: ListAIGuardrailVersionsRequest,
+  ): Effect.Effect<
+    ListAIGuardrailVersionsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAIGuardrails(
+    input: ListAIGuardrailsRequest,
+  ): Effect.Effect<
+    ListAIGuardrailsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAIPromptVersions(
+    input: ListAIPromptVersionsRequest,
+  ): Effect.Effect<
+    ListAIPromptVersionsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAIPrompts(
+    input: ListAIPromptsRequest,
+  ): Effect.Effect<
+    ListAIPromptsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAssistantAssociations(
+    input: ListAssistantAssociationsRequest,
+  ): Effect.Effect<
+    ListAssistantAssociationsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAssistants(
+    input: ListAssistantsRequest,
+  ): Effect.Effect<
+    ListAssistantsResponse,
+    | AccessDeniedException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listContentAssociations(
+    input: ListContentAssociationsRequest,
+  ): Effect.Effect<
+    ListContentAssociationsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listContents(
+    input: ListContentsRequest,
+  ): Effect.Effect<
+    ListContentsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listImportJobs(
+    input: ListImportJobsRequest,
+  ): Effect.Effect<
+    ListImportJobsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listKnowledgeBases(
+    input: ListKnowledgeBasesRequest,
+  ): Effect.Effect<
+    ListKnowledgeBasesResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listMessageTemplateVersions(
+    input: ListMessageTemplateVersionsRequest,
+  ): Effect.Effect<
+    ListMessageTemplateVersionsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMessageTemplates(
+    input: ListMessageTemplatesRequest,
+  ): Effect.Effect<
+    ListMessageTemplatesResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listMessages(
+    input: ListMessagesRequest,
+  ): Effect.Effect<
+    ListMessagesResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listQuickResponses(
+    input: ListQuickResponsesRequest,
+  ): Effect.Effect<
+    ListQuickResponsesResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  notifyRecommendationsReceived(
+    input: NotifyRecommendationsReceivedRequest,
+  ): Effect.Effect<
+    NotifyRecommendationsReceivedResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putFeedback(
+    input: PutFeedbackRequest,
+  ): Effect.Effect<
+    PutFeedbackResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  queryAssistant(
+    input: QueryAssistantRequest,
+  ): Effect.Effect<
+    QueryAssistantResponse,
+    | AccessDeniedException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  removeAssistantAIAgent(
+    input: RemoveAssistantAIAgentRequest,
+  ): Effect.Effect<
+    RemoveAssistantAIAgentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  removeKnowledgeBaseTemplateUri(
+    input: RemoveKnowledgeBaseTemplateUriRequest,
+  ): Effect.Effect<
+    RemoveKnowledgeBaseTemplateUriResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  renderMessageTemplate(
+    input: RenderMessageTemplateRequest,
+  ): Effect.Effect<
+    RenderMessageTemplateResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchContent(
+    input: SearchContentRequest,
+  ): Effect.Effect<
+    SearchContentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchMessageTemplates(
+    input: SearchMessageTemplatesRequest,
+  ): Effect.Effect<
+    SearchMessageTemplatesResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchQuickResponses(
+    input: SearchQuickResponsesRequest,
+  ): Effect.Effect<
+    SearchQuickResponsesResponse,
+    | AccessDeniedException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchSessions(
+    input: SearchSessionsRequest,
+  ): Effect.Effect<
+    SearchSessionsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  sendMessage(
+    input: SendMessageRequest,
+  ): Effect.Effect<
+    SendMessageResponse,
+    | AccessDeniedException
+    | ConflictException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startContentUpload(
+    input: StartContentUploadRequest,
+  ): Effect.Effect<
+    StartContentUploadResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startImportJob(
+    input: StartImportJobRequest,
+  ): Effect.Effect<
+    StartImportJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAIAgent(
+    input: UpdateAIAgentRequest,
+  ): Effect.Effect<
+    UpdateAIAgentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAIGuardrail(
+    input: UpdateAIGuardrailRequest,
+  ): Effect.Effect<
+    UpdateAIGuardrailResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAIPrompt(
+    input: UpdateAIPromptRequest,
+  ): Effect.Effect<
+    UpdateAIPromptResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAssistantAIAgent(
+    input: UpdateAssistantAIAgentRequest,
+  ): Effect.Effect<
+    UpdateAssistantAIAgentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateContent(
+    input: UpdateContentRequest,
+  ): Effect.Effect<
+    UpdateContentResponse,
+    | AccessDeniedException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateKnowledgeBaseTemplateUri(
+    input: UpdateKnowledgeBaseTemplateUriRequest,
+  ): Effect.Effect<
+    UpdateKnowledgeBaseTemplateUriResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateMessageTemplate(
+    input: UpdateMessageTemplateRequest,
+  ): Effect.Effect<
+    UpdateMessageTemplateResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateMessageTemplateMetadata(
+    input: UpdateMessageTemplateMetadataRequest,
+  ): Effect.Effect<
+    UpdateMessageTemplateMetadataResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateQuickResponse(
+    input: UpdateQuickResponseRequest,
+  ): Effect.Effect<
+    UpdateQuickResponseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSession(
+    input: UpdateSessionRequest,
+  ): Effect.Effect<
+    UpdateSessionResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSessionData(
+    input: UpdateSessionDataRequest,
+  ): Effect.Effect<
+    UpdateSessionDataResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Qconnect extends QConnect {}
@@ -2350,4 +3290,1036 @@ export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
   export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace ActivateMessageTemplate {
+  export type Input = ActivateMessageTemplateRequest;
+  export type Output = ActivateMessageTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAIAgent {
+  export type Input = CreateAIAgentRequest;
+  export type Output = CreateAIAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAIAgentVersion {
+  export type Input = CreateAIAgentVersionRequest;
+  export type Output = CreateAIAgentVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAIGuardrail {
+  export type Input = CreateAIGuardrailRequest;
+  export type Output = CreateAIGuardrailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAIGuardrailVersion {
+  export type Input = CreateAIGuardrailVersionRequest;
+  export type Output = CreateAIGuardrailVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAIPrompt {
+  export type Input = CreateAIPromptRequest;
+  export type Output = CreateAIPromptResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAIPromptVersion {
+  export type Input = CreateAIPromptVersionRequest;
+  export type Output = CreateAIPromptVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAssistant {
+  export type Input = CreateAssistantRequest;
+  export type Output = CreateAssistantResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAssistantAssociation {
+  export type Input = CreateAssistantAssociationRequest;
+  export type Output = CreateAssistantAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateContent {
+  export type Input = CreateContentRequest;
+  export type Output = CreateContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateContentAssociation {
+  export type Input = CreateContentAssociationRequest;
+  export type Output = CreateContentAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateKnowledgeBase {
+  export type Input = CreateKnowledgeBaseRequest;
+  export type Output = CreateKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMessageTemplate {
+  export type Input = CreateMessageTemplateRequest;
+  export type Output = CreateMessageTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMessageTemplateAttachment {
+  export type Input = CreateMessageTemplateAttachmentRequest;
+  export type Output = CreateMessageTemplateAttachmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateMessageTemplateVersion {
+  export type Input = CreateMessageTemplateVersionRequest;
+  export type Output = CreateMessageTemplateVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateQuickResponse {
+  export type Input = CreateQuickResponseRequest;
+  export type Output = CreateQuickResponseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSession {
+  export type Input = CreateSessionRequest;
+  export type Output = CreateSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeactivateMessageTemplate {
+  export type Input = DeactivateMessageTemplateRequest;
+  export type Output = DeactivateMessageTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAIAgent {
+  export type Input = DeleteAIAgentRequest;
+  export type Output = DeleteAIAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAIAgentVersion {
+  export type Input = DeleteAIAgentVersionRequest;
+  export type Output = DeleteAIAgentVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAIGuardrail {
+  export type Input = DeleteAIGuardrailRequest;
+  export type Output = DeleteAIGuardrailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAIGuardrailVersion {
+  export type Input = DeleteAIGuardrailVersionRequest;
+  export type Output = DeleteAIGuardrailVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAIPrompt {
+  export type Input = DeleteAIPromptRequest;
+  export type Output = DeleteAIPromptResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAIPromptVersion {
+  export type Input = DeleteAIPromptVersionRequest;
+  export type Output = DeleteAIPromptVersionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAssistant {
+  export type Input = DeleteAssistantRequest;
+  export type Output = DeleteAssistantResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAssistantAssociation {
+  export type Input = DeleteAssistantAssociationRequest;
+  export type Output = DeleteAssistantAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteContent {
+  export type Input = DeleteContentRequest;
+  export type Output = DeleteContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteContentAssociation {
+  export type Input = DeleteContentAssociationRequest;
+  export type Output = DeleteContentAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteImportJob {
+  export type Input = DeleteImportJobRequest;
+  export type Output = DeleteImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteKnowledgeBase {
+  export type Input = DeleteKnowledgeBaseRequest;
+  export type Output = DeleteKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMessageTemplate {
+  export type Input = DeleteMessageTemplateRequest;
+  export type Output = DeleteMessageTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteMessageTemplateAttachment {
+  export type Input = DeleteMessageTemplateAttachmentRequest;
+  export type Output = DeleteMessageTemplateAttachmentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteQuickResponse {
+  export type Input = DeleteQuickResponseRequest;
+  export type Output = DeleteQuickResponseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAIAgent {
+  export type Input = GetAIAgentRequest;
+  export type Output = GetAIAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAIGuardrail {
+  export type Input = GetAIGuardrailRequest;
+  export type Output = GetAIGuardrailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAIPrompt {
+  export type Input = GetAIPromptRequest;
+  export type Output = GetAIPromptResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAssistant {
+  export type Input = GetAssistantRequest;
+  export type Output = GetAssistantResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAssistantAssociation {
+  export type Input = GetAssistantAssociationRequest;
+  export type Output = GetAssistantAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetContent {
+  export type Input = GetContentRequest;
+  export type Output = GetContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetContentAssociation {
+  export type Input = GetContentAssociationRequest;
+  export type Output = GetContentAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetContentSummary {
+  export type Input = GetContentSummaryRequest;
+  export type Output = GetContentSummaryResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetImportJob {
+  export type Input = GetImportJobRequest;
+  export type Output = GetImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetKnowledgeBase {
+  export type Input = GetKnowledgeBaseRequest;
+  export type Output = GetKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetMessageTemplate {
+  export type Input = GetMessageTemplateRequest;
+  export type Output = GetMessageTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetNextMessage {
+  export type Input = GetNextMessageRequest;
+  export type Output = GetNextMessageResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQuickResponse {
+  export type Input = GetQuickResponseRequest;
+  export type Output = GetQuickResponseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRecommendations {
+  export type Input = GetRecommendationsRequest;
+  export type Output = GetRecommendationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSession {
+  export type Input = GetSessionRequest;
+  export type Output = GetSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAIAgentVersions {
+  export type Input = ListAIAgentVersionsRequest;
+  export type Output = ListAIAgentVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAIAgents {
+  export type Input = ListAIAgentsRequest;
+  export type Output = ListAIAgentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAIGuardrailVersions {
+  export type Input = ListAIGuardrailVersionsRequest;
+  export type Output = ListAIGuardrailVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAIGuardrails {
+  export type Input = ListAIGuardrailsRequest;
+  export type Output = ListAIGuardrailsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAIPromptVersions {
+  export type Input = ListAIPromptVersionsRequest;
+  export type Output = ListAIPromptVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAIPrompts {
+  export type Input = ListAIPromptsRequest;
+  export type Output = ListAIPromptsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAssistantAssociations {
+  export type Input = ListAssistantAssociationsRequest;
+  export type Output = ListAssistantAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAssistants {
+  export type Input = ListAssistantsRequest;
+  export type Output = ListAssistantsResponse;
+  export type Error =
+    | AccessDeniedException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListContentAssociations {
+  export type Input = ListContentAssociationsRequest;
+  export type Output = ListContentAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListContents {
+  export type Input = ListContentsRequest;
+  export type Output = ListContentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListImportJobs {
+  export type Input = ListImportJobsRequest;
+  export type Output = ListImportJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListKnowledgeBases {
+  export type Input = ListKnowledgeBasesRequest;
+  export type Output = ListKnowledgeBasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMessageTemplateVersions {
+  export type Input = ListMessageTemplateVersionsRequest;
+  export type Output = ListMessageTemplateVersionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMessageTemplates {
+  export type Input = ListMessageTemplatesRequest;
+  export type Output = ListMessageTemplatesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListMessages {
+  export type Input = ListMessagesRequest;
+  export type Output = ListMessagesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListQuickResponses {
+  export type Input = ListQuickResponsesRequest;
+  export type Output = ListQuickResponsesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace NotifyRecommendationsReceived {
+  export type Input = NotifyRecommendationsReceivedRequest;
+  export type Output = NotifyRecommendationsReceivedResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutFeedback {
+  export type Input = PutFeedbackRequest;
+  export type Output = PutFeedbackResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace QueryAssistant {
+  export type Input = QueryAssistantRequest;
+  export type Output = QueryAssistantResponse;
+  export type Error =
+    | AccessDeniedException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveAssistantAIAgent {
+  export type Input = RemoveAssistantAIAgentRequest;
+  export type Output = RemoveAssistantAIAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveKnowledgeBaseTemplateUri {
+  export type Input = RemoveKnowledgeBaseTemplateUriRequest;
+  export type Output = RemoveKnowledgeBaseTemplateUriResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RenderMessageTemplate {
+  export type Input = RenderMessageTemplateRequest;
+  export type Output = RenderMessageTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchContent {
+  export type Input = SearchContentRequest;
+  export type Output = SearchContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchMessageTemplates {
+  export type Input = SearchMessageTemplatesRequest;
+  export type Output = SearchMessageTemplatesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchQuickResponses {
+  export type Input = SearchQuickResponsesRequest;
+  export type Output = SearchQuickResponsesResponse;
+  export type Error =
+    | AccessDeniedException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchSessions {
+  export type Input = SearchSessionsRequest;
+  export type Output = SearchSessionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SendMessage {
+  export type Input = SendMessageRequest;
+  export type Output = SendMessageResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartContentUpload {
+  export type Input = StartContentUploadRequest;
+  export type Output = StartContentUploadResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartImportJob {
+  export type Input = StartImportJobRequest;
+  export type Output = StartImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAIAgent {
+  export type Input = UpdateAIAgentRequest;
+  export type Output = UpdateAIAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAIGuardrail {
+  export type Input = UpdateAIGuardrailRequest;
+  export type Output = UpdateAIGuardrailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAIPrompt {
+  export type Input = UpdateAIPromptRequest;
+  export type Output = UpdateAIPromptResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAssistantAIAgent {
+  export type Input = UpdateAssistantAIAgentRequest;
+  export type Output = UpdateAssistantAIAgentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateContent {
+  export type Input = UpdateContentRequest;
+  export type Output = UpdateContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateKnowledgeBaseTemplateUri {
+  export type Input = UpdateKnowledgeBaseTemplateUriRequest;
+  export type Output = UpdateKnowledgeBaseTemplateUriResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMessageTemplate {
+  export type Input = UpdateMessageTemplateRequest;
+  export type Output = UpdateMessageTemplateResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateMessageTemplateMetadata {
+  export type Input = UpdateMessageTemplateMetadataRequest;
+  export type Output = UpdateMessageTemplateMetadataResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateQuickResponse {
+  export type Input = UpdateQuickResponseRequest;
+  export type Output = UpdateQuickResponseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSession {
+  export type Input = UpdateSessionRequest;
+  export type Output = UpdateSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSessionData {
+  export type Input = UpdateSessionDataRequest;
+  export type Output = UpdateSessionDataResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
 }

--- a/src/services/redshift-serverless/index.ts
+++ b/src/services/redshift-serverless/index.ts
@@ -154,6 +154,490 @@ export declare class RedshiftServerless extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  convertRecoveryPointToSnapshot(
+    input: ConvertRecoveryPointToSnapshotRequest,
+  ): Effect.Effect<
+    ConvertRecoveryPointToSnapshotResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createEndpointAccess(
+    input: CreateEndpointAccessRequest,
+  ): Effect.Effect<
+    CreateEndpointAccessResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createNamespace(
+    input: CreateNamespaceRequest,
+  ): Effect.Effect<
+    CreateNamespaceResponse,
+    | ConflictException
+    | InternalServerException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createReservation(
+    input: CreateReservationRequest,
+  ): Effect.Effect<
+    CreateReservationResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createScheduledAction(
+    input: CreateScheduledActionRequest,
+  ): Effect.Effect<
+    CreateScheduledActionResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSnapshot(
+    input: CreateSnapshotRequest,
+  ): Effect.Effect<
+    CreateSnapshotResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSnapshotCopyConfiguration(
+    input: CreateSnapshotCopyConfigurationRequest,
+  ): Effect.Effect<
+    CreateSnapshotCopyConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createUsageLimit(
+    input: CreateUsageLimitRequest,
+  ): Effect.Effect<
+    CreateUsageLimitResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createWorkgroup(
+    input: CreateWorkgroupRequest,
+  ): Effect.Effect<
+    CreateWorkgroupResponse,
+    | ConflictException
+    | InsufficientCapacityException
+    | InternalServerException
+    | Ipv6CidrBlockNotFoundException
+    | ResourceNotFoundException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteEndpointAccess(
+    input: DeleteEndpointAccessRequest,
+  ): Effect.Effect<
+    DeleteEndpointAccessResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteNamespace(
+    input: DeleteNamespaceRequest,
+  ): Effect.Effect<
+    DeleteNamespaceResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteScheduledAction(
+    input: DeleteScheduledActionRequest,
+  ): Effect.Effect<
+    DeleteScheduledActionResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSnapshot(
+    input: DeleteSnapshotRequest,
+  ): Effect.Effect<
+    DeleteSnapshotResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSnapshotCopyConfiguration(
+    input: DeleteSnapshotCopyConfigurationRequest,
+  ): Effect.Effect<
+    DeleteSnapshotCopyConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteUsageLimit(
+    input: DeleteUsageLimitRequest,
+  ): Effect.Effect<
+    DeleteUsageLimitResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteWorkgroup(
+    input: DeleteWorkgroupRequest,
+  ): Effect.Effect<
+    DeleteWorkgroupResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEndpointAccess(
+    input: GetEndpointAccessRequest,
+  ): Effect.Effect<
+    GetEndpointAccessResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getNamespace(
+    input: GetNamespaceRequest,
+  ): Effect.Effect<
+    GetNamespaceResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRecoveryPoint(
+    input: GetRecoveryPointRequest,
+  ): Effect.Effect<
+    GetRecoveryPointResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReservation(
+    input: GetReservationRequest,
+  ): Effect.Effect<
+    GetReservationResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getReservationOffering(
+    input: GetReservationOfferingRequest,
+  ): Effect.Effect<
+    GetReservationOfferingResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getScheduledAction(
+    input: GetScheduledActionRequest,
+  ): Effect.Effect<
+    GetScheduledActionResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSnapshot(
+    input: GetSnapshotRequest,
+  ): Effect.Effect<
+    GetSnapshotResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTableRestoreStatus(
+    input: GetTableRestoreStatusRequest,
+  ): Effect.Effect<
+    GetTableRestoreStatusResponse,
+    ResourceNotFoundException | ValidationException | CommonAwsError
+  >;
+  getUsageLimit(
+    input: GetUsageLimitRequest,
+  ): Effect.Effect<
+    GetUsageLimitResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getWorkgroup(
+    input: GetWorkgroupRequest,
+  ): Effect.Effect<
+    GetWorkgroupResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEndpointAccess(
+    input: ListEndpointAccessRequest,
+  ): Effect.Effect<
+    ListEndpointAccessResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listManagedWorkgroups(
+    input: ListManagedWorkgroupsRequest,
+  ): Effect.Effect<
+    ListManagedWorkgroupsResponse,
+    AccessDeniedException | InternalServerException | CommonAwsError
+  >;
+  listNamespaces(
+    input: ListNamespacesRequest,
+  ): Effect.Effect<
+    ListNamespacesResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listRecoveryPoints(
+    input: ListRecoveryPointsRequest,
+  ): Effect.Effect<
+    ListRecoveryPointsResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  listReservationOfferings(
+    input: ListReservationOfferingsRequest,
+  ): Effect.Effect<
+    ListReservationOfferingsResponse,
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listReservations(
+    input: ListReservationsRequest,
+  ): Effect.Effect<
+    ListReservationsResponse,
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listScheduledActions(
+    input: ListScheduledActionsRequest,
+  ): Effect.Effect<
+    ListScheduledActionsResponse,
+    | InternalServerException
+    | InvalidPaginationException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSnapshotCopyConfigurations(
+    input: ListSnapshotCopyConfigurationsRequest,
+  ): Effect.Effect<
+    ListSnapshotCopyConfigurationsResponse,
+    | ConflictException
+    | InternalServerException
+    | InvalidPaginationException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSnapshots(
+    input: ListSnapshotsRequest,
+  ): Effect.Effect<
+    ListSnapshotsResponse,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTableRestoreStatus(
+    input: ListTableRestoreStatusRequest,
+  ): Effect.Effect<
+    ListTableRestoreStatusResponse,
+    | InvalidPaginationException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listUsageLimits(
+    input: ListUsageLimitsRequest,
+  ): Effect.Effect<
+    ListUsageLimitsResponse,
+    | ConflictException
+    | InternalServerException
+    | InvalidPaginationException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listWorkgroups(
+    input: ListWorkgroupsRequest,
+  ): Effect.Effect<
+    ListWorkgroupsResponse,
+    InternalServerException | ValidationException | CommonAwsError
+  >;
+  restoreFromRecoveryPoint(
+    input: RestoreFromRecoveryPointRequest,
+  ): Effect.Effect<
+    RestoreFromRecoveryPointResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  restoreFromSnapshot(
+    input: RestoreFromSnapshotRequest,
+  ): Effect.Effect<
+    RestoreFromSnapshotResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  restoreTableFromRecoveryPoint(
+    input: RestoreTableFromRecoveryPointRequest,
+  ): Effect.Effect<
+    RestoreTableFromRecoveryPointResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  restoreTableFromSnapshot(
+    input: RestoreTableFromSnapshotRequest,
+  ): Effect.Effect<
+    RestoreTableFromSnapshotResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateEndpointAccess(
+    input: UpdateEndpointAccessRequest,
+  ): Effect.Effect<
+    UpdateEndpointAccessResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateNamespace(
+    input: UpdateNamespaceRequest,
+  ): Effect.Effect<
+    UpdateNamespaceResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateScheduledAction(
+    input: UpdateScheduledActionRequest,
+  ): Effect.Effect<
+    UpdateScheduledActionResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSnapshot(
+    input: UpdateSnapshotRequest,
+  ): Effect.Effect<
+    UpdateSnapshotResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSnapshotCopyConfiguration(
+    input: UpdateSnapshotCopyConfigurationRequest,
+  ): Effect.Effect<
+    UpdateSnapshotCopyConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateUsageLimit(
+    input: UpdateUsageLimitRequest,
+  ): Effect.Effect<
+    UpdateUsageLimitResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateWorkgroup(
+    input: UpdateWorkgroupRequest,
+  ): Effect.Effect<
+    UpdateWorkgroupResponse,
+    | ConflictException
+    | InsufficientCapacityException
+    | InternalServerException
+    | Ipv6CidrBlockNotFoundException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -1293,6 +1777,549 @@ export declare namespace UpdateCustomDomainAssociation {
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ConvertRecoveryPointToSnapshot {
+  export type Input = ConvertRecoveryPointToSnapshotRequest;
+  export type Output = ConvertRecoveryPointToSnapshotResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateEndpointAccess {
+  export type Input = CreateEndpointAccessRequest;
+  export type Output = CreateEndpointAccessResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateNamespace {
+  export type Input = CreateNamespaceRequest;
+  export type Output = CreateNamespaceResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateReservation {
+  export type Input = CreateReservationRequest;
+  export type Output = CreateReservationResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateScheduledAction {
+  export type Input = CreateScheduledActionRequest;
+  export type Output = CreateScheduledActionResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSnapshot {
+  export type Input = CreateSnapshotRequest;
+  export type Output = CreateSnapshotResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSnapshotCopyConfiguration {
+  export type Input = CreateSnapshotCopyConfigurationRequest;
+  export type Output = CreateSnapshotCopyConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateUsageLimit {
+  export type Input = CreateUsageLimitRequest;
+  export type Output = CreateUsageLimitResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkgroup {
+  export type Input = CreateWorkgroupRequest;
+  export type Output = CreateWorkgroupResponse;
+  export type Error =
+    | ConflictException
+    | InsufficientCapacityException
+    | InternalServerException
+    | Ipv6CidrBlockNotFoundException
+    | ResourceNotFoundException
+    | TooManyTagsException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEndpointAccess {
+  export type Input = DeleteEndpointAccessRequest;
+  export type Output = DeleteEndpointAccessResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteNamespace {
+  export type Input = DeleteNamespaceRequest;
+  export type Output = DeleteNamespaceResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteScheduledAction {
+  export type Input = DeleteScheduledActionRequest;
+  export type Output = DeleteScheduledActionResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSnapshot {
+  export type Input = DeleteSnapshotRequest;
+  export type Output = DeleteSnapshotResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSnapshotCopyConfiguration {
+  export type Input = DeleteSnapshotCopyConfigurationRequest;
+  export type Output = DeleteSnapshotCopyConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteUsageLimit {
+  export type Input = DeleteUsageLimitRequest;
+  export type Output = DeleteUsageLimitResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkgroup {
+  export type Input = DeleteWorkgroupRequest;
+  export type Output = DeleteWorkgroupResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEndpointAccess {
+  export type Input = GetEndpointAccessRequest;
+  export type Output = GetEndpointAccessResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetNamespace {
+  export type Input = GetNamespaceRequest;
+  export type Output = GetNamespaceResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRecoveryPoint {
+  export type Input = GetRecoveryPointRequest;
+  export type Output = GetRecoveryPointResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReservation {
+  export type Input = GetReservationRequest;
+  export type Output = GetReservationResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetReservationOffering {
+  export type Input = GetReservationOfferingRequest;
+  export type Output = GetReservationOfferingResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetScheduledAction {
+  export type Input = GetScheduledActionRequest;
+  export type Output = GetScheduledActionResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSnapshot {
+  export type Input = GetSnapshotRequest;
+  export type Output = GetSnapshotResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTableRestoreStatus {
+  export type Input = GetTableRestoreStatusRequest;
+  export type Output = GetTableRestoreStatusResponse;
+  export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetUsageLimit {
+  export type Input = GetUsageLimitRequest;
+  export type Output = GetUsageLimitResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetWorkgroup {
+  export type Input = GetWorkgroupRequest;
+  export type Output = GetWorkgroupResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEndpointAccess {
+  export type Input = ListEndpointAccessRequest;
+  export type Output = ListEndpointAccessResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListManagedWorkgroups {
+  export type Input = ListManagedWorkgroupsRequest;
+  export type Output = ListManagedWorkgroupsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | CommonAwsError;
+}
+
+export declare namespace ListNamespaces {
+  export type Input = ListNamespacesRequest;
+  export type Output = ListNamespacesResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRecoveryPoints {
+  export type Input = ListRecoveryPointsRequest;
+  export type Output = ListRecoveryPointsResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReservationOfferings {
+  export type Input = ListReservationOfferingsRequest;
+  export type Output = ListReservationOfferingsResponse;
+  export type Error =
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListReservations {
+  export type Input = ListReservationsRequest;
+  export type Output = ListReservationsResponse;
+  export type Error =
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListScheduledActions {
+  export type Input = ListScheduledActionsRequest;
+  export type Output = ListScheduledActionsResponse;
+  export type Error =
+    | InternalServerException
+    | InvalidPaginationException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSnapshotCopyConfigurations {
+  export type Input = ListSnapshotCopyConfigurationsRequest;
+  export type Output = ListSnapshotCopyConfigurationsResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | InvalidPaginationException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSnapshots {
+  export type Input = ListSnapshotsRequest;
+  export type Output = ListSnapshotsResponse;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTableRestoreStatus {
+  export type Input = ListTableRestoreStatusRequest;
+  export type Output = ListTableRestoreStatusResponse;
+  export type Error =
+    | InvalidPaginationException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListUsageLimits {
+  export type Input = ListUsageLimitsRequest;
+  export type Output = ListUsageLimitsResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | InvalidPaginationException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkgroups {
+  export type Input = ListWorkgroupsRequest;
+  export type Output = ListWorkgroupsResponse;
+  export type Error =
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RestoreFromRecoveryPoint {
+  export type Input = RestoreFromRecoveryPointRequest;
+  export type Output = RestoreFromRecoveryPointResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RestoreFromSnapshot {
+  export type Input = RestoreFromSnapshotRequest;
+  export type Output = RestoreFromSnapshotResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RestoreTableFromRecoveryPoint {
+  export type Input = RestoreTableFromRecoveryPointRequest;
+  export type Output = RestoreTableFromRecoveryPointResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RestoreTableFromSnapshot {
+  export type Input = RestoreTableFromSnapshotRequest;
+  export type Output = RestoreTableFromSnapshotResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateEndpointAccess {
+  export type Input = UpdateEndpointAccessRequest;
+  export type Output = UpdateEndpointAccessResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateNamespace {
+  export type Input = UpdateNamespaceRequest;
+  export type Output = UpdateNamespaceResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateScheduledAction {
+  export type Input = UpdateScheduledActionRequest;
+  export type Output = UpdateScheduledActionResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSnapshot {
+  export type Input = UpdateSnapshotRequest;
+  export type Output = UpdateSnapshotResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSnapshotCopyConfiguration {
+  export type Input = UpdateSnapshotCopyConfigurationRequest;
+  export type Output = UpdateSnapshotCopyConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateUsageLimit {
+  export type Input = UpdateUsageLimitRequest;
+  export type Output = UpdateUsageLimitResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWorkgroup {
+  export type Input = UpdateWorkgroupRequest;
+  export type Output = UpdateWorkgroupResponse;
+  export type Error =
+    | ConflictException
+    | InsufficientCapacityException
+    | InternalServerException
+    | Ipv6CidrBlockNotFoundException
+    | ResourceNotFoundException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/resource-explorer-2/index.ts
+++ b/src/services/resource-explorer-2/index.ts
@@ -152,6 +152,121 @@ export declare class ResourceExplorer2 extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateDefaultView(
+    input: AssociateDefaultViewInput,
+  ): Effect.Effect<
+    AssociateDefaultViewOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createIndex(
+    input: CreateIndexInput,
+  ): Effect.Effect<
+    CreateIndexOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createView(
+    input: CreateViewInput,
+  ): Effect.Effect<
+    CreateViewOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteIndex(
+    input: DeleteIndexInput,
+  ): Effect.Effect<
+    DeleteIndexOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteView(
+    input: DeleteViewInput,
+  ): Effect.Effect<
+    DeleteViewOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getView(
+    input: GetViewInput,
+  ): Effect.Effect<
+    GetViewOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIndexes(
+    input: ListIndexesInput,
+  ): Effect.Effect<
+    ListIndexesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listViews(
+    input: ListViewsInput,
+  ): Effect.Effect<
+    ListViewsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateIndexType(
+    input: UpdateIndexTypeInput,
+  ): Effect.Effect<
+    UpdateIndexTypeOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateView(
+    input: UpdateViewInput,
+  ): Effect.Effect<
+    UpdateViewOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -637,6 +752,131 @@ export declare namespace UntagResource {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateDefaultView {
+  export type Input = AssociateDefaultViewInput;
+  export type Output = AssociateDefaultViewOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateIndex {
+  export type Input = CreateIndexInput;
+  export type Output = CreateIndexOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateView {
+  export type Input = CreateViewInput;
+  export type Output = CreateViewOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIndex {
+  export type Input = DeleteIndexInput;
+  export type Output = DeleteIndexOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteView {
+  export type Input = DeleteViewInput;
+  export type Output = DeleteViewOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetView {
+  export type Input = GetViewInput;
+  export type Output = GetViewOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | UnauthorizedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIndexes {
+  export type Input = ListIndexesInput;
+  export type Output = ListIndexesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListViews {
+  export type Input = ListViewsInput;
+  export type Output = ListViewsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateIndexType {
+  export type Input = UpdateIndexTypeInput;
+  export type Output = UpdateIndexTypeOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateView {
+  export type Input = UpdateViewInput;
+  export type Output = UpdateViewOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ServiceQuotaExceededException
     | ThrottlingException
     | UnauthorizedException
     | ValidationException

--- a/src/services/rolesanywhere/index.ts
+++ b/src/services/rolesanywhere/index.ts
@@ -49,6 +49,174 @@ export declare class RolesAnywhere extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createProfile(
+    input: CreateProfileRequest,
+  ): Effect.Effect<
+    ProfileDetailResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  createTrustAnchor(
+    input: CreateTrustAnchorRequest,
+  ): Effect.Effect<
+    TrustAnchorDetailResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  deleteAttributeMapping(
+    input: DeleteAttributeMappingRequest,
+  ): Effect.Effect<
+    DeleteAttributeMappingResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteCrl(
+    input: ScalarCrlRequest,
+  ): Effect.Effect<
+    CrlDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  deleteProfile(
+    input: ScalarProfileRequest,
+  ): Effect.Effect<
+    ProfileDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  deleteTrustAnchor(
+    input: ScalarTrustAnchorRequest,
+  ): Effect.Effect<
+    TrustAnchorDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  disableCrl(
+    input: ScalarCrlRequest,
+  ): Effect.Effect<
+    CrlDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  disableProfile(
+    input: ScalarProfileRequest,
+  ): Effect.Effect<
+    ProfileDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  disableTrustAnchor(
+    input: ScalarTrustAnchorRequest,
+  ): Effect.Effect<
+    TrustAnchorDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  enableCrl(
+    input: ScalarCrlRequest,
+  ): Effect.Effect<
+    CrlDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  enableProfile(
+    input: ScalarProfileRequest,
+  ): Effect.Effect<
+    ProfileDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  enableTrustAnchor(
+    input: ScalarTrustAnchorRequest,
+  ): Effect.Effect<
+    TrustAnchorDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  getCrl(
+    input: ScalarCrlRequest,
+  ): Effect.Effect<
+    CrlDetailResponse,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getProfile(
+    input: ScalarProfileRequest,
+  ): Effect.Effect<
+    ProfileDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  getSubject(
+    input: ScalarSubjectRequest,
+  ): Effect.Effect<
+    SubjectDetailResponse,
+    AccessDeniedException | ResourceNotFoundException | CommonAwsError
+  >;
+  getTrustAnchor(
+    input: ScalarTrustAnchorRequest,
+  ): Effect.Effect<
+    TrustAnchorDetailResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  importCrl(
+    input: ImportCrlRequest,
+  ): Effect.Effect<
+    CrlDetailResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listCrls(
+    input: ListRequest,
+  ): Effect.Effect<
+    ListCrlsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listProfiles(
+    input: ListRequest,
+  ): Effect.Effect<
+    ListProfilesResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listSubjects(
+    input: ListRequest,
+  ): Effect.Effect<
+    ListSubjectsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listTrustAnchors(
+    input: ListRequest,
+  ): Effect.Effect<
+    ListTrustAnchorsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  putAttributeMapping(
+    input: PutAttributeMappingRequest,
+  ): Effect.Effect<
+    PutAttributeMappingResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateCrl(
+    input: UpdateCrlRequest,
+  ): Effect.Effect<
+    CrlDetailResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateProfile(
+    input: UpdateProfileRequest,
+  ): Effect.Effect<
+    ProfileDetailResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTrustAnchor(
+    input: UpdateTrustAnchorRequest,
+  ): Effect.Effect<
+    TrustAnchorDetailResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Rolesanywhere extends RolesAnywhere {}
@@ -401,6 +569,234 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateProfile {
+  export type Input = CreateProfileRequest;
+  export type Output = ProfileDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTrustAnchor {
+  export type Input = CreateTrustAnchorRequest;
+  export type Output = TrustAnchorDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAttributeMapping {
+  export type Input = DeleteAttributeMappingRequest;
+  export type Output = DeleteAttributeMappingResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCrl {
+  export type Input = ScalarCrlRequest;
+  export type Output = CrlDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteProfile {
+  export type Input = ScalarProfileRequest;
+  export type Output = ProfileDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTrustAnchor {
+  export type Input = ScalarTrustAnchorRequest;
+  export type Output = TrustAnchorDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DisableCrl {
+  export type Input = ScalarCrlRequest;
+  export type Output = CrlDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DisableProfile {
+  export type Input = ScalarProfileRequest;
+  export type Output = ProfileDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DisableTrustAnchor {
+  export type Input = ScalarTrustAnchorRequest;
+  export type Output = TrustAnchorDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace EnableCrl {
+  export type Input = ScalarCrlRequest;
+  export type Output = CrlDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace EnableProfile {
+  export type Input = ScalarProfileRequest;
+  export type Output = ProfileDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace EnableTrustAnchor {
+  export type Input = ScalarTrustAnchorRequest;
+  export type Output = TrustAnchorDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetCrl {
+  export type Input = ScalarCrlRequest;
+  export type Output = CrlDetailResponse;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetProfile {
+  export type Input = ScalarProfileRequest;
+  export type Output = ProfileDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetSubject {
+  export type Input = ScalarSubjectRequest;
+  export type Output = SubjectDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetTrustAnchor {
+  export type Input = ScalarTrustAnchorRequest;
+  export type Output = TrustAnchorDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ImportCrl {
+  export type Input = ImportCrlRequest;
+  export type Output = CrlDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListCrls {
+  export type Input = ListRequest;
+  export type Output = ListCrlsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListProfiles {
+  export type Input = ListRequest;
+  export type Output = ListProfilesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSubjects {
+  export type Input = ListRequest;
+  export type Output = ListSubjectsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTrustAnchors {
+  export type Input = ListRequest;
+  export type Output = ListTrustAnchorsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutAttributeMapping {
+  export type Input = PutAttributeMappingRequest;
+  export type Output = PutAttributeMappingResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCrl {
+  export type Input = UpdateCrlRequest;
+  export type Output = CrlDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProfile {
+  export type Input = UpdateProfileRequest;
+  export type Output = ProfileDetailResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTrustAnchor {
+  export type Input = UpdateTrustAnchorRequest;
+  export type Output = TrustAnchorDetailResponse;
   export type Error =
     | AccessDeniedException
     | ResourceNotFoundException

--- a/src/services/rum/index.ts
+++ b/src/services/rum/index.ts
@@ -41,6 +41,199 @@ export declare class RUM extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  batchCreateRumMetricDefinitions(
+    input: BatchCreateRumMetricDefinitionsRequest,
+  ): Effect.Effect<
+    BatchCreateRumMetricDefinitionsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchDeleteRumMetricDefinitions(
+    input: BatchDeleteRumMetricDefinitionsRequest,
+  ): Effect.Effect<
+    BatchDeleteRumMetricDefinitionsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  batchGetRumMetricDefinitions(
+    input: BatchGetRumMetricDefinitionsRequest,
+  ): Effect.Effect<
+    BatchGetRumMetricDefinitionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAppMonitor(
+    input: CreateAppMonitorRequest,
+  ): Effect.Effect<
+    CreateAppMonitorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAppMonitor(
+    input: DeleteAppMonitorRequest,
+  ): Effect.Effect<
+    DeleteAppMonitorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteResourcePolicy(
+    input: DeleteResourcePolicyRequest,
+  ): Effect.Effect<
+    DeleteResourcePolicyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidPolicyRevisionIdException
+    | PolicyNotFoundException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRumMetricsDestination(
+    input: DeleteRumMetricsDestinationRequest,
+  ): Effect.Effect<
+    DeleteRumMetricsDestinationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAppMonitor(
+    input: GetAppMonitorRequest,
+  ): Effect.Effect<
+    GetAppMonitorResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAppMonitorData(
+    input: GetAppMonitorDataRequest,
+  ): Effect.Effect<
+    GetAppMonitorDataResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getResourcePolicy(
+    input: GetResourcePolicyRequest,
+  ): Effect.Effect<
+    GetResourcePolicyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | PolicyNotFoundException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAppMonitors(
+    input: ListAppMonitorsRequest,
+  ): Effect.Effect<
+    ListAppMonitorsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRumMetricsDestinations(
+    input: ListRumMetricsDestinationsRequest,
+  ): Effect.Effect<
+    ListRumMetricsDestinationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putResourcePolicy(
+    input: PutResourcePolicyRequest,
+  ): Effect.Effect<
+    PutResourcePolicyResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidPolicyRevisionIdException
+    | MalformedPolicyDocumentException
+    | PolicySizeLimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putRumMetricsDestination(
+    input: PutRumMetricsDestinationRequest,
+  ): Effect.Effect<
+    PutRumMetricsDestinationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAppMonitor(
+    input: UpdateAppMonitorRequest,
+  ): Effect.Effect<
+    UpdateAppMonitorResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateRumMetricDefinition(
+    input: UpdateRumMetricDefinitionRequest,
+  ): Effect.Effect<
+    UpdateRumMetricDefinitionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Rum extends RUM {}
@@ -505,6 +698,215 @@ export declare namespace UntagResource {
   export type Error =
     | InternalServerException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchCreateRumMetricDefinitions {
+  export type Input = BatchCreateRumMetricDefinitionsRequest;
+  export type Output = BatchCreateRumMetricDefinitionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchDeleteRumMetricDefinitions {
+  export type Input = BatchDeleteRumMetricDefinitionsRequest;
+  export type Output = BatchDeleteRumMetricDefinitionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetRumMetricDefinitions {
+  export type Input = BatchGetRumMetricDefinitionsRequest;
+  export type Output = BatchGetRumMetricDefinitionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAppMonitor {
+  export type Input = CreateAppMonitorRequest;
+  export type Output = CreateAppMonitorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAppMonitor {
+  export type Input = DeleteAppMonitorRequest;
+  export type Output = DeleteAppMonitorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteResourcePolicy {
+  export type Input = DeleteResourcePolicyRequest;
+  export type Output = DeleteResourcePolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidPolicyRevisionIdException
+    | PolicyNotFoundException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRumMetricsDestination {
+  export type Input = DeleteRumMetricsDestinationRequest;
+  export type Output = DeleteRumMetricsDestinationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAppMonitor {
+  export type Input = GetAppMonitorRequest;
+  export type Output = GetAppMonitorResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAppMonitorData {
+  export type Input = GetAppMonitorDataRequest;
+  export type Output = GetAppMonitorDataResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetResourcePolicy {
+  export type Input = GetResourcePolicyRequest;
+  export type Output = GetResourcePolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | PolicyNotFoundException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAppMonitors {
+  export type Input = ListAppMonitorsRequest;
+  export type Output = ListAppMonitorsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRumMetricsDestinations {
+  export type Input = ListRumMetricsDestinationsRequest;
+  export type Output = ListRumMetricsDestinationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutResourcePolicy {
+  export type Input = PutResourcePolicyRequest;
+  export type Output = PutResourcePolicyResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | InvalidPolicyRevisionIdException
+    | MalformedPolicyDocumentException
+    | PolicySizeLimitExceededException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutRumMetricsDestination {
+  export type Input = PutRumMetricsDestinationRequest;
+  export type Output = PutRumMetricsDestinationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAppMonitor {
+  export type Input = UpdateAppMonitorRequest;
+  export type Output = UpdateAppMonitorResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRumMetricDefinition {
+  export type Input = UpdateRumMetricDefinitionRequest;
+  export type Output = UpdateRumMetricDefinitionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/sagemaker-geospatial/index.ts
+++ b/src/services/sagemaker-geospatial/index.ts
@@ -36,6 +36,194 @@ export declare class SageMakerGeospatial extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  deleteEarthObservationJob(
+    input: DeleteEarthObservationJobInput,
+  ): Effect.Effect<
+    DeleteEarthObservationJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteVectorEnrichmentJob(
+    input: DeleteVectorEnrichmentJobInput,
+  ): Effect.Effect<
+    DeleteVectorEnrichmentJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  exportEarthObservationJob(
+    input: ExportEarthObservationJobInput,
+  ): Effect.Effect<
+    ExportEarthObservationJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  exportVectorEnrichmentJob(
+    input: ExportVectorEnrichmentJobInput,
+  ): Effect.Effect<
+    ExportVectorEnrichmentJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getEarthObservationJob(
+    input: GetEarthObservationJobInput,
+  ): Effect.Effect<
+    GetEarthObservationJobOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRasterDataCollection(
+    input: GetRasterDataCollectionInput,
+  ): Effect.Effect<
+    GetRasterDataCollectionOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTile(
+    input: GetTileInput,
+  ): Effect.Effect<
+    GetTileOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getVectorEnrichmentJob(
+    input: GetVectorEnrichmentJobInput,
+  ): Effect.Effect<
+    GetVectorEnrichmentJobOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listEarthObservationJobs(
+    input: ListEarthObservationJobInput,
+  ): Effect.Effect<
+    ListEarthObservationJobOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRasterDataCollections(
+    input: ListRasterDataCollectionsInput,
+  ): Effect.Effect<
+    ListRasterDataCollectionsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listVectorEnrichmentJobs(
+    input: ListVectorEnrichmentJobInput,
+  ): Effect.Effect<
+    ListVectorEnrichmentJobOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchRasterDataCollection(
+    input: SearchRasterDataCollectionInput,
+  ): Effect.Effect<
+    SearchRasterDataCollectionOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startEarthObservationJob(
+    input: StartEarthObservationJobInput,
+  ): Effect.Effect<
+    StartEarthObservationJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startVectorEnrichmentJob(
+    input: StartVectorEnrichmentJobInput,
+  ): Effect.Effect<
+    StartVectorEnrichmentJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopEarthObservationJob(
+    input: StopEarthObservationJobInput,
+  ): Effect.Effect<
+    StopEarthObservationJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopVectorEnrichmentJob(
+    input: StopVectorEnrichmentJobInput,
+  ): Effect.Effect<
+    StopVectorEnrichmentJobOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class SagemakerGeospatial extends SageMakerGeospatial {}
@@ -718,6 +906,210 @@ export declare namespace UntagResource {
   export type Output = UntagResourceResponse;
   export type Error =
     | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteEarthObservationJob {
+  export type Input = DeleteEarthObservationJobInput;
+  export type Output = DeleteEarthObservationJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteVectorEnrichmentJob {
+  export type Input = DeleteVectorEnrichmentJobInput;
+  export type Output = DeleteVectorEnrichmentJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ExportEarthObservationJob {
+  export type Input = ExportEarthObservationJobInput;
+  export type Output = ExportEarthObservationJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ExportVectorEnrichmentJob {
+  export type Input = ExportVectorEnrichmentJobInput;
+  export type Output = ExportVectorEnrichmentJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetEarthObservationJob {
+  export type Input = GetEarthObservationJobInput;
+  export type Output = GetEarthObservationJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRasterDataCollection {
+  export type Input = GetRasterDataCollectionInput;
+  export type Output = GetRasterDataCollectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTile {
+  export type Input = GetTileInput;
+  export type Output = GetTileOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetVectorEnrichmentJob {
+  export type Input = GetVectorEnrichmentJobInput;
+  export type Output = GetVectorEnrichmentJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListEarthObservationJobs {
+  export type Input = ListEarthObservationJobInput;
+  export type Output = ListEarthObservationJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRasterDataCollections {
+  export type Input = ListRasterDataCollectionsInput;
+  export type Output = ListRasterDataCollectionsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListVectorEnrichmentJobs {
+  export type Input = ListVectorEnrichmentJobInput;
+  export type Output = ListVectorEnrichmentJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchRasterDataCollection {
+  export type Input = SearchRasterDataCollectionInput;
+  export type Output = SearchRasterDataCollectionOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartEarthObservationJob {
+  export type Input = StartEarthObservationJobInput;
+  export type Output = StartEarthObservationJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartVectorEnrichmentJob {
+  export type Input = StartVectorEnrichmentJobInput;
+  export type Output = StartVectorEnrichmentJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopEarthObservationJob {
+  export type Input = StopEarthObservationJobInput;
+  export type Output = StopEarthObservationJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopVectorEnrichmentJob {
+  export type Input = StopVectorEnrichmentJobInput;
+  export type Output = StopVectorEnrichmentJobOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException

--- a/src/services/scheduler/index.ts
+++ b/src/services/scheduler/index.ts
@@ -35,6 +35,101 @@ export declare class Scheduler extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createSchedule(
+    input: CreateScheduleInput,
+  ): Effect.Effect<
+    CreateScheduleOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createScheduleGroup(
+    input: CreateScheduleGroupInput,
+  ): Effect.Effect<
+    CreateScheduleGroupOutput,
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSchedule(
+    input: DeleteScheduleInput,
+  ): Effect.Effect<
+    DeleteScheduleOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteScheduleGroup(
+    input: DeleteScheduleGroupInput,
+  ): Effect.Effect<
+    DeleteScheduleGroupOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSchedule(
+    input: GetScheduleInput,
+  ): Effect.Effect<
+    GetScheduleOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getScheduleGroup(
+    input: GetScheduleGroupInput,
+  ): Effect.Effect<
+    GetScheduleGroupOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listScheduleGroups(
+    input: ListScheduleGroupsInput,
+  ): Effect.Effect<
+    ListScheduleGroupsOutput,
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSchedules(
+    input: ListSchedulesInput,
+  ): Effect.Effect<
+    ListSchedulesOutput,
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSchedule(
+    input: UpdateScheduleInput,
+  ): Effect.Effect<
+    UpdateScheduleOutput,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export type ActionAfterCompletion = string;
@@ -439,6 +534,110 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceInput;
   export type Output = UntagResourceOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSchedule {
+  export type Input = CreateScheduleInput;
+  export type Output = CreateScheduleOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateScheduleGroup {
+  export type Input = CreateScheduleGroupInput;
+  export type Output = CreateScheduleGroupOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSchedule {
+  export type Input = DeleteScheduleInput;
+  export type Output = DeleteScheduleOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteScheduleGroup {
+  export type Input = DeleteScheduleGroupInput;
+  export type Output = DeleteScheduleGroupOutput;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSchedule {
+  export type Input = GetScheduleInput;
+  export type Output = GetScheduleOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetScheduleGroup {
+  export type Input = GetScheduleGroupInput;
+  export type Output = GetScheduleGroupOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListScheduleGroups {
+  export type Input = ListScheduleGroupsInput;
+  export type Output = ListScheduleGroupsOutput;
+  export type Error =
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSchedules {
+  export type Input = ListSchedulesInput;
+  export type Output = ListSchedulesOutput;
+  export type Error =
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSchedule {
+  export type Input = UpdateScheduleInput;
+  export type Output = UpdateScheduleOutput;
   export type Error =
     | ConflictException
     | InternalServerException

--- a/src/services/security-ir/index.ts
+++ b/src/services/security-ir/index.ts
@@ -30,6 +30,63 @@ export declare class SecurityIR extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  batchGetMemberAccountDetails(
+    input: BatchGetMemberAccountDetailsRequest,
+  ): Effect.Effect<BatchGetMemberAccountDetailsResponse, CommonAwsError>;
+  cancelMembership(
+    input: CancelMembershipRequest,
+  ): Effect.Effect<CancelMembershipResponse, CommonAwsError>;
+  closeCase(
+    input: CloseCaseRequest,
+  ): Effect.Effect<CloseCaseResponse, CommonAwsError>;
+  createCase(
+    input: CreateCaseRequest,
+  ): Effect.Effect<CreateCaseResponse, CommonAwsError>;
+  createCaseComment(
+    input: CreateCaseCommentRequest,
+  ): Effect.Effect<CreateCaseCommentResponse, CommonAwsError>;
+  createMembership(
+    input: CreateMembershipRequest,
+  ): Effect.Effect<CreateMembershipResponse, CommonAwsError>;
+  getCase(
+    input: GetCaseRequest,
+  ): Effect.Effect<GetCaseResponse, CommonAwsError>;
+  getCaseAttachmentDownloadUrl(
+    input: GetCaseAttachmentDownloadUrlRequest,
+  ): Effect.Effect<GetCaseAttachmentDownloadUrlResponse, CommonAwsError>;
+  getCaseAttachmentUploadUrl(
+    input: GetCaseAttachmentUploadUrlRequest,
+  ): Effect.Effect<GetCaseAttachmentUploadUrlResponse, CommonAwsError>;
+  getMembership(
+    input: GetMembershipRequest,
+  ): Effect.Effect<GetMembershipResponse, CommonAwsError>;
+  listCaseEdits(
+    input: ListCaseEditsRequest,
+  ): Effect.Effect<ListCaseEditsResponse, CommonAwsError>;
+  listCases(
+    input: ListCasesRequest,
+  ): Effect.Effect<ListCasesResponse, CommonAwsError>;
+  listComments(
+    input: ListCommentsRequest,
+  ): Effect.Effect<ListCommentsResponse, CommonAwsError>;
+  listMemberships(
+    input: ListMembershipsRequest,
+  ): Effect.Effect<ListMembershipsResponse, CommonAwsError>;
+  updateCase(
+    input: UpdateCaseRequest,
+  ): Effect.Effect<UpdateCaseResponse, CommonAwsError>;
+  updateCaseComment(
+    input: UpdateCaseCommentRequest,
+  ): Effect.Effect<UpdateCaseCommentResponse, CommonAwsError>;
+  updateCaseStatus(
+    input: UpdateCaseStatusRequest,
+  ): Effect.Effect<UpdateCaseStatusResponse, CommonAwsError>;
+  updateMembership(
+    input: UpdateMembershipRequest,
+  ): Effect.Effect<UpdateMembershipResponse, CommonAwsError>;
+  updateResolverType(
+    input: UpdateResolverTypeRequest,
+  ): Effect.Effect<UpdateResolverTypeResponse, CommonAwsError>;
 }
 
 export declare class SecurityIr extends SecurityIR {}
@@ -554,4 +611,118 @@ export declare namespace UntagResource {
     | ResourceNotFoundException
     | ValidationException
     | CommonAwsError;
+}
+
+export declare namespace BatchGetMemberAccountDetails {
+  export type Input = BatchGetMemberAccountDetailsRequest;
+  export type Output = BatchGetMemberAccountDetailsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CancelMembership {
+  export type Input = CancelMembershipRequest;
+  export type Output = CancelMembershipResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CloseCase {
+  export type Input = CloseCaseRequest;
+  export type Output = CloseCaseResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateCase {
+  export type Input = CreateCaseRequest;
+  export type Output = CreateCaseResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateCaseComment {
+  export type Input = CreateCaseCommentRequest;
+  export type Output = CreateCaseCommentResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace CreateMembership {
+  export type Input = CreateMembershipRequest;
+  export type Output = CreateMembershipResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetCase {
+  export type Input = GetCaseRequest;
+  export type Output = GetCaseResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetCaseAttachmentDownloadUrl {
+  export type Input = GetCaseAttachmentDownloadUrlRequest;
+  export type Output = GetCaseAttachmentDownloadUrlResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetCaseAttachmentUploadUrl {
+  export type Input = GetCaseAttachmentUploadUrlRequest;
+  export type Output = GetCaseAttachmentUploadUrlResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace GetMembership {
+  export type Input = GetMembershipRequest;
+  export type Output = GetMembershipResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListCaseEdits {
+  export type Input = ListCaseEditsRequest;
+  export type Output = ListCaseEditsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListCases {
+  export type Input = ListCasesRequest;
+  export type Output = ListCasesResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListComments {
+  export type Input = ListCommentsRequest;
+  export type Output = ListCommentsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListMemberships {
+  export type Input = ListMembershipsRequest;
+  export type Output = ListMembershipsResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateCase {
+  export type Input = UpdateCaseRequest;
+  export type Output = UpdateCaseResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateCaseComment {
+  export type Input = UpdateCaseCommentRequest;
+  export type Output = UpdateCaseCommentResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateCaseStatus {
+  export type Input = UpdateCaseStatusRequest;
+  export type Output = UpdateCaseStatusResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateMembership {
+  export type Input = UpdateMembershipRequest;
+  export type Output = UpdateMembershipResponse;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace UpdateResolverType {
+  export type Input = UpdateResolverTypeRequest;
+  export type Output = UpdateResolverTypeResponse;
+  export type Error = CommonAwsError;
 }

--- a/src/services/securitylake/index.ts
+++ b/src/services/securitylake/index.ts
@@ -123,6 +123,258 @@ export declare class SecurityLake extends AWSServiceClient {
     | ThrottlingException
     | CommonAwsError
   >;
+  createAwsLogSource(
+    input: CreateAwsLogSourceRequest,
+  ): Effect.Effect<
+    CreateAwsLogSourceResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createCustomLogSource(
+    input: CreateCustomLogSourceRequest,
+  ): Effect.Effect<
+    CreateCustomLogSourceResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createDataLake(
+    input: CreateDataLakeRequest,
+  ): Effect.Effect<
+    CreateDataLakeResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createDataLakeOrganizationConfiguration(
+    input: CreateDataLakeOrganizationConfigurationRequest,
+  ): Effect.Effect<
+    CreateDataLakeOrganizationConfigurationResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createSubscriber(
+    input: CreateSubscriberRequest,
+  ): Effect.Effect<
+    CreateSubscriberResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createSubscriberNotification(
+    input: CreateSubscriberNotificationRequest,
+  ): Effect.Effect<
+    CreateSubscriberNotificationResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteAwsLogSource(
+    input: DeleteAwsLogSourceRequest,
+  ): Effect.Effect<
+    DeleteAwsLogSourceResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteCustomLogSource(
+    input: DeleteCustomLogSourceRequest,
+  ): Effect.Effect<
+    DeleteCustomLogSourceResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteDataLake(
+    input: DeleteDataLakeRequest,
+  ): Effect.Effect<
+    DeleteDataLakeResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteDataLakeOrganizationConfiguration(
+    input: DeleteDataLakeOrganizationConfigurationRequest,
+  ): Effect.Effect<
+    DeleteDataLakeOrganizationConfigurationResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteSubscriber(
+    input: DeleteSubscriberRequest,
+  ): Effect.Effect<
+    DeleteSubscriberResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteSubscriberNotification(
+    input: DeleteSubscriberNotificationRequest,
+  ): Effect.Effect<
+    DeleteSubscriberNotificationResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getDataLakeOrganizationConfiguration(
+    input: GetDataLakeOrganizationConfigurationRequest,
+  ): Effect.Effect<
+    GetDataLakeOrganizationConfigurationResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getDataLakeSources(
+    input: GetDataLakeSourcesRequest,
+  ): Effect.Effect<
+    GetDataLakeSourcesResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  getSubscriber(
+    input: GetSubscriberRequest,
+  ): Effect.Effect<
+    GetSubscriberResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  listDataLakes(
+    input: ListDataLakesRequest,
+  ): Effect.Effect<
+    ListDataLakesResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  listLogSources(
+    input: ListLogSourcesRequest,
+  ): Effect.Effect<
+    ListLogSourcesResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  listSubscribers(
+    input: ListSubscribersRequest,
+  ): Effect.Effect<
+    ListSubscribersResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateDataLake(
+    input: UpdateDataLakeRequest,
+  ): Effect.Effect<
+    UpdateDataLakeResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateSubscriber(
+    input: UpdateSubscriberRequest,
+  ): Effect.Effect<
+    UpdateSubscriberResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateSubscriberNotification(
+    input: UpdateSubscriberNotificationRequest,
+  ): Effect.Effect<
+    UpdateSubscriberNotificationResponse,
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
 }
 
 export declare class Securitylake extends SecurityLake {}
@@ -713,6 +965,279 @@ export declare namespace UntagResource {
 export declare namespace UpdateDataLakeExceptionSubscription {
   export type Input = UpdateDataLakeExceptionSubscriptionRequest;
   export type Output = UpdateDataLakeExceptionSubscriptionResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAwsLogSource {
+  export type Input = CreateAwsLogSourceRequest;
+  export type Output = CreateAwsLogSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateCustomLogSource {
+  export type Input = CreateCustomLogSourceRequest;
+  export type Output = CreateCustomLogSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataLake {
+  export type Input = CreateDataLakeRequest;
+  export type Output = CreateDataLakeResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataLakeOrganizationConfiguration {
+  export type Input = CreateDataLakeOrganizationConfigurationRequest;
+  export type Output = CreateDataLakeOrganizationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSubscriber {
+  export type Input = CreateSubscriberRequest;
+  export type Output = CreateSubscriberResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSubscriberNotification {
+  export type Input = CreateSubscriberNotificationRequest;
+  export type Output = CreateSubscriberNotificationResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAwsLogSource {
+  export type Input = DeleteAwsLogSourceRequest;
+  export type Output = DeleteAwsLogSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCustomLogSource {
+  export type Input = DeleteCustomLogSourceRequest;
+  export type Output = DeleteCustomLogSourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataLake {
+  export type Input = DeleteDataLakeRequest;
+  export type Output = DeleteDataLakeResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataLakeOrganizationConfiguration {
+  export type Input = DeleteDataLakeOrganizationConfigurationRequest;
+  export type Output = DeleteDataLakeOrganizationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSubscriber {
+  export type Input = DeleteSubscriberRequest;
+  export type Output = DeleteSubscriberResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSubscriberNotification {
+  export type Input = DeleteSubscriberNotificationRequest;
+  export type Output = DeleteSubscriberNotificationResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataLakeOrganizationConfiguration {
+  export type Input = GetDataLakeOrganizationConfigurationRequest;
+  export type Output = GetDataLakeOrganizationConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataLakeSources {
+  export type Input = GetDataLakeSourcesRequest;
+  export type Output = GetDataLakeSourcesResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace GetSubscriber {
+  export type Input = GetSubscriberRequest;
+  export type Output = GetSubscriberResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataLakes {
+  export type Input = ListDataLakesRequest;
+  export type Output = ListDataLakesResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace ListLogSources {
+  export type Input = ListLogSourcesRequest;
+  export type Output = ListLogSourcesResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace ListSubscribers {
+  export type Input = ListSubscribersRequest;
+  export type Output = ListSubscribersResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataLake {
+  export type Input = UpdateDataLakeRequest;
+  export type Output = UpdateDataLakeResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSubscriber {
+  export type Input = UpdateSubscriberRequest;
+  export type Output = UpdateSubscriberResponse;
+  export type Error =
+    | AccessDeniedException
+    | BadRequestException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSubscriberNotification {
+  export type Input = UpdateSubscriberNotificationRequest;
+  export type Output = UpdateSubscriberNotificationResponse;
   export type Error =
     | AccessDeniedException
     | BadRequestException

--- a/src/services/simspaceweaver/index.ts
+++ b/src/services/simspaceweaver/index.ts
@@ -24,6 +24,144 @@ export declare class SimSpaceWeaver extends AWSServiceClient {
     UntagResourceOutput,
     ResourceNotFoundException | ValidationException | CommonAwsError
   >;
+  createSnapshot(
+    input: CreateSnapshotInput,
+  ): Effect.Effect<
+    CreateSnapshotOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteApp(
+    input: DeleteAppInput,
+  ): Effect.Effect<
+    DeleteAppOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSimulation(
+    input: DeleteSimulationInput,
+  ): Effect.Effect<
+    DeleteSimulationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeApp(
+    input: DescribeAppInput,
+  ): Effect.Effect<
+    DescribeAppOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeSimulation(
+    input: DescribeSimulationInput,
+  ): Effect.Effect<
+    DescribeSimulationOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApps(
+    input: ListAppsInput,
+  ): Effect.Effect<
+    ListAppsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSimulations(
+    input: ListSimulationsInput,
+  ): Effect.Effect<
+    ListSimulationsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startApp(
+    input: StartAppInput,
+  ): Effect.Effect<
+    StartAppOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startClock(
+    input: StartClockInput,
+  ): Effect.Effect<
+    StartClockOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startSimulation(
+    input: StartSimulationInput,
+  ): Effect.Effect<
+    StartSimulationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopApp(
+    input: StopAppInput,
+  ): Effect.Effect<
+    StopAppOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopClock(
+    input: StopClockInput,
+  ): Effect.Effect<
+    StopClockOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  stopSimulation(
+    input: StopSimulationInput,
+  ): Effect.Effect<
+    StopSimulationOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Simspaceweaver extends SimSpaceWeaver {}
@@ -331,6 +469,157 @@ export declare namespace UntagResource {
   export type Input = UntagResourceInput;
   export type Output = UntagResourceOutput;
   export type Error =
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSnapshot {
+  export type Input = CreateSnapshotInput;
+  export type Output = CreateSnapshotOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApp {
+  export type Input = DeleteAppInput;
+  export type Output = DeleteAppOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSimulation {
+  export type Input = DeleteSimulationInput;
+  export type Output = DeleteSimulationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeApp {
+  export type Input = DescribeAppInput;
+  export type Output = DescribeAppOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeSimulation {
+  export type Input = DescribeSimulationInput;
+  export type Output = DescribeSimulationOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApps {
+  export type Input = ListAppsInput;
+  export type Output = ListAppsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSimulations {
+  export type Input = ListSimulationsInput;
+  export type Output = ListSimulationsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartApp {
+  export type Input = StartAppInput;
+  export type Output = StartAppOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartClock {
+  export type Input = StartClockInput;
+  export type Output = StartClockOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartSimulation {
+  export type Input = StartSimulationInput;
+  export type Output = StartSimulationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopApp {
+  export type Input = StopAppInput;
+  export type Output = StopAppOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopClock {
+  export type Input = StopClockInput;
+  export type Output = StopClockOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StopSimulation {
+  export type Input = StopSimulationInput;
+  export type Output = StopSimulationOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
     | ResourceNotFoundException
     | ValidationException
     | CommonAwsError;

--- a/src/services/snow-device-management/index.ts
+++ b/src/services/snow-device-management/index.ts
@@ -30,6 +30,115 @@ export declare class SnowDeviceManagement extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  cancelTask(
+    input: CancelTaskInput,
+  ): Effect.Effect<
+    CancelTaskOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTask(
+    input: CreateTaskInput,
+  ): Effect.Effect<
+    CreateTaskOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeDevice(
+    input: DescribeDeviceInput,
+  ): Effect.Effect<
+    DescribeDeviceOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeDeviceEc2Instances(
+    input: DescribeDeviceEc2Input,
+  ): Effect.Effect<
+    DescribeDeviceEc2Output,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeExecution(
+    input: DescribeExecutionInput,
+  ): Effect.Effect<
+    DescribeExecutionOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeTask(
+    input: DescribeTaskInput,
+  ): Effect.Effect<
+    DescribeTaskOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDeviceResources(
+    input: ListDeviceResourcesInput,
+  ): Effect.Effect<
+    ListDeviceResourcesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDevices(
+    input: ListDevicesInput,
+  ): Effect.Effect<
+    ListDevicesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listExecutions(
+    input: ListExecutionsInput,
+  ): Effect.Effect<
+    ListExecutionsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTasks(
+    input: ListTasksInput,
+  ): Effect.Effect<
+    ListTasksOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -344,6 +453,125 @@ export declare namespace UntagResource {
   export type Error =
     | InternalServerException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CancelTask {
+  export type Input = CancelTaskInput;
+  export type Output = CancelTaskOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTask {
+  export type Input = CreateTaskInput;
+  export type Output = CreateTaskOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeDevice {
+  export type Input = DescribeDeviceInput;
+  export type Output = DescribeDeviceOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeDeviceEc2Instances {
+  export type Input = DescribeDeviceEc2Input;
+  export type Output = DescribeDeviceEc2Output;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeExecution {
+  export type Input = DescribeExecutionInput;
+  export type Output = DescribeExecutionOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeTask {
+  export type Input = DescribeTaskInput;
+  export type Output = DescribeTaskOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDeviceResources {
+  export type Input = ListDeviceResourcesInput;
+  export type Output = ListDeviceResourcesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDevices {
+  export type Input = ListDevicesInput;
+  export type Output = ListDevicesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListExecutions {
+  export type Input = ListExecutionsInput;
+  export type Output = ListExecutionsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTasks {
+  export type Input = ListTasksInput;
+  export type Output = ListTasksOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/socialmessaging/index.ts
+++ b/src/services/socialmessaging/index.ts
@@ -118,6 +118,114 @@ export declare class SocialMessaging extends AWSServiceClient {
     | ThrottledRequestException
     | CommonAwsError
   >;
+  associateWhatsAppBusinessAccount(
+    input: AssociateWhatsAppBusinessAccountInput,
+  ): Effect.Effect<
+    AssociateWhatsAppBusinessAccountOutput,
+    | DependencyException
+    | InvalidParametersException
+    | LimitExceededException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  deleteWhatsAppMessageMedia(
+    input: DeleteWhatsAppMessageMediaInput,
+  ): Effect.Effect<
+    DeleteWhatsAppMessageMediaOutput,
+    | AccessDeniedByMetaException
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  disassociateWhatsAppBusinessAccount(
+    input: DisassociateWhatsAppBusinessAccountInput,
+  ): Effect.Effect<
+    DisassociateWhatsAppBusinessAccountOutput,
+    | DependencyException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  getLinkedWhatsAppBusinessAccount(
+    input: GetLinkedWhatsAppBusinessAccountInput,
+  ): Effect.Effect<
+    GetLinkedWhatsAppBusinessAccountOutput,
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  getLinkedWhatsAppBusinessAccountPhoneNumber(
+    input: GetLinkedWhatsAppBusinessAccountPhoneNumberInput,
+  ): Effect.Effect<
+    GetLinkedWhatsAppBusinessAccountPhoneNumberOutput,
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  getWhatsAppMessageMedia(
+    input: GetWhatsAppMessageMediaInput,
+  ): Effect.Effect<
+    GetWhatsAppMessageMediaOutput,
+    | AccessDeniedByMetaException
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  listLinkedWhatsAppBusinessAccounts(
+    input: ListLinkedWhatsAppBusinessAccountsInput,
+  ): Effect.Effect<
+    ListLinkedWhatsAppBusinessAccountsOutput,
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  postWhatsAppMessageMedia(
+    input: PostWhatsAppMessageMediaInput,
+  ): Effect.Effect<
+    PostWhatsAppMessageMediaOutput,
+    | AccessDeniedByMetaException
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  putWhatsAppBusinessAccountEventDestinations(
+    input: PutWhatsAppBusinessAccountEventDestinationsInput,
+  ): Effect.Effect<
+    PutWhatsAppBusinessAccountEventDestinationsOutput,
+    | InternalServiceException
+    | InvalidParametersException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
+  sendWhatsAppMessage(
+    input: SendWhatsAppMessageInput,
+  ): Effect.Effect<
+    SendWhatsAppMessageOutput,
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError
+  >;
 }
 
 export declare class Socialmessaging extends SocialMessaging {}
@@ -704,6 +812,124 @@ export declare namespace UntagResource {
 export declare namespace UpdateWhatsAppMessageTemplate {
   export type Input = UpdateWhatsAppMessageTemplateInput;
   export type Output = UpdateWhatsAppMessageTemplateOutput;
+  export type Error =
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateWhatsAppBusinessAccount {
+  export type Input = AssociateWhatsAppBusinessAccountInput;
+  export type Output = AssociateWhatsAppBusinessAccountOutput;
+  export type Error =
+    | DependencyException
+    | InvalidParametersException
+    | LimitExceededException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWhatsAppMessageMedia {
+  export type Input = DeleteWhatsAppMessageMediaInput;
+  export type Output = DeleteWhatsAppMessageMediaOutput;
+  export type Error =
+    | AccessDeniedByMetaException
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateWhatsAppBusinessAccount {
+  export type Input = DisassociateWhatsAppBusinessAccountInput;
+  export type Output = DisassociateWhatsAppBusinessAccountOutput;
+  export type Error =
+    | DependencyException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace GetLinkedWhatsAppBusinessAccount {
+  export type Input = GetLinkedWhatsAppBusinessAccountInput;
+  export type Output = GetLinkedWhatsAppBusinessAccountOutput;
+  export type Error =
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace GetLinkedWhatsAppBusinessAccountPhoneNumber {
+  export type Input = GetLinkedWhatsAppBusinessAccountPhoneNumberInput;
+  export type Output = GetLinkedWhatsAppBusinessAccountPhoneNumberOutput;
+  export type Error =
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace GetWhatsAppMessageMedia {
+  export type Input = GetWhatsAppMessageMediaInput;
+  export type Output = GetWhatsAppMessageMediaOutput;
+  export type Error =
+    | AccessDeniedByMetaException
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace ListLinkedWhatsAppBusinessAccounts {
+  export type Input = ListLinkedWhatsAppBusinessAccountsInput;
+  export type Output = ListLinkedWhatsAppBusinessAccountsOutput;
+  export type Error =
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace PostWhatsAppMessageMedia {
+  export type Input = PostWhatsAppMessageMediaInput;
+  export type Output = PostWhatsAppMessageMediaOutput;
+  export type Error =
+    | AccessDeniedByMetaException
+    | DependencyException
+    | InternalServiceException
+    | InvalidParametersException
+    | ResourceNotFoundException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace PutWhatsAppBusinessAccountEventDestinations {
+  export type Input = PutWhatsAppBusinessAccountEventDestinationsInput;
+  export type Output = PutWhatsAppBusinessAccountEventDestinationsOutput;
+  export type Error =
+    | InternalServiceException
+    | InvalidParametersException
+    | ThrottledRequestException
+    | CommonAwsError;
+}
+
+export declare namespace SendWhatsAppMessage {
+  export type Input = SendWhatsAppMessageInput;
+  export type Output = SendWhatsAppMessageOutput;
   export type Error =
     | DependencyException
     | InternalServiceException

--- a/src/services/sso-admin/index.ts
+++ b/src/services/sso-admin/index.ts
@@ -706,6 +706,144 @@ export declare class SSOAdmin extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  deleteApplicationAccessScope(
+    input: DeleteApplicationAccessScopeRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteApplicationAuthenticationMethod(
+    input: DeleteApplicationAuthenticationMethodRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteApplicationGrant(
+    input: DeleteApplicationGrantRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApplicationAccessScope(
+    input: GetApplicationAccessScopeRequest,
+  ): Effect.Effect<
+    GetApplicationAccessScopeResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApplicationAuthenticationMethod(
+    input: GetApplicationAuthenticationMethodRequest,
+  ): Effect.Effect<
+    GetApplicationAuthenticationMethodResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getApplicationGrant(
+    input: GetApplicationGrantRequest,
+  ): Effect.Effect<
+    GetApplicationGrantResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApplicationAccessScopes(
+    input: ListApplicationAccessScopesRequest,
+  ): Effect.Effect<
+    ListApplicationAccessScopesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApplicationAuthenticationMethods(
+    input: ListApplicationAuthenticationMethodsRequest,
+  ): Effect.Effect<
+    ListApplicationAuthenticationMethodsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listApplicationGrants(
+    input: ListApplicationGrantsRequest,
+  ): Effect.Effect<
+    ListApplicationGrantsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putApplicationAccessScope(
+    input: PutApplicationAccessScopeRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putApplicationAuthenticationMethod(
+    input: PutApplicationAuthenticationMethodRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  putApplicationGrant(
+    input: PutApplicationGrantRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class SsoAdmin extends SSOAdmin {}
@@ -2456,6 +2594,156 @@ export declare namespace UpdatePermissionSet {
 export declare namespace UpdateTrustedTokenIssuer {
   export type Input = UpdateTrustedTokenIssuerRequest;
   export type Output = UpdateTrustedTokenIssuerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplicationAccessScope {
+  export type Input = DeleteApplicationAccessScopeRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplicationAuthenticationMethod {
+  export type Input = DeleteApplicationAuthenticationMethodRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteApplicationGrant {
+  export type Input = DeleteApplicationGrantRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApplicationAccessScope {
+  export type Input = GetApplicationAccessScopeRequest;
+  export type Output = GetApplicationAccessScopeResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApplicationAuthenticationMethod {
+  export type Input = GetApplicationAuthenticationMethodRequest;
+  export type Output = GetApplicationAuthenticationMethodResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetApplicationGrant {
+  export type Input = GetApplicationGrantRequest;
+  export type Output = GetApplicationGrantResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplicationAccessScopes {
+  export type Input = ListApplicationAccessScopesRequest;
+  export type Output = ListApplicationAccessScopesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplicationAuthenticationMethods {
+  export type Input = ListApplicationAuthenticationMethodsRequest;
+  export type Output = ListApplicationAuthenticationMethodsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListApplicationGrants {
+  export type Input = ListApplicationGrantsRequest;
+  export type Output = ListApplicationGrantsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutApplicationAccessScope {
+  export type Input = PutApplicationAccessScopeRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutApplicationAuthenticationMethod {
+  export type Input = PutApplicationAuthenticationMethodRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace PutApplicationGrant {
+  export type Input = PutApplicationGrantRequest;
+  export type Output = {};
   export type Error =
     | AccessDeniedException
     | ConflictException

--- a/src/services/supplychain/index.ts
+++ b/src/services/supplychain/index.ts
@@ -92,6 +92,250 @@ export declare class SupplyChain extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createBillOfMaterialsImportJob(
+    input: CreateBillOfMaterialsImportJobRequest,
+  ): Effect.Effect<
+    CreateBillOfMaterialsImportJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataIntegrationFlow(
+    input: CreateDataIntegrationFlowRequest,
+  ): Effect.Effect<
+    CreateDataIntegrationFlowResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataLakeDataset(
+    input: CreateDataLakeDatasetRequest,
+  ): Effect.Effect<
+    CreateDataLakeDatasetResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataLakeNamespace(
+    input: CreateDataLakeNamespaceRequest,
+  ): Effect.Effect<
+    CreateDataLakeNamespaceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createInstance(
+    input: CreateInstanceRequest,
+  ): Effect.Effect<
+    CreateInstanceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataIntegrationFlow(
+    input: DeleteDataIntegrationFlowRequest,
+  ): Effect.Effect<
+    DeleteDataIntegrationFlowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteDataLakeDataset(
+    input: DeleteDataLakeDatasetRequest,
+  ): Effect.Effect<
+    DeleteDataLakeDatasetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataLakeNamespace(
+    input: DeleteDataLakeNamespaceRequest,
+  ): Effect.Effect<
+    DeleteDataLakeNamespaceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteInstance(
+    input: DeleteInstanceRequest,
+  ): Effect.Effect<
+    DeleteInstanceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBillOfMaterialsImportJob(
+    input: GetBillOfMaterialsImportJobRequest,
+  ): Effect.Effect<
+    GetBillOfMaterialsImportJobResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataIntegrationFlow(
+    input: GetDataIntegrationFlowRequest,
+  ): Effect.Effect<
+    GetDataIntegrationFlowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataLakeDataset(
+    input: GetDataLakeDatasetRequest,
+  ): Effect.Effect<
+    GetDataLakeDatasetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataLakeNamespace(
+    input: GetDataLakeNamespaceRequest,
+  ): Effect.Effect<
+    GetDataLakeNamespaceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getInstance(
+    input: GetInstanceRequest,
+  ): Effect.Effect<
+    GetInstanceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataIntegrationFlows(
+    input: ListDataIntegrationFlowsRequest,
+  ): Effect.Effect<
+    ListDataIntegrationFlowsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataLakeDatasets(
+    input: ListDataLakeDatasetsRequest,
+  ): Effect.Effect<
+    ListDataLakeDatasetsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataLakeNamespaces(
+    input: ListDataLakeNamespacesRequest,
+  ): Effect.Effect<
+    ListDataLakeNamespacesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listInstances(
+    input: ListInstancesRequest,
+  ): Effect.Effect<
+    ListInstancesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataIntegrationFlow(
+    input: UpdateDataIntegrationFlowRequest,
+  ): Effect.Effect<
+    UpdateDataIntegrationFlowResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataLakeDataset(
+    input: UpdateDataLakeDatasetRequest,
+  ): Effect.Effect<
+    UpdateDataLakeDatasetResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataLakeNamespace(
+    input: UpdateDataLakeNamespaceRequest,
+  ): Effect.Effect<
+    UpdateDataLakeNamespaceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateInstance(
+    input: UpdateInstanceRequest,
+  ): Effect.Effect<
+    UpdateInstanceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class Supplychain extends SupplyChain {}
@@ -809,6 +1053,272 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBillOfMaterialsImportJob {
+  export type Input = CreateBillOfMaterialsImportJobRequest;
+  export type Output = CreateBillOfMaterialsImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataIntegrationFlow {
+  export type Input = CreateDataIntegrationFlowRequest;
+  export type Output = CreateDataIntegrationFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataLakeDataset {
+  export type Input = CreateDataLakeDatasetRequest;
+  export type Output = CreateDataLakeDatasetResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataLakeNamespace {
+  export type Input = CreateDataLakeNamespaceRequest;
+  export type Output = CreateDataLakeNamespaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateInstance {
+  export type Input = CreateInstanceRequest;
+  export type Output = CreateInstanceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataIntegrationFlow {
+  export type Input = DeleteDataIntegrationFlowRequest;
+  export type Output = DeleteDataIntegrationFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataLakeDataset {
+  export type Input = DeleteDataLakeDatasetRequest;
+  export type Output = DeleteDataLakeDatasetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataLakeNamespace {
+  export type Input = DeleteDataLakeNamespaceRequest;
+  export type Output = DeleteDataLakeNamespaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteInstance {
+  export type Input = DeleteInstanceRequest;
+  export type Output = DeleteInstanceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBillOfMaterialsImportJob {
+  export type Input = GetBillOfMaterialsImportJobRequest;
+  export type Output = GetBillOfMaterialsImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataIntegrationFlow {
+  export type Input = GetDataIntegrationFlowRequest;
+  export type Output = GetDataIntegrationFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataLakeDataset {
+  export type Input = GetDataLakeDatasetRequest;
+  export type Output = GetDataLakeDatasetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataLakeNamespace {
+  export type Input = GetDataLakeNamespaceRequest;
+  export type Output = GetDataLakeNamespaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetInstance {
+  export type Input = GetInstanceRequest;
+  export type Output = GetInstanceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataIntegrationFlows {
+  export type Input = ListDataIntegrationFlowsRequest;
+  export type Output = ListDataIntegrationFlowsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataLakeDatasets {
+  export type Input = ListDataLakeDatasetsRequest;
+  export type Output = ListDataLakeDatasetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataLakeNamespaces {
+  export type Input = ListDataLakeNamespacesRequest;
+  export type Output = ListDataLakeNamespacesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListInstances {
+  export type Input = ListInstancesRequest;
+  export type Output = ListInstancesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataIntegrationFlow {
+  export type Input = UpdateDataIntegrationFlowRequest;
+  export type Output = UpdateDataIntegrationFlowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataLakeDataset {
+  export type Input = UpdateDataLakeDatasetRequest;
+  export type Output = UpdateDataLakeDatasetResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataLakeNamespace {
+  export type Input = UpdateDataLakeNamespaceRequest;
+  export type Output = UpdateDataLakeNamespaceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateInstance {
+  export type Input = UpdateInstanceRequest;
+  export type Output = UpdateInstanceResponse;
   export type Error =
     | AccessDeniedException
     | InternalServerException

--- a/src/services/timestream-influxdb/index.ts
+++ b/src/services/timestream-influxdb/index.ts
@@ -18,6 +18,170 @@ export declare class TimestreamInfluxDB extends AWSServiceClient {
   untagResource(
     input: UntagResourceRequest,
   ): Effect.Effect<{}, ResourceNotFoundException | CommonAwsError>;
+  createDbCluster(
+    input: CreateDbClusterInput,
+  ): Effect.Effect<
+    CreateDbClusterOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDbInstance(
+    input: CreateDbInstanceInput,
+  ): Effect.Effect<
+    CreateDbInstanceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDbParameterGroup(
+    input: CreateDbParameterGroupInput,
+  ): Effect.Effect<
+    CreateDbParameterGroupOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDbCluster(
+    input: DeleteDbClusterInput,
+  ): Effect.Effect<
+    DeleteDbClusterOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDbInstance(
+    input: DeleteDbInstanceInput,
+  ): Effect.Effect<
+    DeleteDbInstanceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDbCluster(
+    input: GetDbClusterInput,
+  ): Effect.Effect<
+    GetDbClusterOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDbInstance(
+    input: GetDbInstanceInput,
+  ): Effect.Effect<
+    GetDbInstanceOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDbParameterGroup(
+    input: GetDbParameterGroupInput,
+  ): Effect.Effect<
+    GetDbParameterGroupOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDbClusters(
+    input: ListDbClustersInput,
+  ): Effect.Effect<
+    ListDbClustersOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDbInstances(
+    input: ListDbInstancesInput,
+  ): Effect.Effect<
+    ListDbInstancesOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDbInstancesForCluster(
+    input: ListDbInstancesForClusterInput,
+  ): Effect.Effect<
+    ListDbInstancesForClusterOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDbParameterGroups(
+    input: ListDbParameterGroupsInput,
+  ): Effect.Effect<
+    ListDbParameterGroupsOutput,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDbCluster(
+    input: UpdateDbClusterInput,
+  ): Effect.Effect<
+    UpdateDbClusterOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDbInstance(
+    input: UpdateDbInstanceInput,
+  ): Effect.Effect<
+    UpdateDbInstanceOutput,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class TimestreamInfluxdb extends TimestreamInfluxDB {}
@@ -535,4 +699,182 @@ export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = {};
   export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace CreateDbCluster {
+  export type Input = CreateDbClusterInput;
+  export type Output = CreateDbClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDbInstance {
+  export type Input = CreateDbInstanceInput;
+  export type Output = CreateDbInstanceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDbParameterGroup {
+  export type Input = CreateDbParameterGroupInput;
+  export type Output = CreateDbParameterGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDbCluster {
+  export type Input = DeleteDbClusterInput;
+  export type Output = DeleteDbClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDbInstance {
+  export type Input = DeleteDbInstanceInput;
+  export type Output = DeleteDbInstanceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDbCluster {
+  export type Input = GetDbClusterInput;
+  export type Output = GetDbClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDbInstance {
+  export type Input = GetDbInstanceInput;
+  export type Output = GetDbInstanceOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDbParameterGroup {
+  export type Input = GetDbParameterGroupInput;
+  export type Output = GetDbParameterGroupOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDbClusters {
+  export type Input = ListDbClustersInput;
+  export type Output = ListDbClustersOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDbInstances {
+  export type Input = ListDbInstancesInput;
+  export type Output = ListDbInstancesOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDbInstancesForCluster {
+  export type Input = ListDbInstancesForClusterInput;
+  export type Output = ListDbInstancesForClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDbParameterGroups {
+  export type Input = ListDbParameterGroupsInput;
+  export type Output = ListDbParameterGroupsOutput;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDbCluster {
+  export type Input = UpdateDbClusterInput;
+  export type Output = UpdateDbClusterOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDbInstance {
+  export type Input = UpdateDbInstanceInput;
+  export type Output = UpdateDbInstanceOutput;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
 }

--- a/src/services/transfer/index.ts
+++ b/src/services/transfer/index.ts
@@ -314,6 +314,465 @@ export declare class Transfer extends AWSServiceClient {
     | ThrottlingException
     | CommonAwsError
   >;
+  createAgreement(
+    input: CreateAgreementRequest,
+  ): Effect.Effect<
+    CreateAgreementResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createConnector(
+    input: CreateConnectorRequest,
+  ): Effect.Effect<
+    CreateConnectorResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createProfile(
+    input: CreateProfileRequest,
+  ): Effect.Effect<
+    CreateProfileResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createServer(
+    input: CreateServerRequest,
+  ): Effect.Effect<
+    CreateServerResponse,
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createUser(
+    input: CreateUserRequest,
+  ): Effect.Effect<
+    CreateUserResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  createWebApp(
+    input: CreateWebAppRequest,
+  ): Effect.Effect<
+    CreateWebAppResponse,
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  createWorkflow(
+    input: CreateWorkflowRequest,
+  ): Effect.Effect<
+    CreateWorkflowResponse,
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteAgreement(
+    input: DeleteAgreementRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  deleteCertificate(
+    input: DeleteCertificateRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  deleteConnector(
+    input: DeleteConnectorRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  deleteProfile(
+    input: DeleteProfileRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  deleteServer(
+    input: DeleteServerRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  deleteUser(
+    input: DeleteUserRequest,
+  ): Effect.Effect<
+    {},
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  deleteWebApp(
+    input: DeleteWebAppRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteWebAppCustomization(
+    input: DeleteWebAppCustomizationRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  deleteWorkflow(
+    input: DeleteWorkflowRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  describeAgreement(
+    input: DescribeAgreementRequest,
+  ): Effect.Effect<
+    DescribeAgreementResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  describeCertificate(
+    input: DescribeCertificateRequest,
+  ): Effect.Effect<
+    DescribeCertificateResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  describeConnector(
+    input: DescribeConnectorRequest,
+  ): Effect.Effect<
+    DescribeConnectorResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  describeProfile(
+    input: DescribeProfileRequest,
+  ): Effect.Effect<
+    DescribeProfileResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  describeServer(
+    input: DescribeServerRequest,
+  ): Effect.Effect<
+    DescribeServerResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  describeUser(
+    input: DescribeUserRequest,
+  ): Effect.Effect<
+    DescribeUserResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  describeWebApp(
+    input: DescribeWebAppRequest,
+  ): Effect.Effect<
+    DescribeWebAppResponse,
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  describeWebAppCustomization(
+    input: DescribeWebAppCustomizationRequest,
+  ): Effect.Effect<
+    DescribeWebAppCustomizationResponse,
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  describeWorkflow(
+    input: DescribeWorkflowRequest,
+  ): Effect.Effect<
+    DescribeWorkflowResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  importCertificate(
+    input: ImportCertificateRequest,
+  ): Effect.Effect<
+    ImportCertificateResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  listAgreements(
+    input: ListAgreementsRequest,
+  ): Effect.Effect<
+    ListAgreementsResponse,
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  listCertificates(
+    input: ListCertificatesRequest,
+  ): Effect.Effect<
+    ListCertificatesResponse,
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  listConnectors(
+    input: ListConnectorsRequest,
+  ): Effect.Effect<
+    ListConnectorsResponse,
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  listProfiles(
+    input: ListProfilesRequest,
+  ): Effect.Effect<
+    ListProfilesResponse,
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  listServers(
+    input: ListServersRequest,
+  ): Effect.Effect<
+    ListServersResponse,
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  listUsers(
+    input: ListUsersRequest,
+  ): Effect.Effect<
+    ListUsersResponse,
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  listWebApps(
+    input: ListWebAppsRequest,
+  ): Effect.Effect<
+    ListWebAppsResponse,
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  listWorkflows(
+    input: ListWorkflowsRequest,
+  ): Effect.Effect<
+    ListWorkflowsResponse,
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ServiceUnavailableException
+    | CommonAwsError
+  >;
+  updateAgreement(
+    input: UpdateAgreementRequest,
+  ): Effect.Effect<
+    UpdateAgreementResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateCertificate(
+    input: UpdateCertificateRequest,
+  ): Effect.Effect<
+    UpdateCertificateResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateConnector(
+    input: UpdateConnectorRequest,
+  ): Effect.Effect<
+    UpdateConnectorResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateProfile(
+    input: UpdateProfileRequest,
+  ): Effect.Effect<
+    UpdateProfileResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateServer(
+    input: UpdateServerRequest,
+  ): Effect.Effect<
+    UpdateServerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateUser(
+    input: UpdateUserRequest,
+  ): Effect.Effect<
+    UpdateUserResponse,
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateWebApp(
+    input: UpdateWebAppRequest,
+  ): Effect.Effect<
+    UpdateWebAppResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
+  updateWebAppCustomization(
+    input: UpdateWebAppCustomizationRequest,
+  ): Effect.Effect<
+    UpdateWebAppCustomizationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -2064,6 +2523,507 @@ export declare namespace UpdateHostKey {
     | InvalidRequestException
     | ResourceNotFoundException
     | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAgreement {
+  export type Input = CreateAgreementRequest;
+  export type Output = CreateAgreementResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateConnector {
+  export type Input = CreateConnectorRequest;
+  export type Output = CreateConnectorResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateProfile {
+  export type Input = CreateProfileRequest;
+  export type Output = CreateProfileResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServer {
+  export type Input = CreateServerRequest;
+  export type Output = CreateServerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateUser {
+  export type Input = CreateUserRequest;
+  export type Output = CreateUserResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWebApp {
+  export type Input = CreateWebAppRequest;
+  export type Output = CreateWebAppResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace CreateWorkflow {
+  export type Input = CreateWorkflowRequest;
+  export type Output = CreateWorkflowResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAgreement {
+  export type Input = DeleteAgreementRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteCertificate {
+  export type Input = DeleteCertificateRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteConnector {
+  export type Input = DeleteConnectorRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteProfile {
+  export type Input = DeleteProfileRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServer {
+  export type Input = DeleteServerRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteUser {
+  export type Input = DeleteUserRequest;
+  export type Output = {};
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWebApp {
+  export type Input = DeleteWebAppRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWebAppCustomization {
+  export type Input = DeleteWebAppCustomizationRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteWorkflow {
+  export type Input = DeleteWorkflowRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeAgreement {
+  export type Input = DescribeAgreementRequest;
+  export type Output = DescribeAgreementResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeCertificate {
+  export type Input = DescribeCertificateRequest;
+  export type Output = DescribeCertificateResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeConnector {
+  export type Input = DescribeConnectorRequest;
+  export type Output = DescribeConnectorResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeProfile {
+  export type Input = DescribeProfileRequest;
+  export type Output = DescribeProfileResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeServer {
+  export type Input = DescribeServerRequest;
+  export type Output = DescribeServerResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeUser {
+  export type Input = DescribeUserRequest;
+  export type Output = DescribeUserResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeWebApp {
+  export type Input = DescribeWebAppRequest;
+  export type Output = DescribeWebAppResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeWebAppCustomization {
+  export type Input = DescribeWebAppCustomizationRequest;
+  export type Output = DescribeWebAppCustomizationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeWorkflow {
+  export type Input = DescribeWorkflowRequest;
+  export type Output = DescribeWorkflowResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace ImportCertificate {
+  export type Input = ImportCertificateRequest;
+  export type Output = ImportCertificateResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace ListAgreements {
+  export type Input = ListAgreementsRequest;
+  export type Output = ListAgreementsResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace ListCertificates {
+  export type Input = ListCertificatesRequest;
+  export type Output = ListCertificatesResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace ListConnectors {
+  export type Input = ListConnectorsRequest;
+  export type Output = ListConnectorsResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace ListProfiles {
+  export type Input = ListProfilesRequest;
+  export type Output = ListProfilesResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace ListServers {
+  export type Input = ListServersRequest;
+  export type Output = ListServersResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace ListUsers {
+  export type Input = ListUsersRequest;
+  export type Output = ListUsersResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace ListWebApps {
+  export type Input = ListWebAppsRequest;
+  export type Output = ListWebAppsResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace ListWorkflows {
+  export type Input = ListWorkflowsRequest;
+  export type Output = ListWorkflowsResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidNextTokenException
+    | InvalidRequestException
+    | ServiceUnavailableException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAgreement {
+  export type Input = UpdateAgreementRequest;
+  export type Output = UpdateAgreementResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateCertificate {
+  export type Input = UpdateCertificateRequest;
+  export type Output = UpdateCertificateResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateConnector {
+  export type Input = UpdateConnectorRequest;
+  export type Output = UpdateConnectorResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateProfile {
+  export type Input = UpdateProfileRequest;
+  export type Output = UpdateProfileResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServer {
+  export type Input = UpdateServerRequest;
+  export type Output = UpdateServerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceExistsException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateUser {
+  export type Input = UpdateUserRequest;
+  export type Output = UpdateUserResponse;
+  export type Error =
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ServiceUnavailableException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWebApp {
+  export type Input = UpdateWebAppRequest;
+  export type Output = UpdateWebAppResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateWebAppCustomization {
+  export type Input = UpdateWebAppCustomizationRequest;
+  export type Output = UpdateWebAppCustomizationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServiceError
+    | InvalidRequestException
+    | ResourceNotFoundException
     | ThrottlingException
     | CommonAwsError;
 }

--- a/src/services/verifiedpermissions/index.ts
+++ b/src/services/verifiedpermissions/index.ts
@@ -34,6 +34,171 @@ export declare class VerifiedPermissions extends AWSServiceClient {
     | ThrottlingException
     | CommonAwsError
   >;
+  batchGetPolicy(
+    input: BatchGetPolicyInput,
+  ): Effect.Effect<BatchGetPolicyOutput, CommonAwsError>;
+  batchIsAuthorized(
+    input: BatchIsAuthorizedInput,
+  ): Effect.Effect<
+    BatchIsAuthorizedOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  batchIsAuthorizedWithToken(
+    input: BatchIsAuthorizedWithTokenInput,
+  ): Effect.Effect<
+    BatchIsAuthorizedWithTokenOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  createIdentitySource(
+    input: CreateIdentitySourceInput,
+  ): Effect.Effect<
+    CreateIdentitySourceOutput,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  createPolicy(
+    input: CreatePolicyInput,
+  ): Effect.Effect<
+    CreatePolicyOutput,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  createPolicyStore(
+    input: CreatePolicyStoreInput,
+  ): Effect.Effect<
+    CreatePolicyStoreOutput,
+    ConflictException | ServiceQuotaExceededException | CommonAwsError
+  >;
+  createPolicyTemplate(
+    input: CreatePolicyTemplateInput,
+  ): Effect.Effect<
+    CreatePolicyTemplateOutput,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  deleteIdentitySource(
+    input: DeleteIdentitySourceInput,
+  ): Effect.Effect<
+    DeleteIdentitySourceOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  deletePolicy(
+    input: DeletePolicyInput,
+  ): Effect.Effect<
+    DeletePolicyOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  deletePolicyStore(
+    input: DeletePolicyStoreInput,
+  ): Effect.Effect<
+    DeletePolicyStoreOutput,
+    InvalidStateException | CommonAwsError
+  >;
+  deletePolicyTemplate(
+    input: DeletePolicyTemplateInput,
+  ): Effect.Effect<
+    DeletePolicyTemplateOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  getIdentitySource(
+    input: GetIdentitySourceInput,
+  ): Effect.Effect<
+    GetIdentitySourceOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getPolicy(
+    input: GetPolicyInput,
+  ): Effect.Effect<GetPolicyOutput, ResourceNotFoundException | CommonAwsError>;
+  getPolicyStore(
+    input: GetPolicyStoreInput,
+  ): Effect.Effect<
+    GetPolicyStoreOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getPolicyTemplate(
+    input: GetPolicyTemplateInput,
+  ): Effect.Effect<
+    GetPolicyTemplateOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  getSchema(
+    input: GetSchemaInput,
+  ): Effect.Effect<GetSchemaOutput, ResourceNotFoundException | CommonAwsError>;
+  isAuthorized(
+    input: IsAuthorizedInput,
+  ): Effect.Effect<
+    IsAuthorizedOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  isAuthorizedWithToken(
+    input: IsAuthorizedWithTokenInput,
+  ): Effect.Effect<
+    IsAuthorizedWithTokenOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  listIdentitySources(
+    input: ListIdentitySourcesInput,
+  ): Effect.Effect<
+    ListIdentitySourcesOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  listPolicies(
+    input: ListPoliciesInput,
+  ): Effect.Effect<
+    ListPoliciesOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  listPolicyStores(
+    input: ListPolicyStoresInput,
+  ): Effect.Effect<ListPolicyStoresOutput, CommonAwsError>;
+  listPolicyTemplates(
+    input: ListPolicyTemplatesInput,
+  ): Effect.Effect<
+    ListPolicyTemplatesOutput,
+    ResourceNotFoundException | CommonAwsError
+  >;
+  putSchema(
+    input: PutSchemaInput,
+  ): Effect.Effect<
+    PutSchemaOutput,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  updateIdentitySource(
+    input: UpdateIdentitySourceInput,
+  ): Effect.Effect<
+    UpdateIdentitySourceOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  updatePolicy(
+    input: UpdatePolicyInput,
+  ): Effect.Effect<
+    UpdatePolicyOutput,
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError
+  >;
+  updatePolicyStore(
+    input: UpdatePolicyStoreInput,
+  ): Effect.Effect<
+    UpdatePolicyStoreOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
+  updatePolicyTemplate(
+    input: UpdatePolicyTemplateInput,
+  ): Effect.Effect<
+    UpdatePolicyTemplateOutput,
+    ConflictException | ResourceNotFoundException | CommonAwsError
+  >;
 }
 
 export declare class Verifiedpermissions extends VerifiedPermissions {}
@@ -999,5 +1164,208 @@ export declare namespace UntagResource {
     | InternalServerException
     | ResourceNotFoundException
     | ThrottlingException
+    | CommonAwsError;
+}
+
+export declare namespace BatchGetPolicy {
+  export type Input = BatchGetPolicyInput;
+  export type Output = BatchGetPolicyOutput;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace BatchIsAuthorized {
+  export type Input = BatchIsAuthorizedInput;
+  export type Output = BatchIsAuthorizedOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace BatchIsAuthorizedWithToken {
+  export type Input = BatchIsAuthorizedWithTokenInput;
+  export type Output = BatchIsAuthorizedWithTokenOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace CreateIdentitySource {
+  export type Input = CreateIdentitySourceInput;
+  export type Output = CreateIdentitySourceOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePolicy {
+  export type Input = CreatePolicyInput;
+  export type Output = CreatePolicyOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePolicyStore {
+  export type Input = CreatePolicyStoreInput;
+  export type Output = CreatePolicyStoreOutput;
+  export type Error =
+    | ConflictException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePolicyTemplate {
+  export type Input = CreatePolicyTemplateInput;
+  export type Output = CreatePolicyTemplateOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIdentitySource {
+  export type Input = DeleteIdentitySourceInput;
+  export type Output = DeleteIdentitySourceOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePolicy {
+  export type Input = DeletePolicyInput;
+  export type Output = DeletePolicyOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePolicyStore {
+  export type Input = DeletePolicyStoreInput;
+  export type Output = DeletePolicyStoreOutput;
+  export type Error = InvalidStateException | CommonAwsError;
+}
+
+export declare namespace DeletePolicyTemplate {
+  export type Input = DeletePolicyTemplateInput;
+  export type Output = DeletePolicyTemplateOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace GetIdentitySource {
+  export type Input = GetIdentitySourceInput;
+  export type Output = GetIdentitySourceOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetPolicy {
+  export type Input = GetPolicyInput;
+  export type Output = GetPolicyOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetPolicyStore {
+  export type Input = GetPolicyStoreInput;
+  export type Output = GetPolicyStoreOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetPolicyTemplate {
+  export type Input = GetPolicyTemplateInput;
+  export type Output = GetPolicyTemplateOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace GetSchema {
+  export type Input = GetSchemaInput;
+  export type Output = GetSchemaOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace IsAuthorized {
+  export type Input = IsAuthorizedInput;
+  export type Output = IsAuthorizedOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace IsAuthorizedWithToken {
+  export type Input = IsAuthorizedWithTokenInput;
+  export type Output = IsAuthorizedWithTokenOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace ListIdentitySources {
+  export type Input = ListIdentitySourcesInput;
+  export type Output = ListIdentitySourcesOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace ListPolicies {
+  export type Input = ListPoliciesInput;
+  export type Output = ListPoliciesOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace ListPolicyStores {
+  export type Input = ListPolicyStoresInput;
+  export type Output = ListPolicyStoresOutput;
+  export type Error = CommonAwsError;
+}
+
+export declare namespace ListPolicyTemplates {
+  export type Input = ListPolicyTemplatesInput;
+  export type Output = ListPolicyTemplatesOutput;
+  export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace PutSchema {
+  export type Input = PutSchemaInput;
+  export type Output = PutSchemaOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateIdentitySource {
+  export type Input = UpdateIdentitySourceInput;
+  export type Output = UpdateIdentitySourceOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePolicy {
+  export type Input = UpdatePolicyInput;
+  export type Output = UpdatePolicyOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePolicyStore {
+  export type Input = UpdatePolicyStoreInput;
+  export type Output = UpdatePolicyStoreOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePolicyTemplate {
+  export type Input = UpdatePolicyTemplateInput;
+  export type Output = UpdatePolicyTemplateOutput;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
     | CommonAwsError;
 }

--- a/src/services/voice-id/index.ts
+++ b/src/services/voice-id/index.ts
@@ -285,6 +285,64 @@ export declare class VoiceID extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createDomain(
+    input: CreateDomainRequest,
+  ): Effect.Effect<
+    CreateDomainResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDomain(
+    input: DeleteDomainRequest,
+  ): Effect.Effect<
+    {},
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  describeDomain(
+    input: DescribeDomainRequest,
+  ): Effect.Effect<
+    DescribeDomainResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDomains(
+    input: ListDomainsRequest,
+  ): Effect.Effect<
+    ListDomainsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDomain(
+    input: UpdateDomainRequest,
+  ): Effect.Effect<
+    UpdateDomainResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class VoiceId extends VoiceID {}
@@ -1153,6 +1211,69 @@ export declare namespace UntagResource {
 export declare namespace UpdateWatchlist {
   export type Input = UpdateWatchlistRequest;
   export type Output = UpdateWatchlistResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDomain {
+  export type Input = CreateDomainRequest;
+  export type Output = CreateDomainResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDomain {
+  export type Input = DeleteDomainRequest;
+  export type Output = {};
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DescribeDomain {
+  export type Input = DescribeDomainRequest;
+  export type Output = DescribeDomainResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDomains {
+  export type Input = ListDomainsRequest;
+  export type Output = ListDomainsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDomain {
+  export type Input = UpdateDomainRequest;
+  export type Output = UpdateDomainResponse;
   export type Error =
     | AccessDeniedException
     | ConflictException

--- a/src/services/vpc-lattice/index.ts
+++ b/src/services/vpc-lattice/index.ts
@@ -122,6 +122,679 @@ export declare class VPCLattice extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  createAccessLogSubscription(
+    input: CreateAccessLogSubscriptionRequest,
+  ): Effect.Effect<
+    CreateAccessLogSubscriptionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createListener(
+    input: CreateListenerRequest,
+  ): Effect.Effect<
+    CreateListenerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createResourceConfiguration(
+    input: CreateResourceConfigurationRequest,
+  ): Effect.Effect<
+    CreateResourceConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createResourceGateway(
+    input: CreateResourceGatewayRequest,
+  ): Effect.Effect<
+    CreateResourceGatewayResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createRule(
+    input: CreateRuleRequest,
+  ): Effect.Effect<
+    CreateRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createService(
+    input: CreateServiceRequest,
+  ): Effect.Effect<
+    CreateServiceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServiceNetwork(
+    input: CreateServiceNetworkRequest,
+  ): Effect.Effect<
+    CreateServiceNetworkResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServiceNetworkResourceAssociation(
+    input: CreateServiceNetworkResourceAssociationRequest,
+  ): Effect.Effect<
+    CreateServiceNetworkResourceAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServiceNetworkServiceAssociation(
+    input: CreateServiceNetworkServiceAssociationRequest,
+  ): Effect.Effect<
+    CreateServiceNetworkServiceAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createServiceNetworkVpcAssociation(
+    input: CreateServiceNetworkVpcAssociationRequest,
+  ): Effect.Effect<
+    CreateServiceNetworkVpcAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTargetGroup(
+    input: CreateTargetGroupRequest,
+  ): Effect.Effect<
+    CreateTargetGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAccessLogSubscription(
+    input: DeleteAccessLogSubscriptionRequest,
+  ): Effect.Effect<
+    DeleteAccessLogSubscriptionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteListener(
+    input: DeleteListenerRequest,
+  ): Effect.Effect<
+    DeleteListenerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteResourceConfiguration(
+    input: DeleteResourceConfigurationRequest,
+  ): Effect.Effect<
+    DeleteResourceConfigurationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteResourceEndpointAssociation(
+    input: DeleteResourceEndpointAssociationRequest,
+  ): Effect.Effect<
+    DeleteResourceEndpointAssociationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteResourceGateway(
+    input: DeleteResourceGatewayRequest,
+  ): Effect.Effect<
+    DeleteResourceGatewayResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteRule(
+    input: DeleteRuleRequest,
+  ): Effect.Effect<
+    DeleteRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteService(
+    input: DeleteServiceRequest,
+  ): Effect.Effect<
+    DeleteServiceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServiceNetwork(
+    input: DeleteServiceNetworkRequest,
+  ): Effect.Effect<
+    DeleteServiceNetworkResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServiceNetworkResourceAssociation(
+    input: DeleteServiceNetworkResourceAssociationRequest,
+  ): Effect.Effect<
+    DeleteServiceNetworkResourceAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServiceNetworkServiceAssociation(
+    input: DeleteServiceNetworkServiceAssociationRequest,
+  ): Effect.Effect<
+    DeleteServiceNetworkServiceAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteServiceNetworkVpcAssociation(
+    input: DeleteServiceNetworkVpcAssociationRequest,
+  ): Effect.Effect<
+    DeleteServiceNetworkVpcAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTargetGroup(
+    input: DeleteTargetGroupRequest,
+  ): Effect.Effect<
+    DeleteTargetGroupResponse,
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deregisterTargets(
+    input: DeregisterTargetsRequest,
+  ): Effect.Effect<
+    DeregisterTargetsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAccessLogSubscription(
+    input: GetAccessLogSubscriptionRequest,
+  ): Effect.Effect<
+    GetAccessLogSubscriptionResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getListener(
+    input: GetListenerRequest,
+  ): Effect.Effect<
+    GetListenerResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getResourceConfiguration(
+    input: GetResourceConfigurationRequest,
+  ): Effect.Effect<
+    GetResourceConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getResourceGateway(
+    input: GetResourceGatewayRequest,
+  ): Effect.Effect<
+    GetResourceGatewayResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRule(
+    input: GetRuleRequest,
+  ): Effect.Effect<
+    GetRuleResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getService(
+    input: GetServiceRequest,
+  ): Effect.Effect<
+    GetServiceResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceNetwork(
+    input: GetServiceNetworkRequest,
+  ): Effect.Effect<
+    GetServiceNetworkResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceNetworkResourceAssociation(
+    input: GetServiceNetworkResourceAssociationRequest,
+  ): Effect.Effect<
+    GetServiceNetworkResourceAssociationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceNetworkServiceAssociation(
+    input: GetServiceNetworkServiceAssociationRequest,
+  ): Effect.Effect<
+    GetServiceNetworkServiceAssociationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getServiceNetworkVpcAssociation(
+    input: GetServiceNetworkVpcAssociationRequest,
+  ): Effect.Effect<
+    GetServiceNetworkVpcAssociationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTargetGroup(
+    input: GetTargetGroupRequest,
+  ): Effect.Effect<
+    GetTargetGroupResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAccessLogSubscriptions(
+    input: ListAccessLogSubscriptionsRequest,
+  ): Effect.Effect<
+    ListAccessLogSubscriptionsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listListeners(
+    input: ListListenersRequest,
+  ): Effect.Effect<
+    ListListenersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listResourceConfigurations(
+    input: ListResourceConfigurationsRequest,
+  ): Effect.Effect<
+    ListResourceConfigurationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listResourceEndpointAssociations(
+    input: ListResourceEndpointAssociationsRequest,
+  ): Effect.Effect<
+    ListResourceEndpointAssociationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listResourceGateways(
+    input: ListResourceGatewaysRequest,
+  ): Effect.Effect<
+    ListResourceGatewaysResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listRules(
+    input: ListRulesRequest,
+  ): Effect.Effect<
+    ListRulesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceNetworkResourceAssociations(
+    input: ListServiceNetworkResourceAssociationsRequest,
+  ): Effect.Effect<
+    ListServiceNetworkResourceAssociationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceNetworkServiceAssociations(
+    input: ListServiceNetworkServiceAssociationsRequest,
+  ): Effect.Effect<
+    ListServiceNetworkServiceAssociationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceNetworkVpcAssociations(
+    input: ListServiceNetworkVpcAssociationsRequest,
+  ): Effect.Effect<
+    ListServiceNetworkVpcAssociationsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServiceNetworks(
+    input: ListServiceNetworksRequest,
+  ): Effect.Effect<
+    ListServiceNetworksResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listServices(
+    input: ListServicesRequest,
+  ): Effect.Effect<
+    ListServicesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTargetGroups(
+    input: ListTargetGroupsRequest,
+  ): Effect.Effect<
+    ListTargetGroupsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTargets(
+    input: ListTargetsRequest,
+  ): Effect.Effect<
+    ListTargetsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  registerTargets(
+    input: RegisterTargetsRequest,
+  ): Effect.Effect<
+    RegisterTargetsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateAccessLogSubscription(
+    input: UpdateAccessLogSubscriptionRequest,
+  ): Effect.Effect<
+    UpdateAccessLogSubscriptionResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateListener(
+    input: UpdateListenerRequest,
+  ): Effect.Effect<
+    UpdateListenerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateResourceConfiguration(
+    input: UpdateResourceConfigurationRequest,
+  ): Effect.Effect<
+    UpdateResourceConfigurationResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateResourceGateway(
+    input: UpdateResourceGatewayRequest,
+  ): Effect.Effect<
+    UpdateResourceGatewayResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateRule(
+    input: UpdateRuleRequest,
+  ): Effect.Effect<
+    UpdateRuleResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateService(
+    input: UpdateServiceRequest,
+  ): Effect.Effect<
+    UpdateServiceResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateServiceNetwork(
+    input: UpdateServiceNetworkRequest,
+  ): Effect.Effect<
+    UpdateServiceNetworkResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateServiceNetworkVpcAssociation(
+    input: UpdateServiceNetworkVpcAssociationRequest,
+  ): Effect.Effect<
+    UpdateServiceNetworkVpcAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTargetGroup(
+    input: UpdateTargetGroupRequest,
+  ): Effect.Effect<
+    UpdateTargetGroupResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class VpcLattice extends VPCLattice {}
@@ -1652,6 +2325,737 @@ export declare namespace UntagResource {
     | AccessDeniedException
     | InternalServerException
     | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAccessLogSubscription {
+  export type Input = CreateAccessLogSubscriptionRequest;
+  export type Output = CreateAccessLogSubscriptionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateListener {
+  export type Input = CreateListenerRequest;
+  export type Output = CreateListenerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateResourceConfiguration {
+  export type Input = CreateResourceConfigurationRequest;
+  export type Output = CreateResourceConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateResourceGateway {
+  export type Input = CreateResourceGatewayRequest;
+  export type Output = CreateResourceGatewayResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateRule {
+  export type Input = CreateRuleRequest;
+  export type Output = CreateRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateService {
+  export type Input = CreateServiceRequest;
+  export type Output = CreateServiceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceNetwork {
+  export type Input = CreateServiceNetworkRequest;
+  export type Output = CreateServiceNetworkResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceNetworkResourceAssociation {
+  export type Input = CreateServiceNetworkResourceAssociationRequest;
+  export type Output = CreateServiceNetworkResourceAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceNetworkServiceAssociation {
+  export type Input = CreateServiceNetworkServiceAssociationRequest;
+  export type Output = CreateServiceNetworkServiceAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateServiceNetworkVpcAssociation {
+  export type Input = CreateServiceNetworkVpcAssociationRequest;
+  export type Output = CreateServiceNetworkVpcAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTargetGroup {
+  export type Input = CreateTargetGroupRequest;
+  export type Output = CreateTargetGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAccessLogSubscription {
+  export type Input = DeleteAccessLogSubscriptionRequest;
+  export type Output = DeleteAccessLogSubscriptionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteListener {
+  export type Input = DeleteListenerRequest;
+  export type Output = DeleteListenerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteResourceConfiguration {
+  export type Input = DeleteResourceConfigurationRequest;
+  export type Output = DeleteResourceConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteResourceEndpointAssociation {
+  export type Input = DeleteResourceEndpointAssociationRequest;
+  export type Output = DeleteResourceEndpointAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteResourceGateway {
+  export type Input = DeleteResourceGatewayRequest;
+  export type Output = DeleteResourceGatewayResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteRule {
+  export type Input = DeleteRuleRequest;
+  export type Output = DeleteRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteService {
+  export type Input = DeleteServiceRequest;
+  export type Output = DeleteServiceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServiceNetwork {
+  export type Input = DeleteServiceNetworkRequest;
+  export type Output = DeleteServiceNetworkResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServiceNetworkResourceAssociation {
+  export type Input = DeleteServiceNetworkResourceAssociationRequest;
+  export type Output = DeleteServiceNetworkResourceAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServiceNetworkServiceAssociation {
+  export type Input = DeleteServiceNetworkServiceAssociationRequest;
+  export type Output = DeleteServiceNetworkServiceAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteServiceNetworkVpcAssociation {
+  export type Input = DeleteServiceNetworkVpcAssociationRequest;
+  export type Output = DeleteServiceNetworkVpcAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTargetGroup {
+  export type Input = DeleteTargetGroupRequest;
+  export type Output = DeleteTargetGroupResponse;
+  export type Error =
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeregisterTargets {
+  export type Input = DeregisterTargetsRequest;
+  export type Output = DeregisterTargetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAccessLogSubscription {
+  export type Input = GetAccessLogSubscriptionRequest;
+  export type Output = GetAccessLogSubscriptionResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetListener {
+  export type Input = GetListenerRequest;
+  export type Output = GetListenerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetResourceConfiguration {
+  export type Input = GetResourceConfigurationRequest;
+  export type Output = GetResourceConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetResourceGateway {
+  export type Input = GetResourceGatewayRequest;
+  export type Output = GetResourceGatewayResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRule {
+  export type Input = GetRuleRequest;
+  export type Output = GetRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetService {
+  export type Input = GetServiceRequest;
+  export type Output = GetServiceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceNetwork {
+  export type Input = GetServiceNetworkRequest;
+  export type Output = GetServiceNetworkResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceNetworkResourceAssociation {
+  export type Input = GetServiceNetworkResourceAssociationRequest;
+  export type Output = GetServiceNetworkResourceAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceNetworkServiceAssociation {
+  export type Input = GetServiceNetworkServiceAssociationRequest;
+  export type Output = GetServiceNetworkServiceAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetServiceNetworkVpcAssociation {
+  export type Input = GetServiceNetworkVpcAssociationRequest;
+  export type Output = GetServiceNetworkVpcAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTargetGroup {
+  export type Input = GetTargetGroupRequest;
+  export type Output = GetTargetGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAccessLogSubscriptions {
+  export type Input = ListAccessLogSubscriptionsRequest;
+  export type Output = ListAccessLogSubscriptionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListListeners {
+  export type Input = ListListenersRequest;
+  export type Output = ListListenersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListResourceConfigurations {
+  export type Input = ListResourceConfigurationsRequest;
+  export type Output = ListResourceConfigurationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListResourceEndpointAssociations {
+  export type Input = ListResourceEndpointAssociationsRequest;
+  export type Output = ListResourceEndpointAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListResourceGateways {
+  export type Input = ListResourceGatewaysRequest;
+  export type Output = ListResourceGatewaysResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListRules {
+  export type Input = ListRulesRequest;
+  export type Output = ListRulesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceNetworkResourceAssociations {
+  export type Input = ListServiceNetworkResourceAssociationsRequest;
+  export type Output = ListServiceNetworkResourceAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceNetworkServiceAssociations {
+  export type Input = ListServiceNetworkServiceAssociationsRequest;
+  export type Output = ListServiceNetworkServiceAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceNetworkVpcAssociations {
+  export type Input = ListServiceNetworkVpcAssociationsRequest;
+  export type Output = ListServiceNetworkVpcAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServiceNetworks {
+  export type Input = ListServiceNetworksRequest;
+  export type Output = ListServiceNetworksResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListServices {
+  export type Input = ListServicesRequest;
+  export type Output = ListServicesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTargetGroups {
+  export type Input = ListTargetGroupsRequest;
+  export type Output = ListTargetGroupsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTargets {
+  export type Input = ListTargetsRequest;
+  export type Output = ListTargetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RegisterTargets {
+  export type Input = RegisterTargetsRequest;
+  export type Output = RegisterTargetsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateAccessLogSubscription {
+  export type Input = UpdateAccessLogSubscriptionRequest;
+  export type Output = UpdateAccessLogSubscriptionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateListener {
+  export type Input = UpdateListenerRequest;
+  export type Output = UpdateListenerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateResourceConfiguration {
+  export type Input = UpdateResourceConfigurationRequest;
+  export type Output = UpdateResourceConfigurationResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateResourceGateway {
+  export type Input = UpdateResourceGatewayRequest;
+  export type Output = UpdateResourceGatewayResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateRule {
+  export type Input = UpdateRuleRequest;
+  export type Output = UpdateRuleResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateService {
+  export type Input = UpdateServiceRequest;
+  export type Output = UpdateServiceResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServiceNetwork {
+  export type Input = UpdateServiceNetworkRequest;
+  export type Output = UpdateServiceNetworkResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateServiceNetworkVpcAssociation {
+  export type Input = UpdateServiceNetworkVpcAssociationRequest;
+  export type Output = UpdateServiceNetworkVpcAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTargetGroup {
+  export type Input = UpdateTargetGroupRequest;
+  export type Output = UpdateTargetGroupResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
     | ValidationException
     | CommonAwsError;
 }

--- a/src/services/wisdom/index.ts
+++ b/src/services/wisdom/index.ts
@@ -21,6 +21,356 @@ export declare class Wisdom extends AWSServiceClient {
     UntagResourceResponse,
     ResourceNotFoundException | CommonAwsError
   >;
+  createAssistant(
+    input: CreateAssistantRequest,
+  ): Effect.Effect<
+    CreateAssistantResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createAssistantAssociation(
+    input: CreateAssistantAssociationRequest,
+  ): Effect.Effect<
+    CreateAssistantAssociationResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createContent(
+    input: CreateContentRequest,
+  ): Effect.Effect<
+    CreateContentResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createKnowledgeBase(
+    input: CreateKnowledgeBaseRequest,
+  ): Effect.Effect<
+    CreateKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createQuickResponse(
+    input: CreateQuickResponseRequest,
+  ): Effect.Effect<
+    CreateQuickResponseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSession(
+    input: CreateSessionRequest,
+  ): Effect.Effect<
+    CreateSessionResponse,
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAssistant(
+    input: DeleteAssistantRequest,
+  ): Effect.Effect<
+    DeleteAssistantResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteAssistantAssociation(
+    input: DeleteAssistantAssociationRequest,
+  ): Effect.Effect<
+    DeleteAssistantAssociationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteContent(
+    input: DeleteContentRequest,
+  ): Effect.Effect<
+    DeleteContentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteImportJob(
+    input: DeleteImportJobRequest,
+  ): Effect.Effect<
+    DeleteImportJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteKnowledgeBase(
+    input: DeleteKnowledgeBaseRequest,
+  ): Effect.Effect<
+    DeleteKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteQuickResponse(
+    input: DeleteQuickResponseRequest,
+  ): Effect.Effect<
+    DeleteQuickResponseResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAssistant(
+    input: GetAssistantRequest,
+  ): Effect.Effect<
+    GetAssistantResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getAssistantAssociation(
+    input: GetAssistantAssociationRequest,
+  ): Effect.Effect<
+    GetAssistantAssociationResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getContent(
+    input: GetContentRequest,
+  ): Effect.Effect<
+    GetContentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getContentSummary(
+    input: GetContentSummaryRequest,
+  ): Effect.Effect<
+    GetContentSummaryResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getImportJob(
+    input: GetImportJobRequest,
+  ): Effect.Effect<
+    GetImportJobResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getKnowledgeBase(
+    input: GetKnowledgeBaseRequest,
+  ): Effect.Effect<
+    GetKnowledgeBaseResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getQuickResponse(
+    input: GetQuickResponseRequest,
+  ): Effect.Effect<
+    GetQuickResponseResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getRecommendations(
+    input: GetRecommendationsRequest,
+  ): Effect.Effect<
+    GetRecommendationsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSession(
+    input: GetSessionRequest,
+  ): Effect.Effect<
+    GetSessionResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAssistantAssociations(
+    input: ListAssistantAssociationsRequest,
+  ): Effect.Effect<
+    ListAssistantAssociationsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listAssistants(
+    input: ListAssistantsRequest,
+  ): Effect.Effect<
+    ListAssistantsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listContents(
+    input: ListContentsRequest,
+  ): Effect.Effect<
+    ListContentsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listImportJobs(
+    input: ListImportJobsRequest,
+  ): Effect.Effect<
+    ListImportJobsResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listKnowledgeBases(
+    input: ListKnowledgeBasesRequest,
+  ): Effect.Effect<
+    ListKnowledgeBasesResponse,
+    AccessDeniedException | ValidationException | CommonAwsError
+  >;
+  listQuickResponses(
+    input: ListQuickResponsesRequest,
+  ): Effect.Effect<
+    ListQuickResponsesResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  notifyRecommendationsReceived(
+    input: NotifyRecommendationsReceivedRequest,
+  ): Effect.Effect<
+    NotifyRecommendationsReceivedResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  queryAssistant(
+    input: QueryAssistantRequest,
+  ): Effect.Effect<
+    QueryAssistantResponse,
+    | AccessDeniedException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  removeKnowledgeBaseTemplateUri(
+    input: RemoveKnowledgeBaseTemplateUriRequest,
+  ): Effect.Effect<
+    RemoveKnowledgeBaseTemplateUriResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchContent(
+    input: SearchContentRequest,
+  ): Effect.Effect<
+    SearchContentResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchQuickResponses(
+    input: SearchQuickResponsesRequest,
+  ): Effect.Effect<
+    SearchQuickResponsesResponse,
+    | AccessDeniedException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  searchSessions(
+    input: SearchSessionsRequest,
+  ): Effect.Effect<
+    SearchSessionsResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startContentUpload(
+    input: StartContentUploadRequest,
+  ): Effect.Effect<
+    StartContentUploadResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  startImportJob(
+    input: StartImportJobRequest,
+  ): Effect.Effect<
+    StartImportJobResponse,
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateContent(
+    input: UpdateContentRequest,
+  ): Effect.Effect<
+    UpdateContentResponse,
+    | AccessDeniedException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateKnowledgeBaseTemplateUri(
+    input: UpdateKnowledgeBaseTemplateUriRequest,
+  ): Effect.Effect<
+    UpdateKnowledgeBaseTemplateUriResponse,
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateQuickResponse(
+    input: UpdateQuickResponseRequest,
+  ): Effect.Effect<
+    UpdateQuickResponseResponse,
+    | AccessDeniedException
+    | ConflictException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class AccessDeniedException extends EffectData.TaggedError(
@@ -930,4 +1280,398 @@ export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
   export type Error = ResourceNotFoundException | CommonAwsError;
+}
+
+export declare namespace CreateAssistant {
+  export type Input = CreateAssistantRequest;
+  export type Output = CreateAssistantResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateAssistantAssociation {
+  export type Input = CreateAssistantAssociationRequest;
+  export type Output = CreateAssistantAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateContent {
+  export type Input = CreateContentRequest;
+  export type Output = CreateContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateKnowledgeBase {
+  export type Input = CreateKnowledgeBaseRequest;
+  export type Output = CreateKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateQuickResponse {
+  export type Input = CreateQuickResponseRequest;
+  export type Output = CreateQuickResponseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSession {
+  export type Input = CreateSessionRequest;
+  export type Output = CreateSessionResponse;
+  export type Error =
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAssistant {
+  export type Input = DeleteAssistantRequest;
+  export type Output = DeleteAssistantResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteAssistantAssociation {
+  export type Input = DeleteAssistantAssociationRequest;
+  export type Output = DeleteAssistantAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteContent {
+  export type Input = DeleteContentRequest;
+  export type Output = DeleteContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteImportJob {
+  export type Input = DeleteImportJobRequest;
+  export type Output = DeleteImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteKnowledgeBase {
+  export type Input = DeleteKnowledgeBaseRequest;
+  export type Output = DeleteKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteQuickResponse {
+  export type Input = DeleteQuickResponseRequest;
+  export type Output = DeleteQuickResponseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAssistant {
+  export type Input = GetAssistantRequest;
+  export type Output = GetAssistantResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetAssistantAssociation {
+  export type Input = GetAssistantAssociationRequest;
+  export type Output = GetAssistantAssociationResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetContent {
+  export type Input = GetContentRequest;
+  export type Output = GetContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetContentSummary {
+  export type Input = GetContentSummaryRequest;
+  export type Output = GetContentSummaryResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetImportJob {
+  export type Input = GetImportJobRequest;
+  export type Output = GetImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetKnowledgeBase {
+  export type Input = GetKnowledgeBaseRequest;
+  export type Output = GetKnowledgeBaseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetQuickResponse {
+  export type Input = GetQuickResponseRequest;
+  export type Output = GetQuickResponseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetRecommendations {
+  export type Input = GetRecommendationsRequest;
+  export type Output = GetRecommendationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSession {
+  export type Input = GetSessionRequest;
+  export type Output = GetSessionResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAssistantAssociations {
+  export type Input = ListAssistantAssociationsRequest;
+  export type Output = ListAssistantAssociationsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListAssistants {
+  export type Input = ListAssistantsRequest;
+  export type Output = ListAssistantsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListContents {
+  export type Input = ListContentsRequest;
+  export type Output = ListContentsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListImportJobs {
+  export type Input = ListImportJobsRequest;
+  export type Output = ListImportJobsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListKnowledgeBases {
+  export type Input = ListKnowledgeBasesRequest;
+  export type Output = ListKnowledgeBasesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListQuickResponses {
+  export type Input = ListQuickResponsesRequest;
+  export type Output = ListQuickResponsesResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace NotifyRecommendationsReceived {
+  export type Input = NotifyRecommendationsReceivedRequest;
+  export type Output = NotifyRecommendationsReceivedResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace QueryAssistant {
+  export type Input = QueryAssistantRequest;
+  export type Output = QueryAssistantResponse;
+  export type Error =
+    | AccessDeniedException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace RemoveKnowledgeBaseTemplateUri {
+  export type Input = RemoveKnowledgeBaseTemplateUriRequest;
+  export type Output = RemoveKnowledgeBaseTemplateUriResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchContent {
+  export type Input = SearchContentRequest;
+  export type Output = SearchContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchQuickResponses {
+  export type Input = SearchQuickResponsesRequest;
+  export type Output = SearchQuickResponsesResponse;
+  export type Error =
+    | AccessDeniedException
+    | RequestTimeoutException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace SearchSessions {
+  export type Input = SearchSessionsRequest;
+  export type Output = SearchSessionsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartContentUpload {
+  export type Input = StartContentUploadRequest;
+  export type Output = StartContentUploadResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace StartImportJob {
+  export type Input = StartImportJobRequest;
+  export type Output = StartImportJobResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateContent {
+  export type Input = UpdateContentRequest;
+  export type Output = UpdateContentResponse;
+  export type Error =
+    | AccessDeniedException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateKnowledgeBaseTemplateUri {
+  export type Input = UpdateKnowledgeBaseTemplateUriRequest;
+  export type Output = UpdateKnowledgeBaseTemplateUriResponse;
+  export type Error =
+    | AccessDeniedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateQuickResponse {
+  export type Input = UpdateQuickResponseRequest;
+  export type Output = UpdateQuickResponseResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | PreconditionFailedException
+    | ResourceNotFoundException
+    | ValidationException
+    | CommonAwsError;
 }

--- a/src/services/workspaces-web/index.ts
+++ b/src/services/workspaces-web/index.ts
@@ -70,6 +70,787 @@ export declare class WorkSpacesWeb extends AWSServiceClient {
     | ValidationException
     | CommonAwsError
   >;
+  associateBrowserSettings(
+    input: AssociateBrowserSettingsRequest,
+  ): Effect.Effect<
+    AssociateBrowserSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateDataProtectionSettings(
+    input: AssociateDataProtectionSettingsRequest,
+  ): Effect.Effect<
+    AssociateDataProtectionSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateIpAccessSettings(
+    input: AssociateIpAccessSettingsRequest,
+  ): Effect.Effect<
+    AssociateIpAccessSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateNetworkSettings(
+    input: AssociateNetworkSettingsRequest,
+  ): Effect.Effect<
+    AssociateNetworkSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateSessionLogger(
+    input: AssociateSessionLoggerRequest,
+  ): Effect.Effect<
+    AssociateSessionLoggerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateTrustStore(
+    input: AssociateTrustStoreRequest,
+  ): Effect.Effect<
+    AssociateTrustStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateUserAccessLoggingSettings(
+    input: AssociateUserAccessLoggingSettingsRequest,
+  ): Effect.Effect<
+    AssociateUserAccessLoggingSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  associateUserSettings(
+    input: AssociateUserSettingsRequest,
+  ): Effect.Effect<
+    AssociateUserSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createBrowserSettings(
+    input: CreateBrowserSettingsRequest,
+  ): Effect.Effect<
+    CreateBrowserSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createDataProtectionSettings(
+    input: CreateDataProtectionSettingsRequest,
+  ): Effect.Effect<
+    CreateDataProtectionSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createIdentityProvider(
+    input: CreateIdentityProviderRequest,
+  ): Effect.Effect<
+    CreateIdentityProviderResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createIpAccessSettings(
+    input: CreateIpAccessSettingsRequest,
+  ): Effect.Effect<
+    CreateIpAccessSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createNetworkSettings(
+    input: CreateNetworkSettingsRequest,
+  ): Effect.Effect<
+    CreateNetworkSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createPortal(
+    input: CreatePortalRequest,
+  ): Effect.Effect<
+    CreatePortalResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createSessionLogger(
+    input: CreateSessionLoggerRequest,
+  ): Effect.Effect<
+    CreateSessionLoggerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createTrustStore(
+    input: CreateTrustStoreRequest,
+  ): Effect.Effect<
+    CreateTrustStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createUserAccessLoggingSettings(
+    input: CreateUserAccessLoggingSettingsRequest,
+  ): Effect.Effect<
+    CreateUserAccessLoggingSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  createUserSettings(
+    input: CreateUserSettingsRequest,
+  ): Effect.Effect<
+    CreateUserSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteBrowserSettings(
+    input: DeleteBrowserSettingsRequest,
+  ): Effect.Effect<
+    DeleteBrowserSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteDataProtectionSettings(
+    input: DeleteDataProtectionSettingsRequest,
+  ): Effect.Effect<
+    DeleteDataProtectionSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteIdentityProvider(
+    input: DeleteIdentityProviderRequest,
+  ): Effect.Effect<
+    DeleteIdentityProviderResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteIpAccessSettings(
+    input: DeleteIpAccessSettingsRequest,
+  ): Effect.Effect<
+    DeleteIpAccessSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteNetworkSettings(
+    input: DeleteNetworkSettingsRequest,
+  ): Effect.Effect<
+    DeleteNetworkSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deletePortal(
+    input: DeletePortalRequest,
+  ): Effect.Effect<
+    DeletePortalResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteSessionLogger(
+    input: DeleteSessionLoggerRequest,
+  ): Effect.Effect<
+    DeleteSessionLoggerResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteTrustStore(
+    input: DeleteTrustStoreRequest,
+  ): Effect.Effect<
+    DeleteTrustStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteUserAccessLoggingSettings(
+    input: DeleteUserAccessLoggingSettingsRequest,
+  ): Effect.Effect<
+    DeleteUserAccessLoggingSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  deleteUserSettings(
+    input: DeleteUserSettingsRequest,
+  ): Effect.Effect<
+    DeleteUserSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateBrowserSettings(
+    input: DisassociateBrowserSettingsRequest,
+  ): Effect.Effect<
+    DisassociateBrowserSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateDataProtectionSettings(
+    input: DisassociateDataProtectionSettingsRequest,
+  ): Effect.Effect<
+    DisassociateDataProtectionSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateIpAccessSettings(
+    input: DisassociateIpAccessSettingsRequest,
+  ): Effect.Effect<
+    DisassociateIpAccessSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateNetworkSettings(
+    input: DisassociateNetworkSettingsRequest,
+  ): Effect.Effect<
+    DisassociateNetworkSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateSessionLogger(
+    input: DisassociateSessionLoggerRequest,
+  ): Effect.Effect<
+    DisassociateSessionLoggerResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateTrustStore(
+    input: DisassociateTrustStoreRequest,
+  ): Effect.Effect<
+    DisassociateTrustStoreResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateUserAccessLoggingSettings(
+    input: DisassociateUserAccessLoggingSettingsRequest,
+  ): Effect.Effect<
+    DisassociateUserAccessLoggingSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  disassociateUserSettings(
+    input: DisassociateUserSettingsRequest,
+  ): Effect.Effect<
+    DisassociateUserSettingsResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getBrowserSettings(
+    input: GetBrowserSettingsRequest,
+  ): Effect.Effect<
+    GetBrowserSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getDataProtectionSettings(
+    input: GetDataProtectionSettingsRequest,
+  ): Effect.Effect<
+    GetDataProtectionSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getIdentityProvider(
+    input: GetIdentityProviderRequest,
+  ): Effect.Effect<
+    GetIdentityProviderResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getIpAccessSettings(
+    input: GetIpAccessSettingsRequest,
+  ): Effect.Effect<
+    GetIpAccessSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getNetworkSettings(
+    input: GetNetworkSettingsRequest,
+  ): Effect.Effect<
+    GetNetworkSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getPortal(
+    input: GetPortalRequest,
+  ): Effect.Effect<
+    GetPortalResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getPortalServiceProviderMetadata(
+    input: GetPortalServiceProviderMetadataRequest,
+  ): Effect.Effect<
+    GetPortalServiceProviderMetadataResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getSessionLogger(
+    input: GetSessionLoggerRequest,
+  ): Effect.Effect<
+    GetSessionLoggerResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTrustStore(
+    input: GetTrustStoreRequest,
+  ): Effect.Effect<
+    GetTrustStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getTrustStoreCertificate(
+    input: GetTrustStoreCertificateRequest,
+  ): Effect.Effect<
+    GetTrustStoreCertificateResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getUserAccessLoggingSettings(
+    input: GetUserAccessLoggingSettingsRequest,
+  ): Effect.Effect<
+    GetUserAccessLoggingSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  getUserSettings(
+    input: GetUserSettingsRequest,
+  ): Effect.Effect<
+    GetUserSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listBrowserSettings(
+    input: ListBrowserSettingsRequest,
+  ): Effect.Effect<
+    ListBrowserSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listDataProtectionSettings(
+    input: ListDataProtectionSettingsRequest,
+  ): Effect.Effect<
+    ListDataProtectionSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIdentityProviders(
+    input: ListIdentityProvidersRequest,
+  ): Effect.Effect<
+    ListIdentityProvidersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listIpAccessSettings(
+    input: ListIpAccessSettingsRequest,
+  ): Effect.Effect<
+    ListIpAccessSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listNetworkSettings(
+    input: ListNetworkSettingsRequest,
+  ): Effect.Effect<
+    ListNetworkSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listPortals(
+    input: ListPortalsRequest,
+  ): Effect.Effect<
+    ListPortalsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listSessionLoggers(
+    input: ListSessionLoggersRequest,
+  ): Effect.Effect<
+    ListSessionLoggersResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTrustStoreCertificates(
+    input: ListTrustStoreCertificatesRequest,
+  ): Effect.Effect<
+    ListTrustStoreCertificatesResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listTrustStores(
+    input: ListTrustStoresRequest,
+  ): Effect.Effect<
+    ListTrustStoresResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listUserAccessLoggingSettings(
+    input: ListUserAccessLoggingSettingsRequest,
+  ): Effect.Effect<
+    ListUserAccessLoggingSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  listUserSettings(
+    input: ListUserSettingsRequest,
+  ): Effect.Effect<
+    ListUserSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateBrowserSettings(
+    input: UpdateBrowserSettingsRequest,
+  ): Effect.Effect<
+    UpdateBrowserSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateDataProtectionSettings(
+    input: UpdateDataProtectionSettingsRequest,
+  ): Effect.Effect<
+    UpdateDataProtectionSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateIdentityProvider(
+    input: UpdateIdentityProviderRequest,
+  ): Effect.Effect<
+    UpdateIdentityProviderResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateIpAccessSettings(
+    input: UpdateIpAccessSettingsRequest,
+  ): Effect.Effect<
+    UpdateIpAccessSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateNetworkSettings(
+    input: UpdateNetworkSettingsRequest,
+  ): Effect.Effect<
+    UpdateNetworkSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updatePortal(
+    input: UpdatePortalRequest,
+  ): Effect.Effect<
+    UpdatePortalResponse,
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateSessionLogger(
+    input: UpdateSessionLoggerRequest,
+  ): Effect.Effect<
+    UpdateSessionLoggerResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateTrustStore(
+    input: UpdateTrustStoreRequest,
+  ): Effect.Effect<
+    UpdateTrustStoreResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateUserAccessLoggingSettings(
+    input: UpdateUserAccessLoggingSettingsRequest,
+  ): Effect.Effect<
+    UpdateUserAccessLoggingSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
+  updateUserSettings(
+    input: UpdateUserSettingsRequest,
+  ): Effect.Effect<
+    UpdateUserSettingsResponse,
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError
+  >;
 }
 
 export declare class WorkspacesWeb extends WorkSpacesWeb {}
@@ -1209,6 +1990,856 @@ export declare namespace TagResource {
 export declare namespace UntagResource {
   export type Input = UntagResourceRequest;
   export type Output = UntagResourceResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateBrowserSettings {
+  export type Input = AssociateBrowserSettingsRequest;
+  export type Output = AssociateBrowserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateDataProtectionSettings {
+  export type Input = AssociateDataProtectionSettingsRequest;
+  export type Output = AssociateDataProtectionSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateIpAccessSettings {
+  export type Input = AssociateIpAccessSettingsRequest;
+  export type Output = AssociateIpAccessSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateNetworkSettings {
+  export type Input = AssociateNetworkSettingsRequest;
+  export type Output = AssociateNetworkSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateSessionLogger {
+  export type Input = AssociateSessionLoggerRequest;
+  export type Output = AssociateSessionLoggerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateTrustStore {
+  export type Input = AssociateTrustStoreRequest;
+  export type Output = AssociateTrustStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateUserAccessLoggingSettings {
+  export type Input = AssociateUserAccessLoggingSettingsRequest;
+  export type Output = AssociateUserAccessLoggingSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace AssociateUserSettings {
+  export type Input = AssociateUserSettingsRequest;
+  export type Output = AssociateUserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateBrowserSettings {
+  export type Input = CreateBrowserSettingsRequest;
+  export type Output = CreateBrowserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateDataProtectionSettings {
+  export type Input = CreateDataProtectionSettingsRequest;
+  export type Output = CreateDataProtectionSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateIdentityProvider {
+  export type Input = CreateIdentityProviderRequest;
+  export type Output = CreateIdentityProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateIpAccessSettings {
+  export type Input = CreateIpAccessSettingsRequest;
+  export type Output = CreateIpAccessSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateNetworkSettings {
+  export type Input = CreateNetworkSettingsRequest;
+  export type Output = CreateNetworkSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreatePortal {
+  export type Input = CreatePortalRequest;
+  export type Output = CreatePortalResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateSessionLogger {
+  export type Input = CreateSessionLoggerRequest;
+  export type Output = CreateSessionLoggerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateTrustStore {
+  export type Input = CreateTrustStoreRequest;
+  export type Output = CreateTrustStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateUserAccessLoggingSettings {
+  export type Input = CreateUserAccessLoggingSettingsRequest;
+  export type Output = CreateUserAccessLoggingSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace CreateUserSettings {
+  export type Input = CreateUserSettingsRequest;
+  export type Output = CreateUserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteBrowserSettings {
+  export type Input = DeleteBrowserSettingsRequest;
+  export type Output = DeleteBrowserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteDataProtectionSettings {
+  export type Input = DeleteDataProtectionSettingsRequest;
+  export type Output = DeleteDataProtectionSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIdentityProvider {
+  export type Input = DeleteIdentityProviderRequest;
+  export type Output = DeleteIdentityProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteIpAccessSettings {
+  export type Input = DeleteIpAccessSettingsRequest;
+  export type Output = DeleteIpAccessSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteNetworkSettings {
+  export type Input = DeleteNetworkSettingsRequest;
+  export type Output = DeleteNetworkSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeletePortal {
+  export type Input = DeletePortalRequest;
+  export type Output = DeletePortalResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteSessionLogger {
+  export type Input = DeleteSessionLoggerRequest;
+  export type Output = DeleteSessionLoggerResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteTrustStore {
+  export type Input = DeleteTrustStoreRequest;
+  export type Output = DeleteTrustStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteUserAccessLoggingSettings {
+  export type Input = DeleteUserAccessLoggingSettingsRequest;
+  export type Output = DeleteUserAccessLoggingSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DeleteUserSettings {
+  export type Input = DeleteUserSettingsRequest;
+  export type Output = DeleteUserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateBrowserSettings {
+  export type Input = DisassociateBrowserSettingsRequest;
+  export type Output = DisassociateBrowserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateDataProtectionSettings {
+  export type Input = DisassociateDataProtectionSettingsRequest;
+  export type Output = DisassociateDataProtectionSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateIpAccessSettings {
+  export type Input = DisassociateIpAccessSettingsRequest;
+  export type Output = DisassociateIpAccessSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateNetworkSettings {
+  export type Input = DisassociateNetworkSettingsRequest;
+  export type Output = DisassociateNetworkSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateSessionLogger {
+  export type Input = DisassociateSessionLoggerRequest;
+  export type Output = DisassociateSessionLoggerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateTrustStore {
+  export type Input = DisassociateTrustStoreRequest;
+  export type Output = DisassociateTrustStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateUserAccessLoggingSettings {
+  export type Input = DisassociateUserAccessLoggingSettingsRequest;
+  export type Output = DisassociateUserAccessLoggingSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace DisassociateUserSettings {
+  export type Input = DisassociateUserSettingsRequest;
+  export type Output = DisassociateUserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetBrowserSettings {
+  export type Input = GetBrowserSettingsRequest;
+  export type Output = GetBrowserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetDataProtectionSettings {
+  export type Input = GetDataProtectionSettingsRequest;
+  export type Output = GetDataProtectionSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetIdentityProvider {
+  export type Input = GetIdentityProviderRequest;
+  export type Output = GetIdentityProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetIpAccessSettings {
+  export type Input = GetIpAccessSettingsRequest;
+  export type Output = GetIpAccessSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetNetworkSettings {
+  export type Input = GetNetworkSettingsRequest;
+  export type Output = GetNetworkSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetPortal {
+  export type Input = GetPortalRequest;
+  export type Output = GetPortalResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetPortalServiceProviderMetadata {
+  export type Input = GetPortalServiceProviderMetadataRequest;
+  export type Output = GetPortalServiceProviderMetadataResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetSessionLogger {
+  export type Input = GetSessionLoggerRequest;
+  export type Output = GetSessionLoggerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTrustStore {
+  export type Input = GetTrustStoreRequest;
+  export type Output = GetTrustStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetTrustStoreCertificate {
+  export type Input = GetTrustStoreCertificateRequest;
+  export type Output = GetTrustStoreCertificateResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetUserAccessLoggingSettings {
+  export type Input = GetUserAccessLoggingSettingsRequest;
+  export type Output = GetUserAccessLoggingSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace GetUserSettings {
+  export type Input = GetUserSettingsRequest;
+  export type Output = GetUserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListBrowserSettings {
+  export type Input = ListBrowserSettingsRequest;
+  export type Output = ListBrowserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListDataProtectionSettings {
+  export type Input = ListDataProtectionSettingsRequest;
+  export type Output = ListDataProtectionSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIdentityProviders {
+  export type Input = ListIdentityProvidersRequest;
+  export type Output = ListIdentityProvidersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListIpAccessSettings {
+  export type Input = ListIpAccessSettingsRequest;
+  export type Output = ListIpAccessSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListNetworkSettings {
+  export type Input = ListNetworkSettingsRequest;
+  export type Output = ListNetworkSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListPortals {
+  export type Input = ListPortalsRequest;
+  export type Output = ListPortalsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListSessionLoggers {
+  export type Input = ListSessionLoggersRequest;
+  export type Output = ListSessionLoggersResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTrustStoreCertificates {
+  export type Input = ListTrustStoreCertificatesRequest;
+  export type Output = ListTrustStoreCertificatesResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListTrustStores {
+  export type Input = ListTrustStoresRequest;
+  export type Output = ListTrustStoresResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListUserAccessLoggingSettings {
+  export type Input = ListUserAccessLoggingSettingsRequest;
+  export type Output = ListUserAccessLoggingSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace ListUserSettings {
+  export type Input = ListUserSettingsRequest;
+  export type Output = ListUserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateBrowserSettings {
+  export type Input = UpdateBrowserSettingsRequest;
+  export type Output = UpdateBrowserSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateDataProtectionSettings {
+  export type Input = UpdateDataProtectionSettingsRequest;
+  export type Output = UpdateDataProtectionSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateIdentityProvider {
+  export type Input = UpdateIdentityProviderRequest;
+  export type Output = UpdateIdentityProviderResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateIpAccessSettings {
+  export type Input = UpdateIpAccessSettingsRequest;
+  export type Output = UpdateIpAccessSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateNetworkSettings {
+  export type Input = UpdateNetworkSettingsRequest;
+  export type Output = UpdateNetworkSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdatePortal {
+  export type Input = UpdatePortalRequest;
+  export type Output = UpdatePortalResponse;
+  export type Error =
+    | AccessDeniedException
+    | ConflictException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateSessionLogger {
+  export type Input = UpdateSessionLoggerRequest;
+  export type Output = UpdateSessionLoggerResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateTrustStore {
+  export type Input = UpdateTrustStoreRequest;
+  export type Output = UpdateTrustStoreResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ServiceQuotaExceededException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateUserAccessLoggingSettings {
+  export type Input = UpdateUserAccessLoggingSettingsRequest;
+  export type Output = UpdateUserAccessLoggingSettingsResponse;
+  export type Error =
+    | AccessDeniedException
+    | InternalServerException
+    | ResourceNotFoundException
+    | ThrottlingException
+    | ValidationException
+    | CommonAwsError;
+}
+
+export declare namespace UpdateUserSettings {
+  export type Input = UpdateUserSettingsRequest;
+  export type Output = UpdateUserSettingsResponse;
   export type Error =
     | AccessDeniedException
     | InternalServerException


### PR DESCRIPTION
Operations can be defined in 2 locations in the Smithy spec. It shouldn't be an either or -- operations are defined in both locations even for the same service. This fixes the generation script.

