### PR TITLE
chore: add pagination example and Stream import to package READMEs

### DIFF
--- a/packages/aws/README.md
+++ b/packages/aws/README.md
@@ -12,7 +12,9 @@ npm install @distilled.cloud/aws effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as Lambda from "@distilled.cloud/aws/lambda";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { Credentials, Region } from "@distilled.cloud/aws";
 
@@ -27,6 +29,10 @@ const program = Effect.gen(function* () {
     Bucket: "my-bucket",
     Key: "hello.txt",
   });
+
+  const functions = yield* Lambda.listFunctions
+    .items({})
+    .pipe(Stream.take(10), Stream.runCollect);
 
   return result.ContentType;
 });

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -12,11 +12,19 @@ npm install @distilled.cloud/cloudflare effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as DNS from "@distilled.cloud/cloudflare/dns";
 import * as R2 from "@distilled.cloud/cloudflare/r2";
 import { CredentialsFromEnv } from "@distilled.cloud/cloudflare";
 
-const program = R2.listBuckets({ account_id: "your-account-id" });
+const program = Effect.gen(function* () {
+  yield* R2.listBuckets({ account_id: "your-account-id" });
+
+  const records = yield* DNS.listRecords
+    .items({ zone_id: "your-zone-id" })
+    .pipe(Stream.take(10), Stream.runCollect);
+});
 
 const CloudflareLive = Layer.mergeAll(FetchHttpClient.layer, CredentialsFromEnv);
 

--- a/packages/coinbase/README.md
+++ b/packages/coinbase/README.md
@@ -12,6 +12,7 @@ npm install @distilled.cloud/coinbase effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { listEvmAccounts } from "@distilled.cloud/coinbase/Operations";
 import { CredentialsFromEnv } from "@distilled.cloud/coinbase";

--- a/packages/fly-io/README.md
+++ b/packages/fly-io/README.md
@@ -12,6 +12,7 @@ npm install @distilled.cloud/fly-io effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { AppsList } from "@distilled.cloud/fly-io/Operations";
 import { CredentialsFromEnv } from "@distilled.cloud/fly-io";

--- a/packages/gcp/README.md
+++ b/packages/gcp/README.md
@@ -12,11 +12,16 @@ npm install @distilled.cloud/gcp effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as Storage from "@distilled.cloud/gcp/storage-v1";
 import { CredentialsFromEnv } from "@distilled.cloud/gcp";
 
-const program = Storage.listBuckets({ project: "my-project" });
+const program = Effect.gen(function* () {
+  const buckets = yield* Storage.listBuckets
+    .items({ project: "my-project" })
+    .pipe(Stream.take(10), Stream.runCollect);
+});
 
 const GCPLive = Layer.mergeAll(FetchHttpClient.layer, CredentialsFromEnv);
 

--- a/packages/mongodb-atlas/README.md
+++ b/packages/mongodb-atlas/README.md
@@ -12,6 +12,7 @@ npm install @distilled.cloud/mongodb-atlas effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { listGroupClusters } from "@distilled.cloud/mongodb-atlas/Operations";
 import { CredentialsFromEnv } from "@distilled.cloud/mongodb-atlas";

--- a/packages/neon/README.md
+++ b/packages/neon/README.md
@@ -12,6 +12,7 @@ npm install @distilled.cloud/neon effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { listProjects } from "@distilled.cloud/neon/Operations";
 import { CredentialsFromEnv } from "@distilled.cloud/neon";

--- a/packages/planetscale/README.md
+++ b/packages/planetscale/README.md
@@ -12,6 +12,7 @@ npm install @distilled.cloud/planetscale effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { listDatabases } from "@distilled.cloud/planetscale/Operations";
 import { CredentialsFromEnv, Credentials } from "@distilled.cloud/planetscale";

--- a/packages/prisma-postgres/README.md
+++ b/packages/prisma-postgres/README.md
@@ -12,6 +12,7 @@ npm install @distilled.cloud/prisma-postgres effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { getV1Databases } from "@distilled.cloud/prisma-postgres/Operations";
 import { CredentialsFromEnv } from "@distilled.cloud/prisma-postgres";

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -12,6 +12,7 @@ npm install @distilled.cloud/stripe effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { GetCustomersSearch } from "@distilled.cloud/stripe/Operations";
 import { CredentialsFromEnv } from "@distilled.cloud/stripe";

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -12,6 +12,7 @@ npm install @distilled.cloud/supabase effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { v1ListAllProjects } from "@distilled.cloud/supabase/Operations";
 import { CredentialsFromEnv } from "@distilled.cloud/supabase";

--- a/packages/turso/README.md
+++ b/packages/turso/README.md
@@ -14,6 +14,7 @@ npm install @distilled.cloud/turso effect
 
 ```typescript
 import { Effect, Layer } from "effect";
+import * as Stream from "effect/Stream";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { CredentialsFromEnv } from "@distilled.cloud/turso";
 


### PR DESCRIPTION
## Summary

Fixes #147

- Adds `import * as Stream from "effect/Stream"` to the Quick Start code block in all package READMEs, replicating the import addition from bd7076d
- Adds streaming pagination examples (using `.items()` + `Stream.take`/`Stream.runCollect`) to the **aws**, **cloudflare**, and **gcp** READMEs — the three packages that have paginated operations
- For packages without pagination support (coinbase, fly-io, mongodb-atlas, neon, planetscale, prisma-postgres, stripe, supabase, turso), only the `Stream` import is added for consistency
- Skips `core` README since it's not a user-facing SDK package