### PR TITLE
chore: use --depth=1 for submodule fetches across all packages

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -74,7 +74,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/api-models-aws && git -C specs/api-models-aws checkout -- . && git submodule update --force --init --recursive specs/aws-sdk-js-v3 && git -C specs/aws-sdk-js-v3 checkout -- . && git submodule update --force --init --recursive specs/smithy && git -C specs/smithy checkout -- . && git submodule update --force --init --recursive specs/smithy-typescript && git -C specs/smithy-typescript checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/api-models-aws && git -C specs/api-models-aws checkout -- . && git submodule update --force --init --recursive --depth=1 specs/aws-sdk-js-v3 && git -C specs/aws-sdk-js-v3 checkout -- . && git submodule update --force --init --recursive --depth=1 specs/smithy && git -C specs/smithy checkout -- . && git submodule update --force --init --recursive --depth=1 specs/smithy-typescript && git -C specs/smithy-typescript checkout -- .",
     "specs:update": "git -C specs/api-models-aws fetch && git -C specs/api-models-aws checkout main && git -C specs/api-models-aws pull && git -C specs/aws-sdk-js-v3 fetch && git -C specs/aws-sdk-js-v3 checkout main && git -C specs/aws-sdk-js-v3 pull && git -C specs/smithy fetch && git -C specs/smithy checkout main && git -C specs/smithy pull && git -C specs/smithy-typescript fetch && git -C specs/smithy-typescript checkout main && git -C specs/smithy-typescript pull"
   },
   "dependencies": {

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -59,7 +59,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/cloudflare-typescript && git -C specs/cloudflare-typescript checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/cloudflare-typescript && git -C specs/cloudflare-typescript checkout -- .",
     "specs:update": "git -C specs/cloudflare-typescript fetch && git -C specs/cloudflare-typescript checkout main && git -C specs/cloudflare-typescript pull"
   },
   "dependencies": {

--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/cdp-sdk && git -C specs/cdp-sdk checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/cdp-sdk && git -C specs/cdp-sdk checkout -- .",
     "specs:update": "git -C specs/cdp-sdk fetch && git -C specs/cdp-sdk checkout main && git -C specs/cdp-sdk pull"
   },
   "dependencies": {

--- a/packages/fly-io/package.json
+++ b/packages/fly-io/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/distilled-spec-fly-io && git -C specs/distilled-spec-fly-io checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-fly-io && git -C specs/distilled-spec-fly-io checkout -- .",
     "specs:update": "git -C specs/distilled-spec-fly-io fetch && git -C specs/distilled-spec-fly-io checkout main && git -C specs/distilled-spec-fly-io pull"
   },
   "dependencies": {

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -53,7 +53,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/distilled-spec-gcp && git -C specs/distilled-spec-gcp checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-gcp && git -C specs/distilled-spec-gcp checkout -- .",
     "specs:update": "git -C specs/distilled-spec-gcp fetch && git -C specs/distilled-spec-gcp checkout main && git -C specs/distilled-spec-gcp pull"
   },
   "dependencies": {

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/kubernetes && git -C specs/kubernetes checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/kubernetes && git -C specs/kubernetes checkout -- .",
     "specs:update": "git -C specs/kubernetes fetch && git -C specs/kubernetes checkout master && git -C specs/kubernetes pull"
   },
   "dependencies": {

--- a/packages/mongodb-atlas/package.json
+++ b/packages/mongodb-atlas/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/distilled-spec-mongodb-atlas && git -C specs/distilled-spec-mongodb-atlas checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-mongodb-atlas && git -C specs/distilled-spec-mongodb-atlas checkout -- .",
     "specs:update": "git -C specs/distilled-spec-mongodb-atlas fetch && git -C specs/distilled-spec-mongodb-atlas checkout main && git -C specs/distilled-spec-mongodb-atlas pull"
   },
   "dependencies": {

--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/distilled-spec-neon && git -C specs/distilled-spec-neon checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-neon && git -C specs/distilled-spec-neon checkout -- .",
     "specs:update": "git -C specs/distilled-spec-neon fetch && git -C specs/distilled-spec-neon checkout main && git -C specs/distilled-spec-neon pull"
   },
   "dependencies": {

--- a/packages/planetscale/package.json
+++ b/packages/planetscale/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/distilled-spec-planetscale && git -C specs/distilled-spec-planetscale checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-planetscale && git -C specs/distilled-spec-planetscale checkout -- .",
     "specs:update": "git -C specs/distilled-spec-planetscale fetch && git -C specs/distilled-spec-planetscale checkout main && git -C specs/distilled-spec-planetscale pull"
   },
   "dependencies": {

--- a/packages/prisma-postgres/package.json
+++ b/packages/prisma-postgres/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/distilled-spec-prisma-postgres && git -C specs/distilled-spec-prisma-postgres checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-prisma-postgres && git -C specs/distilled-spec-prisma-postgres checkout -- .",
     "specs:update": "git -C specs/distilled-spec-prisma-postgres fetch && git -C specs/distilled-spec-prisma-postgres checkout main && git -C specs/distilled-spec-prisma-postgres pull"
   },
   "dependencies": {

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/stripe-openapi && git -C specs/stripe-openapi checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/stripe-openapi && git -C specs/stripe-openapi checkout -- .",
     "specs:update": "git -C specs/stripe-openapi fetch && git -C specs/stripe-openapi checkout master && git -C specs/stripe-openapi pull"
   },
   "dependencies": {

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/distilled-spec-supabase && git -C specs/distilled-spec-supabase checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-supabase && git -C specs/distilled-spec-supabase checkout -- .",
     "specs:update": "git -C specs/distilled-spec-supabase fetch && git -C specs/distilled-spec-supabase checkout main && git -C specs/distilled-spec-supabase pull"
   },
   "dependencies": {

--- a/packages/turso/package.json
+++ b/packages/turso/package.json
@@ -69,7 +69,7 @@
     "test": "bunx vitest run test",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
-    "specs:fetch": "git submodule update --force --init --recursive specs/turso-docs && git -C specs/turso-docs checkout -- .",
+    "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/turso-docs && git -C specs/turso-docs checkout -- .",
     "specs:update": "git -C specs/turso-docs fetch && git -C specs/turso-docs checkout main && git -C specs/turso-docs pull"
   },
   "dependencies": {

--- a/scripts/create-sdk.ts
+++ b/scripts/create-sdk.ts
@@ -941,7 +941,7 @@ const scaffoldPackage = (
     if (!pkgJsonExists) {
       const specsFetchCmds = submoduleNames.map(
         (sm) =>
-          `git submodule update --force --init --recursive specs/${sm} && git -C specs/${sm} checkout -- .`,
+          `git submodule update --force --init --recursive --depth=1 specs/${sm} && git -C specs/${sm} checkout -- .`,
       );
       const specsUpdateCmds = submoduleNames.map(
         (sm) =>


### PR DESCRIPTION
## Summary

Closes #118

- Adds `--depth=1` to all `specs:fetch` scripts in every package's `package.json`, extending the optimization from #117 (which only covered the AWS CI workflow) to all SDK packages
- Updates the `create-sdk.ts` scaffolding template so newly created SDKs also use shallow submodule clones by default

This avoids fetching full git histories for spec submodules, significantly speeding up `bun run specs:fetch` in CI and locally.

### Packages updated
aws, cloudflare, coinbase, fly-io, gcp, kubernetes, mongodb-atlas, neon, planetscale, prisma-postgres, stripe, supabase, turso