### PR TITLE
fix(cloudflare): add DuplicateMigrationTarget error for PutScript

### DIFF
--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -7,6 +7,12 @@
         "code": 10074,
         "message": { "includes": "not a SQLite Durable Object" }
       }
+    ],
+    "DuplicateMigrationTarget": [
+      {
+        "code": 10074,
+        "message": { "includes": "cannot be the target of more than one migration" }
+      }
     ]
   },
   "request": {

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -35,6 +35,14 @@ export class DomainNotFound extends Schema.TaggedErrorClass<DomainNotFound>()(
 ) {}
 T.applyErrorMatchers(DomainNotFound, [{ code: 100114 }]);
 
+export class DuplicateMigrationTarget extends Schema.TaggedErrorClass<DuplicateMigrationTarget>()(
+  "DuplicateMigrationTarget",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(DuplicateMigrationTarget, [
+  { code: 10074, message: { includes: "cannot be the target of more than one migration" } },
+]);
+
 export class DurableObjectMustBeSqlite extends Schema.TaggedErrorClass<DurableObjectMustBeSqlite>()(
   "DurableObjectMustBeSqlite",
   { code: Schema.Number, message: Schema.String },
@@ -7470,6 +7478,7 @@ export const PutScriptResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type PutScriptError =
   | DefaultErrors
+  | DuplicateMigrationTarget
   | InvalidRoute
   | InvalidWorkerScript
   | DurableObjectMustBeSqlite;
@@ -7482,7 +7491,7 @@ export const putScript: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: PutScriptRequest,
   output: PutScriptResponse,
-  errors: [InvalidRoute, InvalidWorkerScript, DurableObjectMustBeSqlite],
+  errors: [DuplicateMigrationTarget, InvalidRoute, InvalidWorkerScript, DurableObjectMustBeSqlite],
 }));
 
 export interface DeleteScriptRequest {


### PR DESCRIPTION
## Summary
- Adds `DuplicateMigrationTarget` error patch for the `PutScript` operation (code 10074, message includes "cannot be the target of more than one migration")
- Previously surfaced as `UnknownCloudflareError`, now correctly tagged as `DuplicateMigrationTarget`

## Test plan
- [ ] Deploy a worker with duplicate migration targets and verify the error is typed as `DuplicateMigrationTarget` instead of `UnknownCloudflareError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)