### PR TITLE
feat(cloudflare): add jwtToken property to createAssetUpload

### DIFF
--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -18,6 +18,7 @@ import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Console, Effect, FileSystem } from "effect";
 import * as path from "node:path";
 import {
+  type ParamInfo,
   type ParsedOperation,
   type ServiceInfo,
   type TypeInfo,
@@ -45,6 +46,25 @@ function withTsExtension(specifier: string): string {
   }
   return `${specifier}.ts`;
 }
+
+const isCreateAssetUploadOperation = (op: ParsedOperation): boolean =>
+  op.operationName === "createAssetUpload" &&
+  op.urlTemplate === "/accounts/{account_id}/workers/assets/upload";
+
+const getSyntheticHeaderParams = (op: ParsedOperation): ParamInfo[] =>
+  isCreateAssetUploadOperation(op)
+    ? [
+        {
+          name: "jwtToken",
+          type: { kind: "primitive", value: "string" },
+          location: "header",
+          required: false,
+          description:
+            "Upload session JWT returned by createScriptAssetUpload. This SDK sends it as an Authorization bearer token for this request.",
+          headerName: "Authorization",
+        },
+      ]
+    : [];
 
 /**
  * Patch file structure (mirrors src/expr.ts OperationPatch).
@@ -925,11 +945,14 @@ function generateOperationSchema(
     }
   }
 
+  const syntheticHeaderParams = getSyntheticHeaderParams(op);
+
   // Collect property names from path/query/header params to avoid duplicates with body params
   const nonBodyParamNames = new Set([
     ...op.pathParams.map((p) => toCamelCase(p.name)),
     ...op.queryParams.map((p) => toCamelCase(p.name)),
     ...op.headerParams.map((p) => toCamelCase(p.name)),
+    ...syntheticHeaderParams.map((p) => toCamelCase(p.name)),
   ]);
 
   // Filter body params to exclude those that conflict with path/query/header params
@@ -942,6 +965,7 @@ function generateOperationSchema(
     ...op.pathParams,
     ...op.queryParams,
     ...op.headerParams,
+    ...syntheticHeaderParams,
     ...filteredBodyParams,
   ].map((param) => ({
     ...param,
@@ -957,10 +981,12 @@ function generateOperationSchema(
     ...p,
     type: resolveTypeInfoDeep(p.type, op.registry),
   }));
-  const resolvedHeaderParams = op.headerParams.map((p) => ({
-    ...p,
-    type: resolveTypeInfoDeep(p.type, op.registry),
-  }));
+  const resolvedHeaderParams = [...op.headerParams, ...syntheticHeaderParams].map(
+    (p) => ({
+      ...p,
+      type: resolveTypeInfoDeep(p.type, op.registry),
+    }),
+  );
   const resolvedBodyParams = filteredBodyParams.map((p) => ({
     ...p,
     type: resolveTypeInfoDeep(p.type, op.registry),

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -21,7 +21,7 @@ import {
   paginateWithDefaults,
   type PaginationStrategy,
 } from "@distilled.cloud/core/pagination";
-import { getPath } from "@distilled.cloud/core/traits";
+import { getPath, type RequestParts } from "@distilled.cloud/core/traits";
 import {
   CloudflareHttpError,
   HTTP_STATUS_MAP,
@@ -315,12 +315,41 @@ class CloudflareDecodeError extends CloudflareHttpError {
   }
 }
 
+const ASSET_UPLOAD_PATH = "/accounts/{account_id}/workers/assets/upload";
+
+export const transformCloudflareRequestParts = ({
+  pathTemplate,
+  parts,
+}: {
+  pathTemplate: string;
+  parts: RequestParts;
+}): RequestParts => {
+  if (pathTemplate !== ASSET_UPLOAD_PATH) {
+    return parts;
+  }
+
+  const authorization = parts.headers.Authorization;
+  if (!authorization || authorization.startsWith("Bearer ")) {
+    return parts;
+  }
+
+  return {
+    ...parts,
+    headers: {
+      ...parts.headers,
+      Authorization: `Bearer ${authorization}`,
+    },
+  };
+};
+
 const _API = makeAPI({
   credentials: Credentials as any,
   getBaseUrl: (creds: any) => creds.apiBaseUrl,
   getAuthHeaders: formatHeaders,
   matchError,
   ParseError: CloudflareDecodeError as any,
+  transformRequestParts: ({ pathTemplate, parts }) =>
+    transformCloudflareRequestParts({ pathTemplate, parts }),
 });
 
 const paginatePageByItems: PaginationStrategy = (

--- a/packages/cloudflare/src/errors.ts
+++ b/packages/cloudflare/src/errors.ts
@@ -18,7 +18,7 @@ export {
   DEFAULT_ERRORS,
   API_ERRORS,
 } from "@distilled.cloud/core/errors";
-export type { DefaultErrors } from "@distilled.cloud/core/errors";
+import type { DefaultErrors as CoreDefaultErrors } from "@distilled.cloud/core/errors";
 
 import * as Schema from "effect/Schema";
 import * as Category from "@distilled.cloud/core/category";
@@ -55,3 +55,19 @@ export class CloudflareHttpError extends Schema.TaggedErrorClass<CloudflareHttpE
     body: Schema.optional(Schema.String),
   },
 ) {}
+
+/**
+ * Errors that any Cloudflare operation may surface in addition to status/code-
+ * matched API errors declared per endpoint.
+ */
+export type ClientErrors =
+  | CloudflareHttpError
+  | CloudflareParseError
+  | UnknownCloudflareError;
+
+/**
+ * Default Cloudflare operation errors include the shared HTTP status errors from
+ * core plus the client-level fallback/decode errors that the Cloudflare client
+ * can emit at runtime.
+ */
+export type DefaultErrors = CoreDefaultErrors | ClientErrors;

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -201,6 +201,8 @@ export interface CreateAssetUploadRequest {
   accountId: string;
   /** Query param: Whether the file contents are base64-encoded. Must be `true`. */
   base64: true;
+  /** Upload session JWT returned by createScriptAssetUpload. This SDK sends it as an Authorization bearer token for this request. */
+  jwtToken?: string;
   /** Body param: */
   body: Record<string, unknown>;
 }
@@ -209,6 +211,9 @@ export const CreateAssetUploadRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
     base64: Schema.Literal(true).pipe(T.HttpQuery("base64")),
+    jwtToken: Schema.optional(Schema.String).pipe(
+      T.HttpHeader("Authorization"),
+    ),
     body: Schema.Struct({}).pipe(T.HttpBody()),
   }).pipe(
     T.Http({

--- a/packages/cloudflare/test/abuse-reports.test.ts
+++ b/packages/cloudflare/test/abuse-reports.test.ts
@@ -21,9 +21,9 @@ describe("AbuseReports", () => {
         });
 
         expect(result).toBeDefined();
-        // reports is null when no reports exist, or an array of report objects
-        if (result.reports !== null) {
-          expect(Array.isArray(result.reports)).toBe(true);
+        // items is null/undefined when no reports exist.
+        if (result.result.items != null) {
+          expect(Array.isArray(result.result.items)).toBe(true);
         }
       }));
 

--- a/packages/cloudflare/test/aisearch.test.ts
+++ b/packages/cloudflare/test/aisearch.test.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import { test, getAccountId, testRunId } from "./test.ts";
-import { formatHeaders, resolveFromEnv } from "~/credentials.ts";
+import { formatHeaders, resolveFromEnv } from "~/credentials";
 import * as AISearch from "~/services/aisearch";
 import * as R2 from "~/services/r2";
 
@@ -72,7 +72,7 @@ const cleanupTokenByName = (tokenName: string) =>
       accountId: accountId(),
     });
 
-    for (const token of tokens) {
+    for (const token of tokens.result) {
       if (token.name === tokenName) {
         yield* AISearch.deleteToken({
           accountId: accountId(),

--- a/packages/cloudflare/test/alerting.test.ts
+++ b/packages/cloudflare/test/alerting.test.ts
@@ -396,11 +396,11 @@ describe("Alerting", () => {
             ],
           }).pipe(
             Effect.map(() => "ok" as const),
-            Effect.catchTag("CloudflareHttpError", (e) => {
-              // 200 with null result is actually success
-              if (e.status === 200) return Effect.succeed("ok" as const);
-              return Effect.fail(e);
-            }),
+            Effect.catchTag("CloudflareHttpError", (e) =>
+              e.status === 200
+                ? Effect.succeed("ok" as const)
+                : Effect.fail(e),
+            ),
           );
 
           expect(result).toBe("ok");

--- a/packages/cloudflare/test/api-gateway.test.ts
+++ b/packages/cloudflare/test/api-gateway.test.ts
@@ -283,10 +283,9 @@ describe("ApiGateway", () => {
           zoneId: zoneId(),
         }).pipe(
           Effect.map(() => "ok" as const),
-          Effect.catchTag("CloudflareHttpError", (e) => {
-            if (e.status === 200) return Effect.succeed("ok" as const);
-            return Effect.fail(e);
-          }),
+          Effect.catchTag("CloudflareHttpError", (e) =>
+            e.status === 200 ? Effect.succeed("ok" as const) : Effect.fail(e),
+          ),
         );
 
         expect(result).toBe("ok");

--- a/packages/cloudflare/test/client-api.test.ts
+++ b/packages/cloudflare/test/client-api.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildRequestParts, getHttpTrait } from "@distilled.cloud/core/traits";
+import { transformCloudflareRequestParts } from "~/client/api";
+import { CreateAssetUploadRequest } from "~/services/workers";
+
+describe("client api", () => {
+  it("maps createAssetUpload jwtToken to a bearer authorization header", () => {
+    const httpTrait = getHttpTrait(CreateAssetUploadRequest.ast);
+    expect(httpTrait).toBeDefined();
+
+    const parts = buildRequestParts(
+      CreateAssetUploadRequest.ast,
+      httpTrait!,
+      {
+        accountId: "account-123",
+        base64: true,
+        jwtToken: "upload-session-jwt",
+        body: { asset: "ZGF0YQ==" },
+      },
+      CreateAssetUploadRequest,
+    );
+
+    expect(parts.headers).toEqual({
+      Authorization: "upload-session-jwt",
+    });
+    expect(parts.body).toEqual({ asset: "ZGF0YQ==" });
+
+    const transformed = transformCloudflareRequestParts({
+      pathTemplate: httpTrait!.path,
+      parts,
+    });
+
+    expect(transformed.headers).toEqual({
+      Authorization: "Bearer upload-session-jwt",
+    });
+    expect(transformed.body).toEqual({ asset: "ZGF0YQ==" });
+  });
+
+  it("does not double-prefix an existing bearer header", () => {
+    const transformed = transformCloudflareRequestParts({
+      pathTemplate: "/accounts/{account_id}/workers/assets/upload",
+      parts: {
+        path: "/accounts/account-123/workers/assets/upload",
+        query: {},
+        headers: { Authorization: "Bearer upload-session-jwt" },
+        body: undefined,
+        isMultipart: true,
+      },
+    });
+
+    expect(transformed.headers).toEqual({
+      Authorization: "Bearer upload-session-jwt",
+    });
+  });
+});

--- a/packages/cloudflare/test/durable-objects.test.ts
+++ b/packages/cloudflare/test/durable-objects.test.ts
@@ -21,10 +21,10 @@ describe("DurableObjects", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
 
         // If there are namespaces, verify shape of each entry
-        for (const ns of result) {
+        for (const ns of result.result) {
           if (ns.id !== undefined) {
             expect(typeof ns.id).toBe("string");
           }
@@ -49,9 +49,9 @@ describe("DurableObjects", () => {
           accountId: accountId(),
         });
 
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
         // Length should be >= 0 (could be empty if no DO namespaces exist)
-        expect(result.length).toBeGreaterThanOrEqual(0);
+        expect(result.result.length).toBeGreaterThanOrEqual(0);
       }));
 
     test("error - InvalidIdentifier for invalid accountId", () =>
@@ -94,9 +94,11 @@ describe("DurableObjects", () => {
     test("happy path - lists objects in an existing namespace", () =>
       Effect.gen(function* () {
         // First, get the list of namespaces to find a valid one
-        const namespaces = yield* DurableObjects.listNamespaces({
-          accountId: accountId(),
-        });
+        const namespaces = (
+          yield* DurableObjects.listNamespaces({
+            accountId: accountId(),
+          })
+        ).result;
 
         // Skip if no namespaces exist (can't test without a DO namespace)
         if (namespaces.length === 0 || !namespaces[0].id) {
@@ -110,10 +112,10 @@ describe("DurableObjects", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
 
         // If there are objects, verify shape
-        for (const obj of result) {
+        for (const obj of result.result) {
           if (obj.id !== undefined) {
             expect(typeof obj.id).toBe("string");
           }
@@ -125,9 +127,11 @@ describe("DurableObjects", () => {
 
     test("error - MalformedParameter for limit that is too low", () =>
       Effect.gen(function* () {
-        const namespaces = yield* DurableObjects.listNamespaces({
-          accountId: accountId(),
-        });
+        const namespaces = (
+          yield* DurableObjects.listNamespaces({
+            accountId: accountId(),
+          })
+        ).result;
 
         if (namespaces.length === 0 || !namespaces[0].id) {
           return;
@@ -224,9 +228,11 @@ describe("DurableObjects", () => {
 
     test("error - MalformedParameter for limit of 0", () =>
       Effect.gen(function* () {
-        const namespaces = yield* DurableObjects.listNamespaces({
-          accountId: accountId(),
-        });
+        const namespaces = (
+          yield* DurableObjects.listNamespaces({
+            accountId: accountId(),
+          })
+        ).result;
 
         if (namespaces.length === 0 || !namespaces[0].id) {
           return;

--- a/packages/cloudflare/test/iam.test.ts
+++ b/packages/cloudflare/test/iam.test.ts
@@ -2,7 +2,6 @@ import { describe, expect } from "vitest";
 import * as Effect from "effect/Effect";
 import { test, getAccountId, testRunId } from "./test.ts";
 import * as IAM from "~/services/iam";
-import { InvalidMember } from "~/services/iam.ts";
 
 const accountId = () => getAccountId();
 
@@ -70,10 +69,10 @@ const withUserGroup = <A, E, R>(
     const groups = yield* IAM.listPermissionGroups({
       accountId: accountId(),
     });
-    if (groups.length === 0) {
+    if (groups.result.length === 0) {
       throw new Error("No permission groups available for testing");
     }
-    const permGroupId = groups[0].id;
+    const permGroupId = groups.result[0].id;
 
     // Create a resource group to use in the policy
     const rg = yield* IAM.createResourceGroup({
@@ -132,11 +131,11 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
-        expect(result.length).toBeGreaterThan(0);
+        expect(Array.isArray(result.result)).toBe(true);
+        expect(result.result.length).toBeGreaterThan(0);
 
         // Verify structure of first item
-        const first = result[0];
+        const first = result.result[0];
         expect(first.id).toBeDefined();
         expect(typeof first.id).toBe("string");
       }));
@@ -149,7 +148,7 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
       }));
 
     test("happy path - returns empty array for non-matching name filter", () =>
@@ -160,8 +159,8 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
-        expect(result.length).toBe(0);
+        expect(Array.isArray(result.result)).toBe(true);
+        expect(result.result.length).toBe(0);
       }));
 
     test("error - invalid accountId", () =>
@@ -199,15 +198,15 @@ describe("IAM", () => {
         const groups = yield* IAM.listPermissionGroups({
           accountId: accountId(),
         });
-        expect(groups.length).toBeGreaterThan(0);
+        expect(groups.result.length).toBeGreaterThan(0);
 
         const result = yield* IAM.getPermissionGroup({
           accountId: accountId(),
-          permissionGroupId: groups[0].id,
+          permissionGroupId: groups.result[0].id,
         });
 
         expect(result).toBeDefined();
-        expect(result.id).toBe(groups[0].id);
+        expect(result.id).toBe(groups.result[0].id);
         expect(typeof result.id).toBe("string");
         if (result.name) {
           expect(typeof result.name).toBe("string");
@@ -440,7 +439,7 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
         // Account should have at least a default resource group
       }));
 
@@ -453,9 +452,9 @@ describe("IAM", () => {
           });
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
+          expect(Array.isArray(result.result)).toBe(true);
           // Should find the resource group we just created
-          const found = result.find((rg) => rg.id === resourceGroupId);
+          const found = result.result.find((rg) => rg.id === resourceGroupId);
           expect(found).toBeDefined();
         }),
       ));
@@ -469,14 +468,14 @@ describe("IAM", () => {
       })
         .pipe(
           Effect.catchTag("CloudflareHttpError", () =>
-            Effect.succeed([] as IAM.ListResourceGroupsResponse),
+            Effect.succeed({ result: [] } as IAM.ListResourceGroupsResponse),
           ),
         )
         .pipe(
           Effect.map((result) => {
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBe(0);
+            expect(Array.isArray(result.result)).toBe(true);
+            expect(result.result.length).toBe(0);
           }),
         ));
 
@@ -675,11 +674,11 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
 
         // Verify structure of items if any exist
-        if (result.length > 0) {
-          const first = result[0];
+        if (result.result.length > 0) {
+          const first = result.result[0];
           if (first.id) {
             expect(typeof first.id).toBe("string");
           }
@@ -728,20 +727,20 @@ describe("IAM", () => {
         });
 
         // Only run the happy path if there's an existing SSO connector
-        if (ssos.length > 0 && ssos[0].id) {
+        if (ssos.result.length > 0 && ssos.result[0].id) {
           const result = yield* IAM.getSso({
             accountId: accountId(),
-            ssoConnectorId: ssos[0].id,
+            ssoConnectorId: ssos.result[0].id,
           });
 
           expect(result).toBeDefined();
           if (result.id) {
-            expect(result.id).toBe(ssos[0].id);
+            expect(result.id).toBe(ssos.result[0].id);
           }
         } else {
           // If no SSO connectors exist, just verify listSsos works
           expect(ssos).toBeDefined();
-          expect(Array.isArray(ssos)).toBe(true);
+          expect(Array.isArray(ssos.result)).toBe(true);
         }
       }));
 
@@ -1047,11 +1046,11 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
 
         // Verify structure of items if any exist
-        if (result.length > 0) {
-          const first = result[0];
+        if (result.result.length > 0) {
+          const first = result.result[0];
           expect(first.id).toBeDefined();
           expect(typeof first.id).toBe("string");
           expect(first.name).toBeDefined();
@@ -1071,7 +1070,7 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
       }));
 
     test("happy path - filters by direction", () =>
@@ -1082,7 +1081,7 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
       }));
 
     test("happy path - fuzzy name search", () =>
@@ -1093,7 +1092,7 @@ describe("IAM", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
       }));
 
     test("error - invalid accountId", () =>
@@ -1130,7 +1129,7 @@ describe("IAM", () => {
         const groups = yield* IAM.listPermissionGroups({
           accountId: accountId(),
         });
-        const permGroupId = groups[0].id;
+        const permGroupId = groups.result[0].id;
 
         const rg = yield* IAM.createResourceGroup({
           accountId: accountId(),
@@ -1260,7 +1259,7 @@ describe("IAM", () => {
           accountId: accountId(),
           name,
         });
-        for (const ug of existing) {
+        for (const ug of existing.result) {
           yield* IAM.deleteUserGroup({
             accountId: accountId(),
             userGroupId: ug.id,
@@ -1433,7 +1432,7 @@ describe("IAM", () => {
         const groups = yield* IAM.listPermissionGroups({
           accountId: accountId(),
         });
-        const permGroupId = groups[0].id;
+        const permGroupId = groups.result[0].id;
 
         const rg = yield* IAM.createResourceGroup({
           accountId: accountId(),
@@ -1540,14 +1539,17 @@ describe("IAM", () => {
         })
           .pipe(
             Effect.catchTag("CloudflareHttpError", () =>
-              Effect.succeed([] as IAM.ListUserGroupMembersResponse),
+              Effect.succeed({
+                result: [],
+                resultInfo: {},
+              } as IAM.ListUserGroupMembersResponse),
             ),
           )
           .pipe(
             Effect.map((result) => {
               // Newly created user group has no members — result is empty
-              expect(Array.isArray(result)).toBe(true);
-              expect(result.length).toBe(0);
+              expect(Array.isArray(result.result)).toBe(true);
+              expect(result.result.length).toBe(0);
             }),
           ),
       ));

--- a/packages/cloudflare/test/kv.test.ts
+++ b/packages/cloudflare/test/kv.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "vitest";
 import * as Effect from "effect/Effect";
 import { test, getAccountId, testRunId } from "./test.ts";
-import { Credentials, formatHeaders } from "~/credentials.ts";
+import { Credentials, formatHeaders } from "~/credentials";
 import * as KV from "~/services/kv";
 
 const accountId = () => getAccountId();

--- a/packages/cloudflare/test/test.ts
+++ b/packages/cloudflare/test/test.ts
@@ -11,8 +11,8 @@ import { MinimumLogLevel } from "effect/References";
 import * as Scope from "effect/Scope";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
-import * as Auth from "~/auth.ts";
-import * as Retry from "~/retry.ts";
+import * as Auth from "~/auth";
+import * as Retry from "~/retry";
 
 type Provided =
   | Scope.Scope

--- a/packages/cloudflare/test/workers.test.ts
+++ b/packages/cloudflare/test/workers.test.ts
@@ -1,19 +1,8 @@
+import { createHash } from "node:crypto";
 import { describe, expect } from "vitest";
 import * as Effect from "effect/Effect";
 import { test, getAccountId, getZoneId, testRunId } from "./test.ts";
 import * as Workers from "~/services/workers";
-import {
-  ContentTypeRequired,
-  DeploymentNotFound,
-  DomainNotFound,
-  InvalidRoute,
-  InvalidRoutePattern,
-  InvalidWorkerScript,
-  RouteNotFound,
-  SecretNotFound,
-  VersionNotFound,
-  WorkerNotFound,
-} from "~/services/workers.ts";
 
 const accountId = () => getAccountId();
 const zoneId = () => {
@@ -38,6 +27,12 @@ const scriptName = (name: string) => `distilled-cf-workers-${name}-${testRunId}`
  */
 const workerModuleSource = `export default { async fetch(request) { return new Response("Hello from test worker"); } };`;
 
+const assetHash = (content: string, extension: string) =>
+  createHash("sha256")
+    .update(Buffer.from(content).toString("base64") + extension)
+    .digest("hex")
+    .slice(0, 32);
+
 /**
  * Create a worker script via putScript, run `fn`, then delete the script.
  * Cleanup-first pattern for idempotency.
@@ -58,16 +53,6 @@ const withScript = <A, E, R>(
     const scriptBlob = new Blob([workerModuleSource], {
       type: "application/javascript+module",
     });
-    const metadataBlob = new Blob(
-      [
-        JSON.stringify({
-          main_module: "index.mjs",
-          compatibility_date: "2024-01-01",
-        }),
-      ],
-      { type: "application/json" },
-    );
-
     const scriptFile = new File([scriptBlob], "index.mjs", {
       type: "application/javascript+module",
     });
@@ -105,16 +90,17 @@ const withBetaWorker = <A, E, R>(
     // Try to find and delete existing worker with same name
     const existing = yield* Workers.listBetaWorkers({
       accountId: accountId(),
-    }).pipe(Effect.catch(() => Effect.succeed([] as any)));
+    }).pipe(
+      Effect.map((response) => response.result),
+      Effect.catch(() => Effect.succeed([])),
+    );
 
-    if (Array.isArray(existing)) {
-      const found = existing.find((w: any) => w.name === name);
-      if (found) {
-        yield* Workers.deleteBetaWorker({
-          accountId: accountId(),
-          workerId: found.id,
-        }).pipe(Effect.catch(() => Effect.void));
-      }
+    const found = existing.find((w) => w.name === name);
+    if (found) {
+      yield* Workers.deleteBetaWorker({
+        accountId: accountId(),
+        workerId: found.id,
+      }).pipe(Effect.catch(() => Effect.void));
     }
 
     // Create the worker
@@ -202,8 +188,8 @@ describe("Workers", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
-        for (const worker of result) {
+        expect(Array.isArray(result.result)).toBe(true);
+        for (const worker of result.result) {
           expect(typeof worker.id).toBe("string");
           expect(typeof worker.name).toBe("string");
         }
@@ -226,16 +212,17 @@ describe("Workers", () => {
         // Cleanup: find and delete existing worker with same name
         const existing = yield* Workers.listBetaWorkers({
           accountId: accountId(),
-        }).pipe(Effect.catch(() => Effect.succeed([] as any)));
+        }).pipe(
+          Effect.map((response) => response.result),
+          Effect.catch(() => Effect.succeed([])),
+        );
 
-        if (Array.isArray(existing)) {
-          const found = existing.find((w: any) => w.name === name);
-          if (found) {
-            yield* Workers.deleteBetaWorker({
-              accountId: accountId(),
-              workerId: found.id,
-            }).pipe(Effect.catch(() => Effect.void));
-          }
+        const found = existing.find((w) => w.name === name);
+        if (found) {
+          yield* Workers.deleteBetaWorker({
+            accountId: accountId(),
+            workerId: found.id,
+          }).pipe(Effect.catch(() => Effect.void));
         }
 
         const result = yield* Workers.createBetaWorker({
@@ -370,15 +357,16 @@ describe("Workers", () => {
         // Cleanup first
         const existing = yield* Workers.listBetaWorkers({
           accountId: accountId(),
-        }).pipe(Effect.catch(() => Effect.succeed([] as any)));
-        if (Array.isArray(existing)) {
-          const found = existing.find((w: any) => w.name === name);
-          if (found) {
-            yield* Workers.deleteBetaWorker({
-              accountId: accountId(),
-              workerId: found.id,
-            }).pipe(Effect.catch(() => Effect.void));
-          }
+        }).pipe(
+          Effect.map((response) => response.result),
+          Effect.catch(() => Effect.succeed([])),
+        );
+        const found = existing.find((w) => w.name === name);
+        if (found) {
+          yield* Workers.deleteBetaWorker({
+            accountId: accountId(),
+            workerId: found.id,
+          }).pipe(Effect.catch(() => Effect.void));
         }
 
         const worker = yield* Workers.createBetaWorker({
@@ -399,7 +387,7 @@ describe("Workers", () => {
         const afterDelete = yield* Workers.listBetaWorkers({
           accountId: accountId(),
         });
-        const stillExists = afterDelete.find((w: any) => w.id === worker.id);
+        const stillExists = afterDelete.result.find((w) => w.id === worker.id);
         expect(stillExists).toBeUndefined();
       }));
 
@@ -612,8 +600,8 @@ describe("Workers", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
-        for (const item of result) {
+        expect(Array.isArray(result.result)).toBe(true);
+        for (const item of result.result) {
           expect(typeof item.key).toBe("string");
           expect(typeof item.lastSeenAt).toBe("number");
           expect(["string", "boolean", "number"]).toContain(item.type);
@@ -702,8 +690,8 @@ describe("Workers", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
-        for (const route of result) {
+        expect(Array.isArray(result.result)).toBe(true);
+        for (const route of result.result) {
           expect(typeof route.id).toBe("string");
           expect(typeof route.pattern).toBe("string");
         }
@@ -793,8 +781,8 @@ describe("Workers", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
-        for (const script of result) {
+        expect(Array.isArray(result.result)).toBe(true);
+        for (const script of result.result) {
           if (script.id) {
             expect(typeof script.id).toBe("string");
           }
@@ -1203,7 +1191,7 @@ describe("Workers", () => {
                 { percentage: 100, versionId: currentVersionId },
               ],
               annotations: {
-                "workers/message": "Test deployment from distilled tests",
+                workersMessage: "Test deployment from distilled tests",
               },
             });
 
@@ -1718,8 +1706,8 @@ describe("Workers", () => {
           });
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
-          for (const version of result) {
+          expect(Array.isArray(result.result.items)).toBe(true);
+          for (const version of result.result.items ?? []) {
             if (version.id !== undefined) {
               expect(typeof version.id).toBe("string");
             }
@@ -1750,8 +1738,11 @@ describe("Workers", () => {
             scriptName: name,
           });
 
-          if (versions.length > 0 && versions[0].id) {
-            const versionId = versions[0].id;
+          if (
+            (versions.result.items?.length ?? 0) > 0 &&
+            versions.result.items?.[0]?.id
+          ) {
+            const versionId = versions.result.items[0].id;
             const result = yield* Workers.getScriptVersion({
               accountId: accountId(),
               scriptName: name,
@@ -1865,6 +1856,71 @@ describe("Workers", () => {
   // AssetUpload (account-level)
   // ==========================================================================
   describe("createAssetUpload", () => {
+    test("happy path - uploads an asset and redeems the completion jwt", () =>
+      withScript(scriptName("asset-upload-complete"), (name) =>
+        Effect.gen(function* () {
+          const path = "/index.html";
+          const content = `<html><body>distilled asset upload ${testRunId}</body></html>`;
+          const hash = assetHash(content, "html");
+          const manifest = {
+            [path]: {
+              hash,
+              size: content.length,
+            },
+          };
+
+          const session = yield* Workers.createScriptAssetUpload({
+            accountId: accountId(),
+            scriptName: name,
+            manifest,
+          });
+
+          expect(typeof session.jwt).toBe("string");
+          expect(Array.isArray(session.buckets)).toBe(true);
+          expect(session.buckets?.some((bucket) => bucket.includes(hash))).toBe(
+            true,
+          );
+
+          const upload = yield* Workers.createAssetUpload({
+            accountId: accountId(),
+            base64: true,
+            jwtToken: session.jwt!,
+            body: {
+              [hash]: Buffer.from(content).toString("base64"),
+            },
+          });
+
+          expect(typeof upload.jwt).toBe("string");
+
+          const scriptFile = new File(
+            [workerModuleSource],
+            "index.mjs",
+            { type: "application/javascript+module" },
+          );
+
+          const result = yield* Workers.putScript({
+            accountId: accountId(),
+            scriptName: name,
+            metadata: {
+              mainModule: "index.mjs",
+              bindings: [{ name: "ASSETS", type: "assets" }],
+              assets: {
+                jwt: upload.jwt!,
+              },
+            },
+            files: [scriptFile],
+          });
+
+          expect(result).toBeDefined();
+          if (result.id) {
+            expect(typeof result.id).toBe("string");
+          }
+          if (result.hasAssets !== undefined) {
+            expect(result.hasAssets).toBe(true);
+          }
+        }),
+      ));
+
     test("error - InvalidRoute for invalid accountId", () =>
       Workers.createAssetUpload({
         accountId: "invalid-account-id-000",

--- a/packages/cloudflare/test/workflows.test.ts
+++ b/packages/cloudflare/test/workflows.test.ts
@@ -2,15 +2,6 @@ import { describe, expect } from "vitest";
 import * as Effect from "effect/Effect";
 import { test, getAccountId, testRunId } from "./test.ts";
 import * as Workflows from "~/services/workflows";
-import {
-  InstanceCannotTerminate,
-  InstanceNotFound,
-  InvalidBody,
-  InvalidRoute,
-  VersionNotFound,
-  WorkflowInternalError,
-  WorkflowNotFound,
-} from "~/services/workflows.ts";
 import * as Workers from "~/services/workers";
 
 const accountId = () => getAccountId();
@@ -161,10 +152,11 @@ describe("Workflows", () => {
         const result = yield* Workflows.listWorkflows({
           accountId: accountId(),
         });
+        const workflows = result.result;
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
-        for (const wf of result) {
+        expect(Array.isArray(workflows)).toBe(true);
+        for (const wf of workflows) {
           expect(typeof wf.id).toBe("string");
           expect(typeof wf.name).toBe("string");
           expect(typeof wf.className).toBe("string");
@@ -182,7 +174,7 @@ describe("Workflows", () => {
         });
 
         expect(result).toBeDefined();
-        expect(Array.isArray(result)).toBe(true);
+        expect(Array.isArray(result.result)).toBe(true);
       }));
 
     test("happy path - lists workflows includes a created workflow", () =>
@@ -191,10 +183,11 @@ describe("Workflows", () => {
           const result = yield* Workflows.listWorkflows({
             accountId: accountId(),
           });
+          const workflows = result.result;
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
-          const found = result.some((wf) => wf.name === wfName);
+          expect(Array.isArray(workflows)).toBe(true);
+          const found = workflows.some((wf) => wf.name === wfName);
           expect(found).toBe(true);
         }),
       ));
@@ -453,11 +446,12 @@ describe("Workflows", () => {
             accountId: accountId(),
             workflowName: wfName,
           });
+          const versions = result.result;
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
-          expect(result.length).toBeGreaterThan(0);
-          for (const version of result) {
+          expect(Array.isArray(versions)).toBe(true);
+          expect(versions.length).toBeGreaterThan(0);
+          for (const version of versions) {
             expect(typeof version.id).toBe("string");
             expect(typeof version.className).toBe("string");
             expect(typeof version.createdOn).toBe("string");
@@ -498,17 +492,18 @@ describe("Workflows", () => {
             accountId: accountId(),
             workflowName: wfName,
           });
+          const versionItems = versions.result;
 
-          expect(versions.length).toBeGreaterThan(0);
+          expect(versionItems.length).toBeGreaterThan(0);
 
           const result = yield* Workflows.getVersion({
             accountId: accountId(),
             workflowName: wfName,
-            versionId: versions[0].id,
+            versionId: versionItems[0].id,
           });
 
           expect(result).toBeDefined();
-          expect(result.id).toBe(versions[0].id);
+          expect(result.id).toBe(versionItems[0].id);
           expect(typeof result.className).toBe("string");
           expect(typeof result.createdOn).toBe("string");
           expect(typeof result.modifiedOn).toBe("string");
@@ -646,11 +641,12 @@ describe("Workflows", () => {
             accountId: accountId(),
             workflowName: wfName,
           });
+          const instances = result.result;
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
-          expect(result.length).toBeGreaterThan(0);
-          for (const instance of result) {
+          expect(Array.isArray(instances)).toBe(true);
+          expect(instances.length).toBeGreaterThan(0);
+          for (const instance of instances) {
             expect(typeof instance.id).toBe("string");
             expect(typeof instance.createdOn).toBe("string");
             expect(typeof instance.modifiedOn).toBe("string");
@@ -677,7 +673,7 @@ describe("Workflows", () => {
           });
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
+          expect(Array.isArray(result.result)).toBe(true);
         }),
       ));
 
@@ -691,7 +687,7 @@ describe("Workflows", () => {
           });
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
+          expect(Array.isArray(result.result)).toBe(true);
         }),
       ));
 
@@ -704,7 +700,7 @@ describe("Workflows", () => {
           });
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
+          expect(Array.isArray(result.result)).toBe(true);
         }),
       ));
 
@@ -798,11 +794,12 @@ describe("Workflows", () => {
               { params: { key: "value2" } },
             ],
           });
+          const instances = result.result;
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
-          expect(result.length).toBe(2);
-          for (const instance of result) {
+          expect(Array.isArray(instances)).toBe(true);
+          expect(instances.length).toBe(2);
+          for (const instance of instances) {
             expect(typeof instance.id).toBe("string");
             expect(typeof instance.status).toBe("string");
             expect(typeof instance.versionId).toBe("string");
@@ -824,8 +821,8 @@ describe("Workflows", () => {
           });
 
           expect(result).toBeDefined();
-          expect(Array.isArray(result)).toBe(true);
-          expect(result.length).toBe(2);
+          expect(Array.isArray(result.result)).toBe(true);
+          expect(result.result.length).toBe(2);
         }),
       ));
 

--- a/packages/cloudflare/test/yieldable.test.ts
+++ b/packages/cloudflare/test/yieldable.test.ts
@@ -9,10 +9,11 @@ describe("OperationMethod yieldable", () => {
   test("direct call - yield* operation(input) works with services in context", () =>
     Effect.gen(function* () {
       const result = yield* Accounts.listAccounts({});
-      expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0].id).toBeDefined();
-      expect(result[0].name).toBeDefined();
+      const accounts = result.result;
+      expect(Array.isArray(accounts)).toBe(true);
+      expect(accounts.length).toBeGreaterThan(0);
+      expect(accounts[0].id).toBeDefined();
+      expect(accounts[0].name).toBeDefined();
     }));
 
   test("yield first - yield* operation captures services and returns requirement-free function", () =>
@@ -22,9 +23,10 @@ describe("OperationMethod yieldable", () => {
 
       // The returned function has Effect<..., ..., never> — no requirements
       const result = yield* listAccounts({});
-      expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0].id).toBeDefined();
-      expect(result[0].name).toBeDefined();
+      const accounts = result.result;
+      expect(Array.isArray(accounts)).toBe(true);
+      expect(accounts.length).toBeGreaterThan(0);
+      expect(accounts[0].id).toBeDefined();
+      expect(accounts[0].name).toBeDefined();
     }));
 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -140,6 +140,17 @@ export interface ClientConfig<Creds> {
    * For example, Cloudflare wraps responses in `{ result: <data>, ... }`.
    */
   transformResponse?: (body: unknown) => unknown;
+
+  /**
+   * Optional transform applied to encoded request parts before building the
+   * outbound HTTP request.
+   */
+  transformRequestParts?: (input: {
+    input: Record<string, unknown>;
+    method: string;
+    pathTemplate: string;
+    parts: Traits.RequestParts;
+  }) => Traits.RequestParts;
 }
 
 /**
@@ -388,12 +399,21 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           const authHeaders = config.getAuthHeaders(creds as ResolvedCreds);
 
           // Use schema-aware request builder for proper camelCase → wire_name mapping
-          const parts = Traits.buildRequestParts(
+          let parts = Traits.buildRequestParts(
             inputSchema.ast,
             httpTrait,
             input as Record<string, unknown>,
             inputSchema,
           );
+
+          if (config.transformRequestParts) {
+            parts = config.transformRequestParts({
+              input: input as Record<string, unknown>,
+              method,
+              pathTemplate: httpTrait.path,
+              parts,
+            });
+          }
 
           let request = HttpClientRequest.make(method)(
             baseUrl + parts.path,

--- a/www/distilled.cloud/scripts/deploy.ts
+++ b/www/distilled.cloud/scripts/deploy.ts
@@ -8,6 +8,7 @@ import { FetchHttpClient } from "effect/unstable/http";
 import {
   Credentials,
   DEFAULT_API_BASE_URL,
+  fromApiToken,
 } from "@distilled.cloud/cloudflare/Credentials";
 import * as Workers from "@distilled.cloud/cloudflare/workers";
 
@@ -102,14 +103,14 @@ function buildManifest(directory: string): Record<string, ManifestEntry> {
 }
 
 // =============================================================================
-// Asset Upload (using SDK with JWT-based credentials)
+// Asset Upload
 // =============================================================================
 
 /**
  * Upload a bucket of assets using Workers.createAssetUpload.
  *
- * The asset upload endpoint requires a different auth token (the upload JWT)
- * than the regular API token, so we provide a scoped Credentials layer.
+ * The asset upload endpoint requires the upload session JWT from
+ * createScriptAssetUpload, which the SDK maps to the Authorization header.
  */
 function uploadBucket(
   accountId: string,
@@ -120,7 +121,7 @@ function uploadBucket(
 ): Effect.Effect<
   string | undefined,
   Workers.CreateAssetUploadError,
-  HttpClient.HttpClient
+  HttpClient.HttpClient | Credentials
 > {
   // Build the body as Record<hash, File> with correct MIME types
   const body: Record<string, File> = {};
@@ -135,20 +136,13 @@ function uploadBucket(
       type: contentType,
     });
   }
-
-  // The asset upload endpoint uses the upload JWT (not the API token)
-  const uploadCredentials = Layer.succeed(Credentials, {
-    apiToken: uploadJwt,
-    apiBaseUrl: DEFAULT_API_BASE_URL,
-  });
-
   return Workers.createAssetUpload({
     accountId,
     base64: true,
+    jwtToken: uploadJwt,
     body,
   }).pipe(
     Effect.map((res) => res.jwt ?? undefined),
-    Effect.provide(uploadCredentials),
   );
 }
 
@@ -156,7 +150,7 @@ function uploadBucket(
 // Layers
 // =============================================================================
 
-const ApiTokenLayer = Layer.succeed(Credentials, {
+const ApiTokenLayer = fromApiToken({
   apiToken: requireEnv("CLOUDFLARE_API_TOKEN"),
   apiBaseUrl: DEFAULT_API_BASE_URL,
 });
@@ -215,7 +209,7 @@ const deploy = Effect.gen(function* () {
 
   let completionJwt = session.jwt;
 
-  // 4. Upload assets to buckets (using SDK with JWT credentials)
+  // 4. Upload assets to buckets
   const buckets = session.buckets ?? [];
   if (buckets.length === 0) {
     console.log("  No new assets to upload (all cached)");


### PR DESCRIPTION
Usage:
```ts
const session = yield* Workers.createScriptAssetUpload({
  accountId: accountId(),
  scriptName: name,
  manifest,
});

const upload = yield* Workers.createAssetUpload({
  accountId: accountId(),
  base64: true,
  jwtToken: session.jwt!,
  body: {
    [hash]: Buffer.from(content).toString("base64"),
  },
});
```