### PR TITLE
feat(cloudflare): add R2 object operations (get, put, delete)

### DIFF
--- a/packages/cloudflare/specs/cloudflare-patch/r2-object.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare-patch/r2-object.openapi.yml
@@ -8,6 +8,112 @@ servers:
 x-distilled-service: r2
 paths:
   /accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}:
+    get:
+      operationId: getObject
+      summary: Download an object from an R2 bucket.
+      description: Downloads an object from an R2 bucket.
+      x-distilled-response-path: result
+      x-distilled-errors:
+        NoSuchBucket:
+          - code: 10006
+        InvalidRoute:
+          - code: 7003
+        NoRoute:
+          - code: 10015
+      parameters:
+        - $ref: "#/components/parameters/BucketName"
+        - $ref: "#/components/parameters/ObjectName"
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/Jurisdiction"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+    put:
+      operationId: putObject
+      summary: Upload an object to an R2 bucket.
+      description: Uploads an object to an R2 bucket.
+      x-distilled-response-path: result
+      x-distilled-errors:
+        NoSuchBucket:
+          - code: 10006
+        InvalidRoute:
+          - code: 7003
+        NoRoute:
+          - code: 10015
+      parameters:
+        - $ref: "#/components/parameters/BucketName"
+        - $ref: "#/components/parameters/ObjectName"
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/Jurisdiction"
+        - name: content-type
+          in: header
+          required: false
+          description: MIME type of the object.
+          schema:
+            type: string
+        - name: content-disposition
+          in: header
+          required: false
+          description: Content disposition of the object.
+          schema:
+            type: string
+        - name: content-encoding
+          in: header
+          required: false
+          description: Content encoding of the object.
+          schema:
+            type: string
+        - name: content-language
+          in: header
+          required: false
+          description: Content language of the object.
+          schema:
+            type: string
+        - name: content-length
+          in: header
+          required: false
+          description: Content length of the object in bytes.
+          schema:
+            type: string
+        - name: cache-control
+          in: header
+          required: false
+          description: Cache control directives for the object.
+          schema:
+            type: string
+        - name: expires
+          in: header
+          required: false
+          description: Expiration date of the object.
+          schema:
+            type: string
+        - name: cf-r2-storage-class
+          in: header
+          required: false
+          description: Storage class for the object.
+          schema:
+            type: string
+            enum:
+              - Standard
+              - InfrequentAccess
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema: {}
     delete:
       operationId: deleteObject
       summary: Delete an object from an R2 bucket.
@@ -21,35 +127,47 @@ paths:
         NoRoute:
           - code: 10015
       parameters:
-        - name: bucketName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: objectName
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: account_id
-          in: path
-          required: true
-          description: Account ID.
-          schema:
-            type: string
-        - name: cf-r2-jurisdiction
-          in: header
-          required: false
-          description: Jurisdiction where objects in this bucket are guaranteed to be stored.
-          schema:
-            type: string
-            enum:
-              - default
-              - eu
-              - fedramp
+        - $ref: "#/components/parameters/BucketName"
+        - $ref: "#/components/parameters/ObjectName"
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/Jurisdiction"
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema: {}
+components:
+  parameters:
+    AccountId:
+      name: account_id
+      in: path
+      required: true
+      description: Account ID.
+      schema:
+        type: string
+    BucketName:
+      name: bucketName
+      in: path
+      required: true
+      description: Name of the R2 bucket.
+      schema:
+        type: string
+    ObjectName:
+      name: objectName
+      in: path
+      required: true
+      description: Key (name) of the object.
+      schema:
+        type: string
+    Jurisdiction:
+      name: cf-r2-jurisdiction
+      in: header
+      required: false
+      description: Jurisdiction where objects in this bucket are guaranteed to be stored.
+      schema:
+        type: string
+        enum:
+          - default
+          - eu
+          - fedramp

--- a/packages/cloudflare/specs/cloudflare/r2.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/r2.openapi.yml
@@ -1,7 +1,8 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare R2 API
+  title: Cloudflare R2 Object API
   version: 0.0.0
+  description: R2 object operations not exposed in the Cloudflare TypeScript SDK.
 servers:
   - url: https://api.cloudflare.com/client/v4
 x-distilled-service: r2
@@ -2486,6 +2487,159 @@ paths:
         InvalidRoute:
           - code: 7003
   /accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}:
+    get:
+      operationId: getObject
+      summary: Download an object from an R2 bucket.
+      description: Downloads an object from an R2 bucket.
+      parameters:
+        - name: bucketName
+          in: path
+          required: true
+          description: Name of the R2 bucket.
+          schema:
+            type: string
+        - name: objectName
+          in: path
+          required: true
+          description: Key (name) of the object.
+          schema:
+            type: string
+        - name: account_id
+          in: path
+          required: true
+          description: Account ID.
+          schema:
+            type: string
+        - name: cf-r2-jurisdiction
+          in: header
+          required: false
+          description: Jurisdiction where objects in this bucket are guaranteed to be
+            stored.
+          schema:
+            type: string
+            enum:
+              - default
+              - eu
+              - fedramp
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string
+                format: binary
+      x-distilled-response-path: result
+      x-distilled-errors:
+        NoSuchBucket:
+          - code: 10006
+        InvalidRoute:
+          - code: 7003
+        NoRoute:
+          - code: 10015
+    put:
+      operationId: putObject
+      summary: Upload an object to an R2 bucket.
+      description: Uploads an object to an R2 bucket.
+      parameters:
+        - name: bucketName
+          in: path
+          required: true
+          description: Name of the R2 bucket.
+          schema:
+            type: string
+        - name: objectName
+          in: path
+          required: true
+          description: Key (name) of the object.
+          schema:
+            type: string
+        - name: account_id
+          in: path
+          required: true
+          description: Account ID.
+          schema:
+            type: string
+        - name: cf-r2-jurisdiction
+          in: header
+          required: false
+          description: Jurisdiction where objects in this bucket are guaranteed to be
+            stored.
+          schema:
+            type: string
+            enum:
+              - default
+              - eu
+              - fedramp
+        - name: content-type
+          in: header
+          required: false
+          description: MIME type of the object.
+          schema:
+            type: string
+        - name: content-disposition
+          in: header
+          required: false
+          description: Content disposition of the object.
+          schema:
+            type: string
+        - name: content-encoding
+          in: header
+          required: false
+          description: Content encoding of the object.
+          schema:
+            type: string
+        - name: content-language
+          in: header
+          required: false
+          description: Content language of the object.
+          schema:
+            type: string
+        - name: content-length
+          in: header
+          required: false
+          description: Content length of the object in bytes.
+          schema:
+            type: string
+        - name: cache-control
+          in: header
+          required: false
+          description: Cache control directives for the object.
+          schema:
+            type: string
+        - name: expires
+          in: header
+          required: false
+          description: Expiration date of the object.
+          schema:
+            type: string
+        - name: cf-r2-storage-class
+          in: header
+          required: false
+          description: Storage class for the object.
+          schema:
+            type: string
+            enum:
+              - Standard
+              - InfrequentAccess
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: Success
+      x-distilled-response-path: result
+      x-distilled-errors:
+        NoSuchBucket:
+          - code: 10006
+        InvalidRoute:
+          - code: 7003
+        NoRoute:
+          - code: 10015
     delete:
       operationId: deleteObject
       summary: Delete an object from an R2 bucket.
@@ -2494,11 +2648,13 @@ paths:
         - name: bucketName
           in: path
           required: true
+          description: Name of the R2 bucket.
           schema:
             type: string
         - name: objectName
           in: path
           required: true
+          description: Key (name) of the object.
           schema:
             type: string
         - name: account_id

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -10,7 +10,10 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
-import { type DefaultErrors } from "../errors.ts";
+import {
+  type DefaultErrors,
+} from "../errors.ts";
+import { UploadableSchema } from "../schemas.ts";
 import { SensitiveString } from "../sensitive.ts";
 
 // =============================================================================
@@ -21,49 +24,49 @@ export class BucketAlreadyExists extends Schema.TaggedErrorClass<BucketAlreadyEx
   "BucketAlreadyExists",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(BucketAlreadyExists, [{ code: 10004 }]);
+T.applyErrorMatchers(BucketAlreadyExists, [{"code":10004}]);
 
 export class BucketNotFound extends Schema.TaggedErrorClass<BucketNotFound>()(
   "BucketNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(BucketNotFound, [{ code: 10085 }]);
+T.applyErrorMatchers(BucketNotFound, [{"code":10085}]);
 
 export class InvalidBucketName extends Schema.TaggedErrorClass<InvalidBucketName>()(
   "InvalidBucketName",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidBucketName, [{ code: 10005 }]);
+T.applyErrorMatchers(InvalidBucketName, [{"code":10005}]);
 
 export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
   "InvalidRoute",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
+T.applyErrorMatchers(InvalidRoute, [{"code":7003}]);
 
 export class NoCorsConfiguration extends Schema.TaggedErrorClass<NoCorsConfiguration>()(
   "NoCorsConfiguration",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoCorsConfiguration, [{ code: 10059 }]);
+T.applyErrorMatchers(NoCorsConfiguration, [{"code":10059}]);
 
 export class NoEventNotificationConfig extends Schema.TaggedErrorClass<NoEventNotificationConfig>()(
   "NoEventNotificationConfig",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoEventNotificationConfig, [{ code: 11015 }]);
+T.applyErrorMatchers(NoEventNotificationConfig, [{"code":11015}]);
 
-export class NoRoute extends Schema.TaggedErrorClass<NoRoute>()("NoRoute", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NoRoute, [{ code: 10015 }]);
+export class NoRoute extends Schema.TaggedErrorClass<NoRoute>()(
+  "NoRoute",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(NoRoute, [{"code":10015}]);
 
 export class NoSuchBucket extends Schema.TaggedErrorClass<NoSuchBucket>()(
   "NoSuchBucket",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoSuchBucket, [{ code: 10006 }]);
+T.applyErrorMatchers(NoSuchBucket, [{"code":10006}]);
 
 // =============================================================================
 // AllSuperSlurperJob
@@ -73,24 +76,17 @@ export interface AbortAllSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const AbortAllSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/jobs/abortAll",
-    }),
-  ) as unknown as Schema.Schema<AbortAllSuperSlurperJobRequest>;
+export const AbortAllSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/abortAll" })) as unknown as Schema.Schema<AbortAllSuperSlurperJobRequest>;
 
 export type AbortAllSuperSlurperJobResponse = string;
 
-export const AbortAllSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<AbortAllSuperSlurperJobResponse>;
+export const AbortAllSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<AbortAllSuperSlurperJobResponse>;
 
-export type AbortAllSuperSlurperJobError = DefaultErrors;
+export type AbortAllSuperSlurperJobError =
+  | DefaultErrors;
 
 export const abortAllSuperSlurperJob: API.OperationMethod<
   AbortAllSuperSlurperJobRequest,
@@ -102,6 +98,7 @@ export const abortAllSuperSlurperJob: API.OperationMethod<
   output: AbortAllSuperSlurperJobResponse,
   errors: [],
 }));
+
 
 // =============================================================================
 // Bucket
@@ -118,15 +115,9 @@ export interface GetBucketRequest {
 export const GetBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
-  }),
-) as unknown as Schema.Schema<GetBucketRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<GetBucketRequest>;
 
 export interface GetBucketResponse {
   /** Creation timestamp. */
@@ -134,20 +125,7 @@ export interface GetBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?:
-    | "apac"
-    | "eeur"
-    | "enam"
-    | "weur"
-    | "wnam"
-    | "oc"
-    | "APAC"
-    | "EEUR"
-    | "ENAM"
-    | "WEUR"
-    | "WNAM"
-    | "OC"
-    | null;
+  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -156,50 +134,16 @@ export interface GetBucketResponse {
 
 export const GetBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(
-    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
-  ),
-  location: Schema.optional(
-    Schema.Union([
-      Schema.Literals([
-        "apac",
-        "eeur",
-        "enam",
-        "weur",
-        "wnam",
-        "oc",
-        "APAC",
-        "EEUR",
-        "ENAM",
-        "WEUR",
-        "WNAM",
-        "OC",
-      ]),
-      Schema.Null,
-    ]),
-  ),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(
-    Schema.Union([
-      Schema.Literals(["Standard", "InfrequentAccess"]),
-      Schema.Null,
-    ]),
-  ),
-})
-  .pipe(
-    Schema.encodeKeys({
-      creationDate: "creation_date",
-      jurisdiction: "jurisdiction",
-      location: "location",
-      name: "name",
-      storageClass: "storage_class",
-    }),
-  )
-  .pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetBucketResponse>;
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
+}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketResponse>;
 
-export type GetBucketError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type GetBucketError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const getBucket: API.OperationMethod<
   GetBucketRequest,
@@ -234,105 +178,32 @@ export interface ListBucketsRequest {
 export const ListBucketsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
   cursor: Schema.optional(Schema.String).pipe(T.HttpQuery("cursor")),
-  direction: Schema.optional(Schema.Literals(["asc", "desc"])).pipe(
-    T.HttpQuery("direction"),
-  ),
-  nameContains: Schema.optional(Schema.String).pipe(
-    T.HttpQuery("name_contains"),
-  ),
+  direction: Schema.optional(Schema.Literals(["asc", "desc"])).pipe(T.HttpQuery("direction")),
+  nameContains: Schema.optional(Schema.String).pipe(T.HttpQuery("name_contains")),
   order: Schema.optional(Schema.Literal("name")).pipe(T.HttpQuery("order")),
   perPage: Schema.optional(Schema.Number).pipe(T.HttpQuery("per_page")),
   startAfter: Schema.optional(Schema.String).pipe(T.HttpQuery("start_after")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets" }),
-) as unknown as Schema.Schema<ListBucketsRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets" })) as unknown as Schema.Schema<ListBucketsRequest>;
 
 export interface ListBucketsResponse {
-  buckets?:
-    | {
-        creationDate?: string | null;
-        jurisdiction?: "default" | "eu" | "fedramp" | null;
-        location?:
-          | "apac"
-          | "eeur"
-          | "enam"
-          | "weur"
-          | "wnam"
-          | "oc"
-          | "APAC"
-          | "EEUR"
-          | "ENAM"
-          | "WEUR"
-          | "WNAM"
-          | "OC"
-          | null;
-        name?: string | null;
-        storageClass?: "Standard" | "InfrequentAccess" | null;
-      }[]
-    | null;
+  buckets?: ({ creationDate?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null; name?: string | null; storageClass?: "Standard" | "InfrequentAccess" | null })[] | null;
 }
 
 export const ListBucketsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  buckets: Schema.optional(
-    Schema.Union([
-      Schema.Array(
-        Schema.Struct({
-          creationDate: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          jurisdiction: Schema.optional(
-            Schema.Union([
-              Schema.Literals(["default", "eu", "fedramp"]),
-              Schema.Null,
-            ]),
-          ),
-          location: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "apac",
-                "eeur",
-                "enam",
-                "weur",
-                "wnam",
-                "oc",
-                "APAC",
-                "EEUR",
-                "ENAM",
-                "WEUR",
-                "WNAM",
-                "OC",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-          name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          storageClass: Schema.optional(
-            Schema.Union([
-              Schema.Literals(["Standard", "InfrequentAccess"]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            creationDate: "creation_date",
-            jurisdiction: "jurisdiction",
-            location: "location",
-            name: "name",
-            storageClass: "storage_class",
-          }),
-        ),
-      ),
-      Schema.Null,
-    ]),
-  ),
-}).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<ListBucketsResponse>;
+  buckets: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
+  name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
+}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" }))), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketsResponse>;
 
-export type ListBucketsError = DefaultErrors | InvalidRoute;
+export type ListBucketsError =
+  | DefaultErrors
+  | InvalidRoute;
 
 export const listBuckets: API.OperationMethod<
   ListBucketsRequest,
@@ -360,19 +231,12 @@ export interface CreateBucketRequest {
 
 export const CreateBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
   name: Schema.String,
-  locationHint: Schema.optional(
-    Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc"]),
-  ),
-  storageClass: Schema.optional(
-    Schema.Literals(["Standard", "InfrequentAccess"]),
-  ),
-}).pipe(
-  T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets" }),
-) as unknown as Schema.Schema<CreateBucketRequest>;
+  locationHint: Schema.optional(Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc"])),
+  storageClass: Schema.optional(Schema.Literals(["Standard", "InfrequentAccess"]))
+})
+  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets" })) as unknown as Schema.Schema<CreateBucketRequest>;
 
 export interface CreateBucketResponse {
   /** Creation timestamp. */
@@ -380,20 +244,7 @@ export interface CreateBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?:
-    | "apac"
-    | "eeur"
-    | "enam"
-    | "weur"
-    | "wnam"
-    | "oc"
-    | "APAC"
-    | "EEUR"
-    | "ENAM"
-    | "WEUR"
-    | "WNAM"
-    | "OC"
-    | null;
+  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -402,48 +253,11 @@ export interface CreateBucketResponse {
 
 export const CreateBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(
-    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
-  ),
-  location: Schema.optional(
-    Schema.Union([
-      Schema.Literals([
-        "apac",
-        "eeur",
-        "enam",
-        "weur",
-        "wnam",
-        "oc",
-        "APAC",
-        "EEUR",
-        "ENAM",
-        "WEUR",
-        "WNAM",
-        "OC",
-      ]),
-      Schema.Null,
-    ]),
-  ),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(
-    Schema.Union([
-      Schema.Literals(["Standard", "InfrequentAccess"]),
-      Schema.Null,
-    ]),
-  ),
-})
-  .pipe(
-    Schema.encodeKeys({
-      creationDate: "creation_date",
-      jurisdiction: "jurisdiction",
-      location: "location",
-      name: "name",
-      storageClass: "storage_class",
-    }),
-  )
-  .pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<CreateBucketResponse>;
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
+}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateBucketResponse>;
 
 export type CreateBucketError =
   | DefaultErrors
@@ -475,18 +289,10 @@ export interface PatchBucketRequest {
 export const PatchBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  storageClass: Schema.Literals(["Standard", "InfrequentAccess"]).pipe(
-    T.HttpHeader("cf-r2-storage-class"),
-  ),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "PATCH",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
-  }),
-) as unknown as Schema.Schema<PatchBucketRequest>;
+  storageClass: Schema.Literals(["Standard", "InfrequentAccess"]).pipe(T.HttpHeader("cf-r2-storage-class")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "PATCH", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<PatchBucketRequest>;
 
 export interface PatchBucketResponse {
   /** Creation timestamp. */
@@ -494,20 +300,7 @@ export interface PatchBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?:
-    | "apac"
-    | "eeur"
-    | "enam"
-    | "weur"
-    | "wnam"
-    | "oc"
-    | "APAC"
-    | "EEUR"
-    | "ENAM"
-    | "WEUR"
-    | "WNAM"
-    | "OC"
-    | null;
+  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -516,50 +309,16 @@ export interface PatchBucketResponse {
 
 export const PatchBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(
-    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
-  ),
-  location: Schema.optional(
-    Schema.Union([
-      Schema.Literals([
-        "apac",
-        "eeur",
-        "enam",
-        "weur",
-        "wnam",
-        "oc",
-        "APAC",
-        "EEUR",
-        "ENAM",
-        "WEUR",
-        "WNAM",
-        "OC",
-      ]),
-      Schema.Null,
-    ]),
-  ),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(
-    Schema.Union([
-      Schema.Literals(["Standard", "InfrequentAccess"]),
-      Schema.Null,
-    ]),
-  ),
-})
-  .pipe(
-    Schema.encodeKeys({
-      creationDate: "creation_date",
-      jurisdiction: "jurisdiction",
-      location: "location",
-      name: "name",
-      storageClass: "storage_class",
-    }),
-  )
-  .pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PatchBucketResponse>;
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
+}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PatchBucketResponse>;
 
-export type PatchBucketError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type PatchBucketError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const patchBucket: API.OperationMethod<
   PatchBucketRequest,
@@ -583,22 +342,13 @@ export interface DeleteBucketRequest {
 export const DeleteBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "DELETE",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
-  }),
-) as unknown as Schema.Schema<DeleteBucketRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<DeleteBucketRequest>;
 
 export type DeleteBucketResponse = unknown;
 
-export const DeleteBucketResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketResponse>;
+export const DeleteBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketResponse>;
 
 export type DeleteBucketError =
   | DefaultErrors
@@ -617,6 +367,7 @@ export const deleteBucket: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
 }));
 
+
 // =============================================================================
 // BucketCor
 // =============================================================================
@@ -632,60 +383,26 @@ export interface GetBucketCorsRequest {
 export const GetBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
-  }),
-) as unknown as Schema.Schema<GetBucketCorsRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<GetBucketCorsRequest>;
 
 export interface GetBucketCorsResponse {
-  rules?:
-    | {
-        allowed: {
-          methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
-          origins: string[];
-          headers?: string[] | null;
-        };
-        id?: string | null;
-        exposeHeaders?: string[] | null;
-        maxAgeSeconds?: number | null;
-      }[]
-    | null;
+  rules?: ({ allowed: { methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[]; origins: string[]; headers?: string[] | null }; id?: string | null; exposeHeaders?: string[] | null; maxAgeSeconds?: number | null })[] | null;
 }
 
 export const GetBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rules: Schema.optional(
-    Schema.Union([
-      Schema.Array(
-        Schema.Struct({
-          allowed: Schema.Struct({
-            methods: Schema.Array(
-              Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"]),
-            ),
-            origins: Schema.Array(Schema.String),
-            headers: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-          }),
-          id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          exposeHeaders: Schema.optional(
-            Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-          ),
-          maxAgeSeconds: Schema.optional(
-            Schema.Union([Schema.Number, Schema.Null]),
-          ),
-        }),
-      ),
-      Schema.Null,
-    ]),
-  ),
-}).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<GetBucketCorsResponse>;
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  allowed: Schema.Struct({
+    methods: Schema.Array(Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"])),
+    origins: Schema.Array(Schema.String),
+    headers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null]))
+  }),
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  exposeHeaders: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  maxAgeSeconds: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketCorsResponse>;
 
 export type GetBucketCorsError =
   | DefaultErrors
@@ -711,55 +428,34 @@ export interface PutBucketCorsRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: {
-    allowed: {
-      methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
-      origins: string[];
-      headers?: string[];
-    };
-    id?: string;
-    exposeHeaders?: string[];
-    maxAgeSeconds?: number;
-  }[];
+  rules?: ({ allowed: { methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[]; origins: string[]; headers?: string[] }; id?: string; exposeHeaders?: string[]; maxAgeSeconds?: number })[];
 }
 
 export const PutBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  rules: Schema.optional(
-    Schema.Array(
-      Schema.Struct({
-        allowed: Schema.Struct({
-          methods: Schema.Array(
-            Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"]),
-          ),
-          origins: Schema.Array(Schema.String),
-          headers: Schema.optional(Schema.Array(Schema.String)),
-        }),
-        id: Schema.optional(Schema.String),
-        exposeHeaders: Schema.optional(Schema.Array(Schema.String)),
-        maxAgeSeconds: Schema.optional(Schema.Number),
-      }),
-    ),
-  ),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.optional(Schema.Array(Schema.Struct({
+  allowed: Schema.Struct({
+    methods: Schema.Array(Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"])),
+    origins: Schema.Array(Schema.String),
+    headers: Schema.optional(Schema.Array(Schema.String))
   }),
-) as unknown as Schema.Schema<PutBucketCorsRequest>;
+  id: Schema.optional(Schema.String),
+  exposeHeaders: Schema.optional(Schema.Array(Schema.String)),
+  maxAgeSeconds: Schema.optional(Schema.Number)
+})))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<PutBucketCorsRequest>;
 
 export type PutBucketCorsResponse = unknown;
 
-export const PutBucketCorsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketCorsResponse>;
+export const PutBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketCorsResponse>;
 
-export type PutBucketCorsError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type PutBucketCorsError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const putBucketCors: API.OperationMethod<
   PutBucketCorsRequest,
@@ -780,28 +476,21 @@ export interface DeleteBucketCorsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketCorsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "DELETE",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
-    }),
-  ) as unknown as Schema.Schema<DeleteBucketCorsRequest>;
+export const DeleteBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<DeleteBucketCorsRequest>;
 
 export type DeleteBucketCorsResponse = unknown;
 
-export const DeleteBucketCorsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketCorsResponse>;
+export const DeleteBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketCorsResponse>;
 
-export type DeleteBucketCorsError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type DeleteBucketCorsError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const deleteBucketCors: API.OperationMethod<
   DeleteBucketCorsRequest,
@@ -813,6 +502,7 @@ export const deleteBucketCors: API.OperationMethod<
   output: DeleteBucketCorsResponse,
   errors: [NoSuchBucket, InvalidRoute],
 }));
+
 
 // =============================================================================
 // BucketDomainCustom
@@ -827,42 +517,20 @@ export interface GetBucketDomainCustomRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketDomainCustomRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    domain: Schema.String.pipe(T.HttpPath("domain")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
-    }),
-  ) as unknown as Schema.Schema<GetBucketDomainCustomRequest>;
+export const GetBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  domain: Schema.String.pipe(T.HttpPath("domain")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<GetBucketDomainCustomRequest>;
 
 export interface GetBucketDomainCustomResponse {
   /** Domain name of the custom domain to be added. */
   domain: string;
   /** Whether this bucket is publicly accessible at the specified custom domain. */
   enabled: boolean;
-  status: {
-    ownership:
-      | "pending"
-      | "active"
-      | "deactivated"
-      | "blocked"
-      | "error"
-      | "unknown";
-    ssl:
-      | "initializing"
-      | "pending"
-      | "active"
-      | "deactivated"
-      | "error"
-      | "unknown";
-  };
+  status: { ownership: "pending" | "active" | "deactivated" | "blocked" | "error" | "unknown"; ssl: "initializing" | "pending" | "active" | "deactivated" | "error" | "unknown" };
   /** An allowlist of ciphers for TLS termination. These ciphers must be in the BoringSSL format. */
   ciphers?: string[] | null;
   /** Minimum TLS Version the custom domain will accept for incoming connections. If not set, defaults to 1.0. */
@@ -873,44 +541,21 @@ export interface GetBucketDomainCustomResponse {
   zoneName?: string | null;
 }
 
-export const GetBucketDomainCustomResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-    status: Schema.Struct({
-      ownership: Schema.Literals([
-        "pending",
-        "active",
-        "deactivated",
-        "blocked",
-        "error",
-        "unknown",
-      ]),
-      ssl: Schema.Literals([
-        "initializing",
-        "pending",
-        "active",
-        "deactivated",
-        "error",
-        "unknown",
-      ]),
-    }),
-    ciphers: Schema.optional(
-      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-    ),
-    minTLS: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
-        Schema.Null,
-      ]),
-    ),
-    zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetBucketDomainCustomResponse>;
+export const GetBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domain: Schema.String,
+  enabled: Schema.Boolean,
+  status: Schema.Struct({
+  ownership: Schema.Literals(["pending", "active", "deactivated", "blocked", "error", "unknown"]),
+  ssl: Schema.Literals(["initializing", "pending", "active", "deactivated", "error", "unknown"])
+}),
+  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null])),
+  zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketDomainCustomResponse>;
 
-export type GetBucketDomainCustomError = DefaultErrors;
+export type GetBucketDomainCustomError =
+  | DefaultErrors;
 
 export const getBucketDomainCustom: API.OperationMethod<
   GetBucketDomainCustomRequest,
@@ -931,87 +576,31 @@ export interface ListBucketDomainCustomsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketDomainCustomsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom",
-    }),
-  ) as unknown as Schema.Schema<ListBucketDomainCustomsRequest>;
+export const ListBucketDomainCustomsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom" })) as unknown as Schema.Schema<ListBucketDomainCustomsRequest>;
 
 export interface ListBucketDomainCustomsResponse {
-  domains: {
-    domain: string;
-    enabled: boolean;
-    status: {
-      ownership:
-        | "pending"
-        | "active"
-        | "deactivated"
-        | "blocked"
-        | "error"
-        | "unknown";
-      ssl:
-        | "initializing"
-        | "pending"
-        | "active"
-        | "deactivated"
-        | "error"
-        | "unknown";
-    };
-    ciphers?: string[] | null;
-    minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
-    zoneId?: string | null;
-    zoneName?: string | null;
-  }[];
+  domains: ({ domain: string; enabled: boolean; status: { ownership: "pending" | "active" | "deactivated" | "blocked" | "error" | "unknown"; ssl: "initializing" | "pending" | "active" | "deactivated" | "error" | "unknown" }; ciphers?: string[] | null; minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null; zoneId?: string | null; zoneName?: string | null })[];
 }
 
-export const ListBucketDomainCustomsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domains: Schema.Array(
-      Schema.Struct({
-        domain: Schema.String,
-        enabled: Schema.Boolean,
-        status: Schema.Struct({
-          ownership: Schema.Literals([
-            "pending",
-            "active",
-            "deactivated",
-            "blocked",
-            "error",
-            "unknown",
-          ]),
-          ssl: Schema.Literals([
-            "initializing",
-            "pending",
-            "active",
-            "deactivated",
-            "error",
-            "unknown",
-          ]),
-        }),
-        ciphers: Schema.optional(
-          Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-        ),
-        minTLS: Schema.optional(
-          Schema.Union([
-            Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
-            Schema.Null,
-          ]),
-        ),
-        zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      }),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ListBucketDomainCustomsResponse>;
+export const ListBucketDomainCustomsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domains: Schema.Array(Schema.Struct({
+  domain: Schema.String,
+  enabled: Schema.Boolean,
+  status: Schema.Struct({
+    ownership: Schema.Literals(["pending", "active", "deactivated", "blocked", "error", "unknown"]),
+    ssl: Schema.Literals(["initializing", "pending", "active", "deactivated", "error", "unknown"])
+  }),
+  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null])),
+  zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketDomainCustomsResponse>;
 
 export type ListBucketDomainCustomsError =
   | DefaultErrors
@@ -1047,24 +636,17 @@ export interface CreateBucketDomainCustomRequest {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3";
 }
 
-export const CreateBucketDomainCustomRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-    zoneId: Schema.String,
-    ciphers: Schema.optional(Schema.Array(Schema.String)),
-    minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"])),
-  }).pipe(
-    T.Http({
-      method: "POST",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom",
-    }),
-  ) as unknown as Schema.Schema<CreateBucketDomainCustomRequest>;
+export const CreateBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  domain: Schema.String,
+  enabled: Schema.Boolean,
+  zoneId: Schema.String,
+  ciphers: Schema.optional(Schema.Array(Schema.String)),
+  minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"]))
+})
+  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom" })) as unknown as Schema.Schema<CreateBucketDomainCustomRequest>;
 
 export interface CreateBucketDomainCustomResponse {
   /** Domain name of the affected custom domain. */
@@ -1077,22 +659,12 @@ export interface CreateBucketDomainCustomResponse {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
 }
 
-export const CreateBucketDomainCustomResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-    ciphers: Schema.optional(
-      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-    ),
-    minTLS: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<CreateBucketDomainCustomResponse>;
+export const CreateBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domain: Schema.String,
+  enabled: Schema.Boolean,
+  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateBucketDomainCustomResponse>;
 
 export type CreateBucketDomainCustomError =
   | DefaultErrors
@@ -1125,23 +697,16 @@ export interface UpdateBucketDomainCustomRequest {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3";
 }
 
-export const UpdateBucketDomainCustomRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    domain: Schema.String.pipe(T.HttpPath("domain")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    ciphers: Schema.optional(Schema.Array(Schema.String)),
-    enabled: Schema.optional(Schema.Boolean),
-    minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"])),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
-    }),
-  ) as unknown as Schema.Schema<UpdateBucketDomainCustomRequest>;
+export const UpdateBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  domain: Schema.String.pipe(T.HttpPath("domain")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  ciphers: Schema.optional(Schema.Array(Schema.String)),
+  enabled: Schema.optional(Schema.Boolean),
+  minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"]))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<UpdateBucketDomainCustomRequest>;
 
 export interface UpdateBucketDomainCustomResponse {
   /** Domain name of the affected custom domain. */
@@ -1154,24 +719,15 @@ export interface UpdateBucketDomainCustomResponse {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
 }
 
-export const UpdateBucketDomainCustomResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domain: Schema.String,
-    ciphers: Schema.optional(
-      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-    ),
-    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    minTLS: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<UpdateBucketDomainCustomResponse>;
+export const UpdateBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domain: Schema.String,
+  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<UpdateBucketDomainCustomResponse>;
 
-export type UpdateBucketDomainCustomError = DefaultErrors;
+export type UpdateBucketDomainCustomError =
+  | DefaultErrors;
 
 export const updateBucketDomainCustom: API.OperationMethod<
   UpdateBucketDomainCustomRequest,
@@ -1193,34 +749,25 @@ export interface DeleteBucketDomainCustomRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketDomainCustomRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    domain: Schema.String.pipe(T.HttpPath("domain")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "DELETE",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
-    }),
-  ) as unknown as Schema.Schema<DeleteBucketDomainCustomRequest>;
+export const DeleteBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  domain: Schema.String.pipe(T.HttpPath("domain")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<DeleteBucketDomainCustomRequest>;
 
 export interface DeleteBucketDomainCustomResponse {
   /** Name of the removed custom domain. */
   domain: string;
 }
 
-export const DeleteBucketDomainCustomResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domain: Schema.String,
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketDomainCustomResponse>;
+export const DeleteBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domain: Schema.String
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketDomainCustomResponse>;
 
-export type DeleteBucketDomainCustomError = DefaultErrors;
+export type DeleteBucketDomainCustomError =
+  | DefaultErrors;
 
 export const deleteBucketDomainCustom: API.OperationMethod<
   DeleteBucketDomainCustomRequest,
@@ -1232,6 +779,7 @@ export const deleteBucketDomainCustom: API.OperationMethod<
   output: DeleteBucketDomainCustomResponse,
   errors: [],
 }));
+
 
 // =============================================================================
 // BucketDomainManaged
@@ -1245,19 +793,12 @@ export interface ListBucketDomainManagedsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketDomainManagedsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed",
-    }),
-  ) as unknown as Schema.Schema<ListBucketDomainManagedsRequest>;
+export const ListBucketDomainManagedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed" })) as unknown as Schema.Schema<ListBucketDomainManagedsRequest>;
 
 export interface ListBucketDomainManagedsResponse {
   /** Bucket ID. */
@@ -1268,14 +809,11 @@ export interface ListBucketDomainManagedsResponse {
   enabled: boolean;
 }
 
-export const ListBucketDomainManagedsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketId: Schema.String,
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ListBucketDomainManagedsResponse>;
+export const ListBucketDomainManagedsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketId: Schema.String,
+  domain: Schema.String,
+  enabled: Schema.Boolean
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketDomainManagedsResponse>;
 
 export type ListBucketDomainManagedsError =
   | DefaultErrors
@@ -1303,20 +841,13 @@ export interface PutBucketDomainManagedRequest {
   enabled: boolean;
 }
 
-export const PutBucketDomainManagedRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    enabled: Schema.Boolean,
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed",
-    }),
-  ) as unknown as Schema.Schema<PutBucketDomainManagedRequest>;
+export const PutBucketDomainManagedRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  enabled: Schema.Boolean
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed" })) as unknown as Schema.Schema<PutBucketDomainManagedRequest>;
 
 export interface PutBucketDomainManagedResponse {
   /** Bucket ID. */
@@ -1327,14 +858,11 @@ export interface PutBucketDomainManagedResponse {
   enabled: boolean;
 }
 
-export const PutBucketDomainManagedResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketId: Schema.String,
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketDomainManagedResponse>;
+export const PutBucketDomainManagedResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketId: Schema.String,
+  domain: Schema.String,
+  enabled: Schema.Boolean
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketDomainManagedResponse>;
 
 export type PutBucketDomainManagedError =
   | DefaultErrors
@@ -1352,6 +880,7 @@ export const putBucketDomainManaged: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
+
 // =============================================================================
 // BucketEventNotification
 // =============================================================================
@@ -1365,80 +894,37 @@ export interface GetBucketEventNotificationRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketEventNotificationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    queueId: Schema.String.pipe(T.HttpPath("queueId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
-    }),
-  ) as unknown as Schema.Schema<GetBucketEventNotificationRequest>;
+export const GetBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  queueId: Schema.String.pipe(T.HttpPath("queueId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<GetBucketEventNotificationRequest>;
 
 export interface GetBucketEventNotificationResponse {
   /** Queue ID. */
   queueId?: string | null;
   /** Name of the queue. */
   queueName?: string | null;
-  rules?:
-    | {
-        actions: (
-          | "PutObject"
-          | "CopyObject"
-          | "DeleteObject"
-          | "CompleteMultipartUpload"
-          | "LifecycleDeletion"
-        )[];
-        createdAt?: string | null;
-        description?: string | null;
-        prefix?: string | null;
-        ruleId?: string | null;
-        suffix?: string | null;
-      }[]
-    | null;
+  rules?: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; createdAt?: string | null; description?: string | null; prefix?: string | null; ruleId?: string | null; suffix?: string | null })[] | null;
 }
 
-export const GetBucketEventNotificationResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    rules: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            actions: Schema.Array(
-              Schema.Literals([
-                "PutObject",
-                "CopyObject",
-                "DeleteObject",
-                "CompleteMultipartUpload",
-                "LifecycleDeletion",
-              ]),
-            ),
-            createdAt: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            description: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetBucketEventNotificationResponse>;
+export const GetBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketEventNotificationResponse>;
 
-export type GetBucketEventNotificationError = DefaultErrors;
+export type GetBucketEventNotificationError =
+  | DefaultErrors;
 
 export const getBucketEventNotification: API.OperationMethod<
   GetBucketEventNotificationRequest,
@@ -1459,102 +945,35 @@ export interface ListBucketEventNotificationsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketEventNotificationsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration",
-    }),
-  ) as unknown as Schema.Schema<ListBucketEventNotificationsRequest>;
+export const ListBucketEventNotificationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration" })) as unknown as Schema.Schema<ListBucketEventNotificationsRequest>;
 
 export interface ListBucketEventNotificationsResponse {
   /** Name of the bucket. */
   bucketName?: string | null;
   /** List of queues associated with the bucket. */
-  queues?:
-    | {
-        queueId?: string | null;
-        queueName?: string | null;
-        rules?:
-          | {
-              actions: (
-                | "PutObject"
-                | "CopyObject"
-                | "DeleteObject"
-                | "CompleteMultipartUpload"
-                | "LifecycleDeletion"
-              )[];
-              createdAt?: string | null;
-              description?: string | null;
-              prefix?: string | null;
-              ruleId?: string | null;
-              suffix?: string | null;
-            }[]
-          | null;
-      }[]
-    | null;
+  queues?: ({ queueId?: string | null; queueName?: string | null; rules?: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; createdAt?: string | null; description?: string | null; prefix?: string | null; ruleId?: string | null; suffix?: string | null })[] | null })[] | null;
 }
 
-export const ListBucketEventNotificationsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    queues: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            queueId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            queueName: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            rules: Schema.optional(
-              Schema.Union([
-                Schema.Array(
-                  Schema.Struct({
-                    actions: Schema.Array(
-                      Schema.Literals([
-                        "PutObject",
-                        "CopyObject",
-                        "DeleteObject",
-                        "CompleteMultipartUpload",
-                        "LifecycleDeletion",
-                      ]),
-                    ),
-                    createdAt: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    description: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    prefix: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    ruleId: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    suffix: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }),
-                ),
-                Schema.Null,
-              ]),
-            ),
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ListBucketEventNotificationsResponse>;
+export const ListBucketEventNotificationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  queues: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+    actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
+    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+  })), Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketEventNotificationsResponse>;
 
 export type ListBucketEventNotificationsError =
   | DefaultErrors
@@ -1571,12 +990,7 @@ export const listBucketEventNotifications: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: ListBucketEventNotificationsRequest,
   output: ListBucketEventNotificationsResponse,
-  errors: [
-    NoSuchBucket,
-    InvalidRoute,
-    NoEventNotificationConfig,
-    BucketNotFound,
-  ],
+  errors: [NoSuchBucket, InvalidRoute, NoEventNotificationConfig, BucketNotFound],
 }));
 
 export interface PutBucketEventNotificationRequest {
@@ -1587,59 +1001,29 @@ export interface PutBucketEventNotificationRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: Array of rules to drive notifications. */
-  rules: {
-    actions: (
-      | "PutObject"
-      | "CopyObject"
-      | "DeleteObject"
-      | "CompleteMultipartUpload"
-      | "LifecycleDeletion"
-    )[];
-    description?: string;
-    prefix?: string;
-    suffix?: string;
-  }[];
+  rules: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; description?: string; prefix?: string; suffix?: string })[];
 }
 
-export const PutBucketEventNotificationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    queueId: Schema.String.pipe(T.HttpPath("queueId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    rules: Schema.Array(
-      Schema.Struct({
-        actions: Schema.Array(
-          Schema.Literals([
-            "PutObject",
-            "CopyObject",
-            "DeleteObject",
-            "CompleteMultipartUpload",
-            "LifecycleDeletion",
-          ]),
-        ),
-        description: Schema.optional(Schema.String),
-        prefix: Schema.optional(Schema.String),
-        suffix: Schema.optional(Schema.String),
-      }),
-    ),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
-    }),
-  ) as unknown as Schema.Schema<PutBucketEventNotificationRequest>;
+export const PutBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  queueId: Schema.String.pipe(T.HttpPath("queueId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.Array(Schema.Struct({
+  actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
+  description: Schema.optional(Schema.String),
+  prefix: Schema.optional(Schema.String),
+  suffix: Schema.optional(Schema.String)
+}))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<PutBucketEventNotificationRequest>;
 
 export type PutBucketEventNotificationResponse = unknown;
 
-export const PutBucketEventNotificationResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketEventNotificationResponse>;
+export const PutBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketEventNotificationResponse>;
 
-export type PutBucketEventNotificationError = DefaultErrors;
+export type PutBucketEventNotificationError =
+  | DefaultErrors;
 
 export const putBucketEventNotification: API.OperationMethod<
   PutBucketEventNotificationRequest,
@@ -1661,29 +1045,20 @@ export interface DeleteBucketEventNotificationRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketEventNotificationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    queueId: Schema.String.pipe(T.HttpPath("queueId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "DELETE",
-      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
-    }),
-  ) as unknown as Schema.Schema<DeleteBucketEventNotificationRequest>;
+export const DeleteBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  queueId: Schema.String.pipe(T.HttpPath("queueId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<DeleteBucketEventNotificationRequest>;
 
 export type DeleteBucketEventNotificationResponse = unknown;
 
-export const DeleteBucketEventNotificationResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketEventNotificationResponse>;
+export const DeleteBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketEventNotificationResponse>;
 
-export type DeleteBucketEventNotificationError = DefaultErrors;
+export type DeleteBucketEventNotificationError =
+  | DefaultErrors;
 
 export const deleteBucketEventNotification: API.OperationMethod<
   DeleteBucketEventNotificationRequest,
@@ -1695,6 +1070,7 @@ export const deleteBucketEventNotification: API.OperationMethod<
   output: DeleteBucketEventNotificationResponse,
   errors: [],
 }));
+
 
 // =============================================================================
 // BucketLifecycle
@@ -1708,126 +1084,51 @@ export interface GetBucketLifecycleRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketLifecycleRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle",
-    }),
-  ) as unknown as Schema.Schema<GetBucketLifecycleRequest>;
+export const GetBucketLifecycleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle" })) as unknown as Schema.Schema<GetBucketLifecycleRequest>;
 
 export interface GetBucketLifecycleResponse {
-  rules?:
-    | {
-        id: string;
-        conditions: { prefix?: string | null };
-        enabled: boolean;
-        abortMultipartUploadsTransition?: {
-          condition?: { maxAge: number; type: "Age" } | null;
-        } | null;
-        deleteObjectsTransition?: {
-          condition?:
-            | { maxAge: number; type: "Age" }
-            | { date: string; type: "Date" }
-            | null;
-        } | null;
-        storageClassTransitions?:
-          | {
-              condition:
-                | { maxAge: number; type: "Age" }
-                | { date: string; type: "Date" };
-              storageClass: "InfrequentAccess";
-            }[]
-          | null;
-      }[]
-    | null;
+  rules?: ({ id: string; conditions: { prefix?: string | null }; enabled: boolean; abortMultipartUploadsTransition?: { condition?: { maxAge: number; type: "Age" } | null } | null; deleteObjectsTransition?: { condition?: { maxAge: number; type: "Age" } | { date: string; type: "Date" } | null } | null; storageClassTransitions?: ({ condition: { maxAge: number; type: "Age" } | { date: string; type: "Date" }; storageClass: "InfrequentAccess" })[] | null })[] | null;
 }
 
-export const GetBucketLifecycleResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    rules: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            id: Schema.String,
-            conditions: Schema.Struct({
-              prefix: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }),
-            enabled: Schema.Boolean,
-            abortMultipartUploadsTransition: Schema.optional(
-              Schema.Union([
-                Schema.Struct({
-                  condition: Schema.optional(
-                    Schema.Union([
-                      Schema.Struct({
-                        maxAge: Schema.Number,
-                        type: Schema.Literal("Age"),
-                      }),
-                      Schema.Null,
-                    ]),
-                  ),
-                }),
-                Schema.Null,
-              ]),
-            ),
-            deleteObjectsTransition: Schema.optional(
-              Schema.Union([
-                Schema.Struct({
-                  condition: Schema.optional(
-                    Schema.Union([
-                      Schema.Union([
-                        Schema.Struct({
-                          maxAge: Schema.Number,
-                          type: Schema.Literal("Age"),
-                        }),
-                        Schema.Struct({
-                          date: Schema.String,
-                          type: Schema.Literal("Date"),
-                        }),
-                      ]),
-                      Schema.Null,
-                    ]),
-                  ),
-                }),
-                Schema.Null,
-              ]),
-            ),
-            storageClassTransitions: Schema.optional(
-              Schema.Union([
-                Schema.Array(
-                  Schema.Struct({
-                    condition: Schema.Union([
-                      Schema.Struct({
-                        maxAge: Schema.Number,
-                        type: Schema.Literal("Age"),
-                      }),
-                      Schema.Struct({
-                        date: Schema.String,
-                        type: Schema.Literal("Date"),
-                      }),
-                    ]),
-                    storageClass: Schema.Literal("InfrequentAccess"),
-                  }),
-                ),
-                Schema.Null,
-              ]),
-            ),
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetBucketLifecycleResponse>;
+export const GetBucketLifecycleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  id: Schema.String,
+  conditions: Schema.Struct({
+    prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+  }),
+  enabled: Schema.Boolean,
+  abortMultipartUploadsTransition: Schema.optional(Schema.Union([Schema.Struct({
+    condition: Schema.optional(Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Null]))
+  }), Schema.Null])),
+  deleteObjectsTransition: Schema.optional(Schema.Union([Schema.Struct({
+    condition: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Struct({
+      date: Schema.String,
+      type: Schema.Literal("Date")
+    })]), Schema.Null]))
+  }), Schema.Null])),
+  storageClassTransitions: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+    condition: Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Struct({
+      date: Schema.String,
+      type: Schema.Literal("Date")
+    })]),
+    storageClass: Schema.Literal("InfrequentAccess")
+  })), Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketLifecycleResponse>;
 
 export type GetBucketLifecycleError =
   | DefaultErrors
@@ -1852,101 +1153,51 @@ export interface PutBucketLifecycleRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: {
-    id: string;
-    conditions: { prefix: string };
-    enabled: boolean;
-    abortMultipartUploadsTransition?: {
-      condition?: { maxAge: number; type: "Age" };
-    };
-    deleteObjectsTransition?: {
-      condition?:
-        | { maxAge: number; type: "Age" }
-        | { date: string; type: "Date" };
-    };
-    storageClassTransitions?: {
-      condition:
-        | { maxAge: number; type: "Age" }
-        | { date: string; type: "Date" };
-      storageClass: "InfrequentAccess";
-    }[];
-  }[];
+  rules?: ({ id: string; conditions: { prefix: string }; enabled: boolean; abortMultipartUploadsTransition?: { condition?: { maxAge: number; type: "Age" } }; deleteObjectsTransition?: { condition?: { maxAge: number; type: "Age" } | { date: string; type: "Date" } }; storageClassTransitions?: ({ condition: { maxAge: number; type: "Age" } | { date: string; type: "Date" }; storageClass: "InfrequentAccess" })[] })[];
 }
 
-export const PutBucketLifecycleRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    rules: Schema.optional(
-      Schema.Array(
-        Schema.Struct({
-          id: Schema.String,
-          conditions: Schema.Struct({
-            prefix: Schema.String,
-          }),
-          enabled: Schema.Boolean,
-          abortMultipartUploadsTransition: Schema.optional(
-            Schema.Struct({
-              condition: Schema.optional(
-                Schema.Struct({
-                  maxAge: Schema.Number,
-                  type: Schema.Literal("Age"),
-                }),
-              ),
-            }),
-          ),
-          deleteObjectsTransition: Schema.optional(
-            Schema.Struct({
-              condition: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    maxAge: Schema.Number,
-                    type: Schema.Literal("Age"),
-                  }),
-                  Schema.Struct({
-                    date: Schema.String,
-                    type: Schema.Literal("Date"),
-                  }),
-                ]),
-              ),
-            }),
-          ),
-          storageClassTransitions: Schema.optional(
-            Schema.Array(
-              Schema.Struct({
-                condition: Schema.Union([
-                  Schema.Struct({
-                    maxAge: Schema.Number,
-                    type: Schema.Literal("Age"),
-                  }),
-                  Schema.Struct({
-                    date: Schema.String,
-                    type: Schema.Literal("Date"),
-                  }),
-                ]),
-                storageClass: Schema.Literal("InfrequentAccess"),
-              }),
-            ),
-          ),
-        }),
-      ),
-    ),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle",
-    }),
-  ) as unknown as Schema.Schema<PutBucketLifecycleRequest>;
+export const PutBucketLifecycleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.optional(Schema.Array(Schema.Struct({
+  id: Schema.String,
+  conditions: Schema.Struct({
+    prefix: Schema.String
+  }),
+  enabled: Schema.Boolean,
+  abortMultipartUploadsTransition: Schema.optional(Schema.Struct({
+    condition: Schema.optional(Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }))
+  })),
+  deleteObjectsTransition: Schema.optional(Schema.Struct({
+    condition: Schema.optional(Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Struct({
+      date: Schema.String,
+      type: Schema.Literal("Date")
+    })]))
+  })),
+  storageClassTransitions: Schema.optional(Schema.Array(Schema.Struct({
+    condition: Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Struct({
+      date: Schema.String,
+      type: Schema.Literal("Date")
+    })]),
+    storageClass: Schema.Literal("InfrequentAccess")
+  })))
+})))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle" })) as unknown as Schema.Schema<PutBucketLifecycleRequest>;
 
 export type PutBucketLifecycleResponse = unknown;
 
-export const PutBucketLifecycleResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketLifecycleResponse>;
+export const PutBucketLifecycleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketLifecycleResponse>;
 
 export type PutBucketLifecycleError =
   | DefaultErrors
@@ -1964,6 +1215,7 @@ export const putBucketLifecycle: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
+
 // =============================================================================
 // BucketLock
 // =============================================================================
@@ -1979,61 +1231,35 @@ export interface GetBucketLockRequest {
 export const GetBucketLockRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock",
-  }),
-) as unknown as Schema.Schema<GetBucketLockRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock" })) as unknown as Schema.Schema<GetBucketLockRequest>;
 
 export interface GetBucketLockResponse {
-  rules?:
-    | {
-        id: string;
-        condition:
-          | { maxAgeSeconds: number; type: "Age" }
-          | { date: string; type: "Date" }
-          | { type: "Indefinite" };
-        enabled: boolean;
-        prefix?: string | null;
-      }[]
-    | null;
+  rules?: ({ id: string; condition: { maxAgeSeconds: number; type: "Age" } | { date: string; type: "Date" } | { type: "Indefinite" }; enabled: boolean; prefix?: string | null })[] | null;
 }
 
 export const GetBucketLockResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rules: Schema.optional(
-    Schema.Union([
-      Schema.Array(
-        Schema.Struct({
-          id: Schema.String,
-          condition: Schema.Union([
-            Schema.Struct({
-              maxAgeSeconds: Schema.Number,
-              type: Schema.Literal("Age"),
-            }),
-            Schema.Struct({
-              date: Schema.String,
-              type: Schema.Literal("Date"),
-            }),
-            Schema.Struct({
-              type: Schema.Literal("Indefinite"),
-            }),
-          ]),
-          enabled: Schema.Boolean,
-          prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-      ),
-      Schema.Null,
-    ]),
-  ),
-}).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<GetBucketLockResponse>;
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  id: Schema.String,
+  condition: Schema.Union([Schema.Struct({
+    maxAgeSeconds: Schema.Number,
+    type: Schema.Literal("Age")
+  }), Schema.Struct({
+    date: Schema.String,
+    type: Schema.Literal("Date")
+  }), Schema.Struct({
+    type: Schema.Literal("Indefinite")
+  })]),
+  enabled: Schema.Boolean,
+  prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketLockResponse>;
 
-export type GetBucketLockError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type GetBucketLockError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const getBucketLock: API.OperationMethod<
   GetBucketLockRequest,
@@ -2053,60 +1279,38 @@ export interface PutBucketLockRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: {
-    id: string;
-    condition:
-      | { maxAgeSeconds: number; type: "Age" }
-      | { date: string; type: "Date" }
-      | { type: "Indefinite" };
-    enabled: boolean;
-    prefix?: string;
-  }[];
+  rules?: ({ id: string; condition: { maxAgeSeconds: number; type: "Age" } | { date: string; type: "Date" } | { type: "Indefinite" }; enabled: boolean; prefix?: string })[];
 }
 
 export const PutBucketLockRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  rules: Schema.optional(
-    Schema.Array(
-      Schema.Struct({
-        id: Schema.String,
-        condition: Schema.Union([
-          Schema.Struct({
-            maxAgeSeconds: Schema.Number,
-            type: Schema.Literal("Age"),
-          }),
-          Schema.Struct({
-            date: Schema.String,
-            type: Schema.Literal("Date"),
-          }),
-          Schema.Struct({
-            type: Schema.Literal("Indefinite"),
-          }),
-        ]),
-        enabled: Schema.Boolean,
-        prefix: Schema.optional(Schema.String),
-      }),
-    ),
-  ),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock",
-  }),
-) as unknown as Schema.Schema<PutBucketLockRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.optional(Schema.Array(Schema.Struct({
+  id: Schema.String,
+  condition: Schema.Union([Schema.Struct({
+    maxAgeSeconds: Schema.Number,
+    type: Schema.Literal("Age")
+  }), Schema.Struct({
+    date: Schema.String,
+    type: Schema.Literal("Date")
+  }), Schema.Struct({
+    type: Schema.Literal("Indefinite")
+  })]),
+  enabled: Schema.Boolean,
+  prefix: Schema.optional(Schema.String)
+})))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock" })) as unknown as Schema.Schema<PutBucketLockRequest>;
 
 export type PutBucketLockResponse = unknown;
 
-export const PutBucketLockResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketLockResponse>;
+export const PutBucketLockResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketLockResponse>;
 
-export type PutBucketLockError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type PutBucketLockError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const putBucketLock: API.OperationMethod<
   PutBucketLockRequest,
@@ -2119,6 +1323,7 @@ export const putBucketLock: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
+
 // =============================================================================
 // BucketMetric
 // =============================================================================
@@ -2128,127 +1333,48 @@ export interface ListBucketMetricsRequest {
   accountId: string;
 }
 
-export const ListBucketMetricsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({ method: "GET", path: "/accounts/{account_id}/r2/metrics" }),
-  ) as unknown as Schema.Schema<ListBucketMetricsRequest>;
+export const ListBucketMetricsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/metrics" })) as unknown as Schema.Schema<ListBucketMetricsRequest>;
 
 export interface ListBucketMetricsResponse {
   /** Metrics based on what state they are in(uploaded or published). */
-  infrequentAccess?: {
-    published?: {
-      metadataSize?: number | null;
-      objects?: number | null;
-      payloadSize?: number | null;
-    } | null;
-    uploaded?: {
-      metadataSize?: number | null;
-      objects?: number | null;
-      payloadSize?: number | null;
-    } | null;
-  } | null;
+  infrequentAccess?: { published?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null; uploaded?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null } | null;
   /** Metrics based on what state they are in(uploaded or published). */
-  standard?: {
-    published?: {
-      metadataSize?: number | null;
-      objects?: number | null;
-      payloadSize?: number | null;
-    } | null;
-    uploaded?: {
-      metadataSize?: number | null;
-      objects?: number | null;
-      payloadSize?: number | null;
-    } | null;
-  } | null;
+  standard?: { published?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null; uploaded?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null } | null;
 }
 
-export const ListBucketMetricsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    infrequentAccess: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          published: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                metadataSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                objects: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                payloadSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-          uploaded: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                metadataSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                objects: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                payloadSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-    standard: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          published: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                metadataSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                objects: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                payloadSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-          uploaded: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                metadataSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                objects: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                payloadSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ListBucketMetricsResponse>;
+export const ListBucketMetricsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  infrequentAccess: Schema.optional(Schema.Union([Schema.Struct({
+  published: Schema.optional(Schema.Union([Schema.Struct({
+    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+  }), Schema.Null])),
+  uploaded: Schema.optional(Schema.Union([Schema.Struct({
+    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+  }), Schema.Null]))
+}), Schema.Null])),
+  standard: Schema.optional(Schema.Union([Schema.Struct({
+  published: Schema.optional(Schema.Union([Schema.Struct({
+    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+  }), Schema.Null])),
+  uploaded: Schema.optional(Schema.Union([Schema.Struct({
+    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+  }), Schema.Null]))
+}), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketMetricsResponse>;
 
-export type ListBucketMetricsError = DefaultErrors | InvalidRoute;
+export type ListBucketMetricsError =
+  | DefaultErrors
+  | InvalidRoute;
 
 export const listBucketMetrics: API.OperationMethod<
   ListBucketMetricsRequest,
@@ -2260,6 +1386,7 @@ export const listBucketMetrics: API.OperationMethod<
   output: ListBucketMetricsResponse,
   errors: [InvalidRoute],
 }));
+
 
 // =============================================================================
 // BucketSippy
@@ -2276,74 +1403,39 @@ export interface GetBucketSippyRequest {
 export const GetBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
-  }),
-) as unknown as Schema.Schema<GetBucketSippyRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<GetBucketSippyRequest>;
 
 export interface GetBucketSippyResponse {
   /** Details about the configured destination bucket. */
-  destination?: {
-    accessKeyId?: string | null;
-    account?: string | null;
-    bucket?: string | null;
-    provider?: "r2" | null;
-  } | null;
+  destination?: { accessKeyId?: string | null; account?: string | null; bucket?: string | null; provider?: "r2" | null } | null;
   /** State of Sippy for this bucket. */
   enabled?: boolean | null;
   /** Details about the configured source bucket. */
-  source?: {
-    bucket?: string | null;
-    bucketUrl?: string | null;
-    provider?: "aws" | "gcs" | "s3" | null;
-    region?: string | null;
-  } | null;
+  source?: { bucket?: string | null; bucketUrl?: string | null; provider?: "aws" | "gcs" | "s3" | null; region?: string | null } | null;
 }
 
-export const GetBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    destination: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          accessKeyId: Schema.optional(
-            Schema.Union([SensitiveString, Schema.Null]),
-          ),
-          account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          provider: Schema.optional(
-            Schema.Union([Schema.Literal("r2"), Schema.Null]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    source: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          bucketUrl: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          provider: Schema.optional(
-            Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null]),
-          ),
-          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  },
-).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<GetBucketSippyResponse>;
+export const GetBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  destination: Schema.optional(Schema.Union([Schema.Struct({
+  accessKeyId: Schema.optional(Schema.Union([SensitiveString, Schema.Null])),
+  account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  provider: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+}), Schema.Null])),
+  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  source: Schema.optional(Schema.Union([Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  bucketUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  provider: Schema.optional(Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null])),
+  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketSippyResponse>;
 
-export type GetBucketSippyError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type GetBucketSippyError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const getBucketSippy: API.OperationMethod<
   GetBucketSippyRequest,
@@ -2363,108 +1455,57 @@ export interface PutBucketSippyRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: R2 bucket to copy objects to. */
-  destination?: {
-    accessKeyId?: string;
-    provider?: "r2";
-    secretAccessKey?: string;
-  };
+  destination?: { accessKeyId?: string; provider?: "r2"; secretAccessKey?: string };
   /** Body param: AWS S3 bucket to copy objects from. */
-  source?: {
-    accessKeyId?: string;
-    bucket?: string;
-    provider?: "aws";
-    region?: string;
-    secretAccessKey?: string;
-  };
+  source?: { accessKeyId?: string; bucket?: string; provider?: "aws"; region?: string; secretAccessKey?: string };
 }
 
 export const PutBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  destination: Schema.optional(
-    Schema.Struct({
-      accessKeyId: Schema.optional(SensitiveString),
-      provider: Schema.optional(Schema.Literal("r2")),
-      secretAccessKey: Schema.optional(SensitiveString),
-    }),
-  ),
-  source: Schema.optional(
-    Schema.Struct({
-      accessKeyId: Schema.optional(SensitiveString),
-      bucket: Schema.optional(Schema.String),
-      provider: Schema.optional(Schema.Literal("aws")),
-      region: Schema.optional(Schema.String),
-      secretAccessKey: Schema.optional(SensitiveString),
-    }),
-  ),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
-  }),
-) as unknown as Schema.Schema<PutBucketSippyRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  destination: Schema.optional(Schema.Struct({
+  accessKeyId: Schema.optional(SensitiveString),
+  provider: Schema.optional(Schema.Literal("r2")),
+  secretAccessKey: Schema.optional(SensitiveString)
+})),
+  source: Schema.optional(Schema.Struct({
+  accessKeyId: Schema.optional(SensitiveString),
+  bucket: Schema.optional(Schema.String),
+  provider: Schema.optional(Schema.Literal("aws")),
+  region: Schema.optional(Schema.String),
+  secretAccessKey: Schema.optional(SensitiveString)
+}))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<PutBucketSippyRequest>;
 
 export interface PutBucketSippyResponse {
   /** Details about the configured destination bucket. */
-  destination?: {
-    accessKeyId?: string | null;
-    account?: string | null;
-    bucket?: string | null;
-    provider?: "r2" | null;
-  } | null;
+  destination?: { accessKeyId?: string | null; account?: string | null; bucket?: string | null; provider?: "r2" | null } | null;
   /** State of Sippy for this bucket. */
   enabled?: boolean | null;
   /** Details about the configured source bucket. */
-  source?: {
-    bucket?: string | null;
-    bucketUrl?: string | null;
-    provider?: "aws" | "gcs" | "s3" | null;
-    region?: string | null;
-  } | null;
+  source?: { bucket?: string | null; bucketUrl?: string | null; provider?: "aws" | "gcs" | "s3" | null; region?: string | null } | null;
 }
 
-export const PutBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    destination: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          accessKeyId: Schema.optional(
-            Schema.Union([SensitiveString, Schema.Null]),
-          ),
-          account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          provider: Schema.optional(
-            Schema.Union([Schema.Literal("r2"), Schema.Null]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    source: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          bucketUrl: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          provider: Schema.optional(
-            Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null]),
-          ),
-          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  },
-).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<PutBucketSippyResponse>;
+export const PutBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  destination: Schema.optional(Schema.Union([Schema.Struct({
+  accessKeyId: Schema.optional(Schema.Union([SensitiveString, Schema.Null])),
+  account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  provider: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+}), Schema.Null])),
+  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  source: Schema.optional(Schema.Union([Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  bucketUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  provider: Schema.optional(Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null])),
+  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketSippyResponse>;
 
-export type PutBucketSippyError = DefaultErrors;
+export type PutBucketSippyError =
+  | DefaultErrors;
 
 export const putBucketSippy: API.OperationMethod<
   PutBucketSippyRequest,
@@ -2485,32 +1526,20 @@ export interface DeleteBucketSippyRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketSippyRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "DELETE",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
-    }),
-  ) as unknown as Schema.Schema<DeleteBucketSippyRequest>;
+export const DeleteBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<DeleteBucketSippyRequest>;
 
 export interface DeleteBucketSippyResponse {
   enabled?: false | null;
 }
 
-export const DeleteBucketSippyResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    enabled: Schema.optional(
-      Schema.Union([Schema.Literal(false), Schema.Null]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketSippyResponse>;
+export const DeleteBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  enabled: Schema.optional(Schema.Union([Schema.Literal(false), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketSippyResponse>;
 
 export type DeleteBucketSippyError =
   | DefaultErrors
@@ -2528,12 +1557,121 @@ export const deleteBucketSippy: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
+
 // =============================================================================
 // Object
 // =============================================================================
 
-export interface DeleteObjectRequest {
+export interface GetObjectRequest {
+  /** Name of the R2 bucket. */
   bucketName: string;
+  /** Key (name) of the object. */
+  objectName: string;
+  /** Account ID. */
+  accountId: string;
+  /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
+  cfR2Jurisdiction?: "default" | "eu" | "fedramp";
+}
+
+export const GetObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  objectName: Schema.String.pipe(T.HttpPath("objectName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}" })) as unknown as Schema.Schema<GetObjectRequest>;
+
+export type GetObjectResponse = File | Blob;
+
+export const GetObjectResponse = /*@__PURE__*/ /*#__PURE__*/ UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetObjectResponse>;
+
+export type GetObjectError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute
+  | NoRoute;
+
+export const getObject: API.OperationMethod<
+  GetObjectRequest,
+  GetObjectResponse,
+  GetObjectError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetObjectRequest,
+  output: GetObjectResponse,
+  errors: [NoSuchBucket, InvalidRoute, NoRoute],
+}));
+
+export interface PutObjectRequest {
+  /** Name of the R2 bucket. */
+  bucketName: string;
+  /** Key (name) of the object. */
+  objectName: string;
+  /** Account ID. */
+  accountId: string;
+  /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
+  cfR2Jurisdiction?: "default" | "eu" | "fedramp";
+  /** MIME type of the object. */
+  contentType?: string;
+  /** Content disposition of the object. */
+  contentDisposition?: string;
+  /** Content encoding of the object. */
+  contentEncoding?: string;
+  /** Content language of the object. */
+  contentLanguage?: string;
+  /** Content length of the object in bytes. */
+  contentLength?: string;
+  /** Cache control directives for the object. */
+  cacheControl?: string;
+  /** Expiration date of the object. */
+  expires?: string;
+  /** Storage class for the object. */
+  cfR2StorageClass?: "Standard" | "InfrequentAccess";
+  body: File | Blob;
+}
+
+export const PutObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  objectName: Schema.String.pipe(T.HttpPath("objectName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  contentType: Schema.optional(Schema.String).pipe(T.HttpHeader("content-type")),
+  contentDisposition: Schema.optional(Schema.String).pipe(T.HttpHeader("content-disposition")),
+  contentEncoding: Schema.optional(Schema.String).pipe(T.HttpHeader("content-encoding")),
+  contentLanguage: Schema.optional(Schema.String).pipe(T.HttpHeader("content-language")),
+  contentLength: Schema.optional(Schema.String).pipe(T.HttpHeader("content-length")),
+  cacheControl: Schema.optional(Schema.String).pipe(T.HttpHeader("cache-control")),
+  expires: Schema.optional(Schema.String).pipe(T.HttpHeader("expires")),
+  cfR2StorageClass: Schema.optional(Schema.Literals(["Standard", "InfrequentAccess"])).pipe(T.HttpHeader("cf-r2-storage-class")),
+  body: UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.HttpBody())
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}", contentType: "multipart" })) as unknown as Schema.Schema<PutObjectRequest>;
+
+export type PutObjectResponse = unknown;
+
+export const PutObjectResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutObjectResponse>;
+
+export type PutObjectError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute
+  | NoRoute;
+
+export const putObject: API.OperationMethod<
+  PutObjectRequest,
+  PutObjectResponse,
+  PutObjectError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: PutObjectRequest,
+  output: PutObjectResponse,
+  errors: [NoSuchBucket, InvalidRoute, NoRoute],
+}));
+
+export interface DeleteObjectRequest {
+  /** Name of the R2 bucket. */
+  bucketName: string;
+  /** Key (name) of the object. */
   objectName: string;
   /** Account ID. */
   accountId: string;
@@ -2545,22 +1683,13 @@ export const DeleteObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   objectName: Schema.String.pipe(T.HttpPath("objectName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  cfR2Jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "DELETE",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}",
-  }),
-) as unknown as Schema.Schema<DeleteObjectRequest>;
+  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}" })) as unknown as Schema.Schema<DeleteObjectRequest>;
 
 export type DeleteObjectResponse = unknown;
 
-export const DeleteObjectResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteObjectResponse>;
+export const DeleteObjectResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteObjectResponse>;
 
 export type DeleteObjectError =
   | DefaultErrors
@@ -2578,6 +1707,7 @@ export const deleteObject: API.OperationMethod<
   output: DeleteObjectResponse,
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
 }));
+
 
 // =============================================================================
 // SuperSlurperConnectivityPrecheck
@@ -2600,39 +1730,30 @@ export interface SourceSuperSlurperConnectivityPrecheckRequest {
   region?: string | null;
 }
 
-export const SourceSuperSlurperConnectivityPrecheckRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    bucket: Schema.String,
-    secret: Schema.Struct({
-      accessKeyId: SensitiveString,
-      secretAccessKey: SensitiveString,
-    }),
-    vendor: Schema.Literal("s3"),
-    endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/source/connectivity-precheck",
-    }),
-  ) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckRequest>;
+export const SourceSuperSlurperConnectivityPrecheckRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  bucket: Schema.String,
+  secret: Schema.Struct({
+  accessKeyId: SensitiveString,
+  secretAccessKey: SensitiveString
+}),
+  vendor: Schema.Literal("s3"),
+  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/source/connectivity-precheck" })) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckRequest>;
 
 export interface SourceSuperSlurperConnectivityPrecheckResponse {
   connectivityStatus?: "success" | "error" | null;
 }
 
-export const SourceSuperSlurperConnectivityPrecheckResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    connectivityStatus: Schema.optional(
-      Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckResponse>;
+export const SourceSuperSlurperConnectivityPrecheckResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  connectivityStatus: Schema.optional(Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckResponse>;
 
-export type SourceSuperSlurperConnectivityPrecheckError = DefaultErrors;
+export type SourceSuperSlurperConnectivityPrecheckError =
+  | DefaultErrors;
 
 export const sourceSuperSlurperConnectivityPrecheck: API.OperationMethod<
   SourceSuperSlurperConnectivityPrecheckRequest,
@@ -2658,39 +1779,28 @@ export interface TargetSuperSlurperConnectivityPrecheckRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const TargetSuperSlurperConnectivityPrecheckRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    bucket: Schema.String,
-    secret: Schema.Struct({
-      accessKeyId: SensitiveString,
-      secretAccessKey: SensitiveString,
-    }),
-    vendor: Schema.Literal("r2"),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/target/connectivity-precheck",
-    }),
-  ) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckRequest>;
+export const TargetSuperSlurperConnectivityPrecheckRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  bucket: Schema.String,
+  secret: Schema.Struct({
+  accessKeyId: SensitiveString,
+  secretAccessKey: SensitiveString
+}),
+  vendor: Schema.Literal("r2"),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"]))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/target/connectivity-precheck" })) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckRequest>;
 
 export interface TargetSuperSlurperConnectivityPrecheckResponse {
   connectivityStatus?: "success" | "error" | null;
 }
 
-export const TargetSuperSlurperConnectivityPrecheckResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    connectivityStatus: Schema.optional(
-      Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckResponse>;
+export const TargetSuperSlurperConnectivityPrecheckResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  connectivityStatus: Schema.optional(Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckResponse>;
 
-export type TargetSuperSlurperConnectivityPrecheckError = DefaultErrors;
+export type TargetSuperSlurperConnectivityPrecheckError =
+  | DefaultErrors;
 
 export const targetSuperSlurperConnectivityPrecheck: API.OperationMethod<
   TargetSuperSlurperConnectivityPrecheckRequest,
@@ -2703,6 +1813,7 @@ export const targetSuperSlurperConnectivityPrecheck: API.OperationMethod<
   errors: [],
 }));
 
+
 // =============================================================================
 // SuperSlurperJob
 // =============================================================================
@@ -2712,138 +1823,55 @@ export interface GetSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const GetSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}",
-    }),
-  ) as unknown as Schema.Schema<GetSuperSlurperJobRequest>;
+export const GetSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}" })) as unknown as Schema.Schema<GetSuperSlurperJobRequest>;
 
 export interface GetSuperSlurperJobResponse {
   id?: string | null;
   createdAt?: string | null;
   finishedAt?: string | null;
   overwrite?: boolean | null;
-  source?:
-    | {
-        bucket?: string | null;
-        endpoint?: string | null;
-        keys?: string[] | null;
-        pathPrefix?: string | null;
-        vendor?: "s3" | null;
-      }
-    | {
-        bucket?: string | null;
-        keys?: string[] | null;
-        pathPrefix?: string | null;
-        vendor?: "gcs" | null;
-      }
-    | {
-        bucket?: string | null;
-        jurisdiction?: "default" | "eu" | "fedramp" | null;
-        keys?: string[] | null;
-        pathPrefix?: string | null;
-        vendor?: "r2" | null;
-      }
-    | null;
+  source?: { bucket?: string | null; endpoint?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "s3" | null } | { bucket?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "gcs" | null } | { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "r2" | null } | null;
   status?: "running" | "paused" | "aborted" | "completed" | null;
-  target?: {
-    bucket?: string | null;
-    jurisdiction?: "default" | "eu" | "fedramp" | null;
-    vendor?: "r2" | null;
-  } | null;
+  target?: { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; vendor?: "r2" | null } | null;
 }
 
-export const GetSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    source: Schema.optional(
-      Schema.Union([
-        Schema.Union([
-          Schema.Struct({
-            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            endpoint: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            keys: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            pathPrefix: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            vendor: Schema.optional(
-              Schema.Union([Schema.Literal("s3"), Schema.Null]),
-            ),
-          }),
-          Schema.Struct({
-            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            keys: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            pathPrefix: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            vendor: Schema.optional(
-              Schema.Union([Schema.Literal("gcs"), Schema.Null]),
-            ),
-          }),
-          Schema.Struct({
-            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            jurisdiction: Schema.optional(
-              Schema.Union([
-                Schema.Literals(["default", "eu", "fedramp"]),
-                Schema.Null,
-              ]),
-            ),
-            keys: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            pathPrefix: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            vendor: Schema.optional(
-              Schema.Union([Schema.Literal("r2"), Schema.Null]),
-            ),
-          }),
-        ]),
-        Schema.Null,
-      ]),
-    ),
-    status: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["running", "paused", "aborted", "completed"]),
-        Schema.Null,
-      ]),
-    ),
-    target: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          jurisdiction: Schema.optional(
-            Schema.Union([
-              Schema.Literals(["default", "eu", "fedramp"]),
-              Schema.Null,
-            ]),
-          ),
-          vendor: Schema.optional(
-            Schema.Union([Schema.Literal("r2"), Schema.Null]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetSuperSlurperJobResponse>;
+export const GetSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  source: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  vendor: Schema.optional(Schema.Union([Schema.Literal("s3"), Schema.Null]))
+}), Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  vendor: Schema.optional(Schema.Union([Schema.Literal("gcs"), Schema.Null]))
+}), Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+})]), Schema.Null])),
+  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
+  target: Schema.optional(Schema.Union([Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+}), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetSuperSlurperJobResponse>;
 
-export type GetSuperSlurperJobError = DefaultErrors;
+export type GetSuperSlurperJobError =
+  | DefaultErrors;
 
 export const getSuperSlurperJob: API.OperationMethod<
   GetSuperSlurperJobRequest,
@@ -2865,148 +1893,52 @@ export interface ListSuperSlurperJobsRequest {
   offset?: number;
 }
 
-export const ListSuperSlurperJobsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
-    offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset")),
-  }).pipe(
-    T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs" }),
-  ) as unknown as Schema.Schema<ListSuperSlurperJobsRequest>;
+export const ListSuperSlurperJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
+  offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs" })) as unknown as Schema.Schema<ListSuperSlurperJobsRequest>;
 
 export interface ListSuperSlurperJobsResponse {
-  result: {
-    id?: string | null;
-    createdAt?: string | null;
-    finishedAt?: string | null;
-    overwrite?: boolean | null;
-    source?:
-      | {
-          bucket?: string | null;
-          endpoint?: string | null;
-          keys?: string[] | null;
-          pathPrefix?: string | null;
-          vendor?: "s3" | null;
-        }
-      | {
-          bucket?: string | null;
-          keys?: string[] | null;
-          pathPrefix?: string | null;
-          vendor?: "gcs" | null;
-        }
-      | {
-          bucket?: string | null;
-          jurisdiction?: "default" | "eu" | "fedramp" | null;
-          keys?: string[] | null;
-          pathPrefix?: string | null;
-          vendor?: "r2" | null;
-        }
-      | null;
-    status?: "running" | "paused" | "aborted" | "completed" | null;
-    target?: {
-      bucket?: string | null;
-      jurisdiction?: "default" | "eu" | "fedramp" | null;
-      vendor?: "r2" | null;
-    } | null;
-  }[];
+  result: ({ id?: string | null; createdAt?: string | null; finishedAt?: string | null; overwrite?: boolean | null; source?: { bucket?: string | null; endpoint?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "s3" | null } | { bucket?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "gcs" | null } | { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "r2" | null } | null; status?: "running" | "paused" | "aborted" | "completed" | null; target?: { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; vendor?: "r2" | null } | null })[];
 }
 
-export const ListSuperSlurperJobsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    result: Schema.Array(
-      Schema.Struct({
-        id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-        source: Schema.optional(
-          Schema.Union([
-            Schema.Union([
-              Schema.Struct({
-                bucket: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                endpoint: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                keys: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                pathPrefix: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                vendor: Schema.optional(
-                  Schema.Union([Schema.Literal("s3"), Schema.Null]),
-                ),
-              }),
-              Schema.Struct({
-                bucket: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                keys: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                pathPrefix: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                vendor: Schema.optional(
-                  Schema.Union([Schema.Literal("gcs"), Schema.Null]),
-                ),
-              }),
-              Schema.Struct({
-                bucket: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                jurisdiction: Schema.optional(
-                  Schema.Union([
-                    Schema.Literals(["default", "eu", "fedramp"]),
-                    Schema.Null,
-                  ]),
-                ),
-                keys: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                pathPrefix: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                vendor: Schema.optional(
-                  Schema.Union([Schema.Literal("r2"), Schema.Null]),
-                ),
-              }),
-            ]),
-            Schema.Null,
-          ]),
-        ),
-        status: Schema.optional(
-          Schema.Union([
-            Schema.Literals(["running", "paused", "aborted", "completed"]),
-            Schema.Null,
-          ]),
-        ),
-        target: Schema.optional(
-          Schema.Union([
-            Schema.Struct({
-              bucket: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              jurisdiction: Schema.optional(
-                Schema.Union([
-                  Schema.Literals(["default", "eu", "fedramp"]),
-                  Schema.Null,
-                ]),
-              ),
-              vendor: Schema.optional(
-                Schema.Union([Schema.Literal("r2"), Schema.Null]),
-              ),
-            }),
-            Schema.Null,
-          ]),
-        ),
-      }),
-    ),
-  }) as unknown as Schema.Schema<ListSuperSlurperJobsResponse>;
+export const ListSuperSlurperJobsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  result: Schema.Array(Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  source: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
+    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    vendor: Schema.optional(Schema.Union([Schema.Literal("s3"), Schema.Null]))
+  }), Schema.Struct({
+    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    vendor: Schema.optional(Schema.Union([Schema.Literal("gcs"), Schema.Null]))
+  }), Schema.Struct({
+    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+  })]), Schema.Null])),
+  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
+  target: Schema.optional(Schema.Union([Schema.Struct({
+    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+    vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+  }), Schema.Null]))
+}))
+}) as unknown as Schema.Schema<ListSuperSlurperJobsResponse>;
 
-export type ListSuperSlurperJobsError = DefaultErrors;
+export type ListSuperSlurperJobsError =
+  | DefaultErrors;
 
 export const listSuperSlurperJobs: API.PaginatedOperationMethod<
   ListSuperSlurperJobsRequest,
@@ -3029,112 +1961,64 @@ export interface CreateSuperSlurperJobRequest {
   /** Body param: */
   overwrite?: boolean;
   /** Body param: */
-  source?:
-    | {
-        bucket: string;
-        secret: { accessKeyId: string; secretAccessKey: string };
-        vendor: "s3";
-        endpoint?: string | null;
-        pathPrefix?: string | null;
-        region?: string | null;
-      }
-    | {
-        bucket: string;
-        secret: { clientEmail: string; privateKey: string };
-        vendor: "gcs";
-        pathPrefix?: string | null;
-      }
-    | {
-        bucket: string;
-        secret: { accessKeyId: string; secretAccessKey: string };
-        vendor: "r2";
-        jurisdiction?: "default" | "eu" | "fedramp";
-        pathPrefix?: string | null;
-      };
+  source?: { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "s3"; endpoint?: string | null; pathPrefix?: string | null; region?: string | null } | { bucket: string; secret: { clientEmail: string; privateKey: string }; vendor: "gcs"; pathPrefix?: string | null } | { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "r2"; jurisdiction?: "default" | "eu" | "fedramp"; pathPrefix?: string | null };
   /** Body param: */
-  target?: {
-    bucket: string;
-    secret: { accessKeyId: string; secretAccessKey: string };
-    vendor: "r2";
-    jurisdiction?: "default" | "eu" | "fedramp";
-  };
+  target?: { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "r2"; jurisdiction?: "default" | "eu" | "fedramp" };
 }
 
-export const CreateSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    overwrite: Schema.optional(Schema.Boolean),
-    source: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          bucket: Schema.String,
-          secret: Schema.Struct({
-            accessKeyId: SensitiveString,
-            secretAccessKey: SensitiveString,
-          }),
-          vendor: Schema.Literal("s3"),
-          endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          pathPrefix: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Struct({
-          bucket: Schema.String,
-          secret: Schema.Struct({
-            clientEmail: Schema.String,
-            privateKey: SensitiveString,
-          }),
-          vendor: Schema.Literal("gcs"),
-          pathPrefix: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }),
-        Schema.Struct({
-          bucket: Schema.String,
-          secret: Schema.Struct({
-            accessKeyId: SensitiveString,
-            secretAccessKey: SensitiveString,
-          }),
-          vendor: Schema.Literal("r2"),
-          jurisdiction: Schema.optional(
-            Schema.Literals(["default", "eu", "fedramp"]),
-          ),
-          pathPrefix: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }),
-      ]),
-    ),
-    target: Schema.optional(
-      Schema.Struct({
-        bucket: Schema.String,
-        secret: Schema.Struct({
-          accessKeyId: SensitiveString,
-          secretAccessKey: SensitiveString,
-        }),
-        vendor: Schema.Literal("r2"),
-        jurisdiction: Schema.optional(
-          Schema.Literals(["default", "eu", "fedramp"]),
-        ),
-      }),
-    ),
-  }).pipe(
-    T.Http({ method: "POST", path: "/accounts/{account_id}/slurper/jobs" }),
-  ) as unknown as Schema.Schema<CreateSuperSlurperJobRequest>;
+export const CreateSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  overwrite: Schema.optional(Schema.Boolean),
+  source: Schema.optional(Schema.Union([Schema.Struct({
+  bucket: Schema.String,
+  secret: Schema.Struct({
+    accessKeyId: SensitiveString,
+    secretAccessKey: SensitiveString
+  }),
+  vendor: Schema.Literal("s3"),
+  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}), Schema.Struct({
+  bucket: Schema.String,
+  secret: Schema.Struct({
+    clientEmail: Schema.String,
+    privateKey: SensitiveString
+  }),
+  vendor: Schema.Literal("gcs"),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}), Schema.Struct({
+  bucket: Schema.String,
+  secret: Schema.Struct({
+    accessKeyId: SensitiveString,
+    secretAccessKey: SensitiveString
+  }),
+  vendor: Schema.Literal("r2"),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})])),
+  target: Schema.optional(Schema.Struct({
+  bucket: Schema.String,
+  secret: Schema.Struct({
+    accessKeyId: SensitiveString,
+    secretAccessKey: SensitiveString
+  }),
+  vendor: Schema.Literal("r2"),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"]))
+}))
+})
+  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/slurper/jobs" })) as unknown as Schema.Schema<CreateSuperSlurperJobRequest>;
 
 export interface CreateSuperSlurperJobResponse {
   id?: string | null;
 }
 
-export const CreateSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<CreateSuperSlurperJobResponse>;
+export const CreateSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateSuperSlurperJobResponse>;
 
-export type CreateSuperSlurperJobError = DefaultErrors;
+export type CreateSuperSlurperJobError =
+  | DefaultErrors;
 
 export const createSuperSlurperJob: API.OperationMethod<
   CreateSuperSlurperJobRequest,
@@ -3152,25 +2036,18 @@ export interface AbortSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const AbortSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/abort",
-    }),
-  ) as unknown as Schema.Schema<AbortSuperSlurperJobRequest>;
+export const AbortSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/abort" })) as unknown as Schema.Schema<AbortSuperSlurperJobRequest>;
 
 export type AbortSuperSlurperJobResponse = string;
 
-export const AbortSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<AbortSuperSlurperJobResponse>;
+export const AbortSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<AbortSuperSlurperJobResponse>;
 
-export type AbortSuperSlurperJobError = DefaultErrors;
+export type AbortSuperSlurperJobError =
+  | DefaultErrors;
 
 export const abortSuperSlurperJob: API.OperationMethod<
   AbortSuperSlurperJobRequest,
@@ -3188,25 +2065,18 @@ export interface PauseSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const PauseSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/pause",
-    }),
-  ) as unknown as Schema.Schema<PauseSuperSlurperJobRequest>;
+export const PauseSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/pause" })) as unknown as Schema.Schema<PauseSuperSlurperJobRequest>;
 
 export type PauseSuperSlurperJobResponse = string;
 
-export const PauseSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PauseSuperSlurperJobResponse>;
+export const PauseSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PauseSuperSlurperJobResponse>;
 
-export type PauseSuperSlurperJobError = DefaultErrors;
+export type PauseSuperSlurperJobError =
+  | DefaultErrors;
 
 export const pauseSuperSlurperJob: API.OperationMethod<
   PauseSuperSlurperJobRequest,
@@ -3224,16 +2094,11 @@ export interface ProgressSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const ProgressSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/progress",
-    }),
-  ) as unknown as Schema.Schema<ProgressSuperSlurperJobRequest>;
+export const ProgressSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}/progress" })) as unknown as Schema.Schema<ProgressSuperSlurperJobRequest>;
 
 export interface ProgressSuperSlurperJobResponse {
   id?: string | null;
@@ -3245,27 +2110,18 @@ export interface ProgressSuperSlurperJobResponse {
   transferredObjects?: number | null;
 }
 
-export const ProgressSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    failedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    skippedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    status: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["running", "paused", "aborted", "completed"]),
-        Schema.Null,
-      ]),
-    ),
-    transferredObjects: Schema.optional(
-      Schema.Union([Schema.Number, Schema.Null]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ProgressSuperSlurperJobResponse>;
+export const ProgressSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  failedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  skippedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
+  transferredObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ProgressSuperSlurperJobResponse>;
 
-export type ProgressSuperSlurperJobError = DefaultErrors;
+export type ProgressSuperSlurperJobError =
+  | DefaultErrors;
 
 export const progressSuperSlurperJob: API.OperationMethod<
   ProgressSuperSlurperJobRequest,
@@ -3283,25 +2139,18 @@ export interface ResumeSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const ResumeSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/resume",
-    }),
-  ) as unknown as Schema.Schema<ResumeSuperSlurperJobRequest>;
+export const ResumeSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/resume" })) as unknown as Schema.Schema<ResumeSuperSlurperJobRequest>;
 
 export type ResumeSuperSlurperJobResponse = string;
 
-export const ResumeSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ResumeSuperSlurperJobResponse>;
+export const ResumeSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ResumeSuperSlurperJobResponse>;
 
-export type ResumeSuperSlurperJobError = DefaultErrors;
+export type ResumeSuperSlurperJobError =
+  | DefaultErrors;
 
 export const resumeSuperSlurperJob: API.OperationMethod<
   ResumeSuperSlurperJobRequest,
@@ -3313,6 +2162,7 @@ export const resumeSuperSlurperJob: API.OperationMethod<
   output: ResumeSuperSlurperJobResponse,
   errors: [],
 }));
+
 
 // =============================================================================
 // SuperSlurperJobLog
@@ -3328,80 +2178,30 @@ export interface ListSuperSlurperJobLogsRequest {
   offset?: number;
 }
 
-export const ListSuperSlurperJobLogsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
-    offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/logs",
-    }),
-  ) as unknown as Schema.Schema<ListSuperSlurperJobLogsRequest>;
+export const ListSuperSlurperJobLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
+  offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}/logs" })) as unknown as Schema.Schema<ListSuperSlurperJobLogsRequest>;
 
 export interface ListSuperSlurperJobLogsResponse {
-  result: {
-    createdAt?: string | null;
-    job?: string | null;
-    logType?:
-      | "migrationStart"
-      | "migrationComplete"
-      | "migrationAbort"
-      | "migrationError"
-      | "migrationPause"
-      | "migrationResume"
-      | "migrationErrorFailedContinuation"
-      | "importErrorRetryExhaustion"
-      | "importSkippedStorageClass"
-      | "importSkippedOversized"
-      | "importSkippedEmptyObject"
-      | "importSkippedUnsupportedContentType"
-      | "importSkippedExcludedContentType"
-      | "importSkippedInvalidMedia"
-      | "importSkippedRequiresRetrieval"
-      | null;
-    message?: string | null;
-    objectKey?: string | null;
-  }[];
+  result: ({ createdAt?: string | null; job?: string | null; logType?: "migrationStart" | "migrationComplete" | "migrationAbort" | "migrationError" | "migrationPause" | "migrationResume" | "migrationErrorFailedContinuation" | "importErrorRetryExhaustion" | "importSkippedStorageClass" | "importSkippedOversized" | "importSkippedEmptyObject" | "importSkippedUnsupportedContentType" | "importSkippedExcludedContentType" | "importSkippedInvalidMedia" | "importSkippedRequiresRetrieval" | null; message?: string | null; objectKey?: string | null })[];
 }
 
-export const ListSuperSlurperJobLogsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    result: Schema.Array(
-      Schema.Struct({
-        createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        job: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        logType: Schema.optional(
-          Schema.Union([
-            Schema.Literals([
-              "migrationStart",
-              "migrationComplete",
-              "migrationAbort",
-              "migrationError",
-              "migrationPause",
-              "migrationResume",
-              "migrationErrorFailedContinuation",
-              "importErrorRetryExhaustion",
-              "importSkippedStorageClass",
-              "importSkippedOversized",
-              "importSkippedEmptyObject",
-              "importSkippedUnsupportedContentType",
-              "importSkippedExcludedContentType",
-              "importSkippedInvalidMedia",
-              "importSkippedRequiresRetrieval",
-            ]),
-            Schema.Null,
-          ]),
-        ),
-        message: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        objectKey: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      }),
-    ),
-  }) as unknown as Schema.Schema<ListSuperSlurperJobLogsResponse>;
+export const ListSuperSlurperJobLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  result: Schema.Array(Schema.Struct({
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  job: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  logType: Schema.optional(Schema.Union([Schema.Literals(["migrationStart", "migrationComplete", "migrationAbort", "migrationError", "migrationPause", "migrationResume", "migrationErrorFailedContinuation", "importErrorRetryExhaustion", "importSkippedStorageClass", "importSkippedOversized", "importSkippedEmptyObject", "importSkippedUnsupportedContentType", "importSkippedExcludedContentType", "importSkippedInvalidMedia", "importSkippedRequiresRetrieval"]), Schema.Null])),
+  message: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  objectKey: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}))
+}) as unknown as Schema.Schema<ListSuperSlurperJobLogsResponse>;
 
-export type ListSuperSlurperJobLogsError = DefaultErrors;
+export type ListSuperSlurperJobLogsError =
+  | DefaultErrors;
 
 export const listSuperSlurperJobLogs: API.PaginatedOperationMethod<
   ListSuperSlurperJobLogsRequest,
@@ -3418,6 +2218,7 @@ export const listSuperSlurperJobLogs: API.PaginatedOperationMethod<
   } as const,
 }));
 
+
 // =============================================================================
 // TemporaryCredential
 // =============================================================================
@@ -3430,11 +2231,7 @@ export interface CreateTemporaryCredentialRequest {
   /** Body param: The parent access key id to use for signing. */
   parentAccessKeyId: string;
   /** Body param: Permissions allowed on the credentials. */
-  permission:
-    | "admin-read-write"
-    | "admin-read-only"
-    | "object-read-write"
-    | "object-read-only";
+  permission: "admin-read-write" | "admin-read-only" | "object-read-write" | "object-read-only";
   /** Body param: How long the credentials will live for in seconds. */
   ttlSeconds: number;
   /** Body param: Optional object paths to scope the credentials to. */
@@ -3443,26 +2240,16 @@ export interface CreateTemporaryCredentialRequest {
   prefixes?: string[];
 }
 
-export const CreateTemporaryCredentialRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    bucket: Schema.String,
-    parentAccessKeyId: Schema.String,
-    permission: Schema.Literals([
-      "admin-read-write",
-      "admin-read-only",
-      "object-read-write",
-      "object-read-only",
-    ]),
-    ttlSeconds: Schema.Number,
-    objects: Schema.optional(Schema.Array(Schema.String)),
-    prefixes: Schema.optional(Schema.Array(Schema.String)),
-  }).pipe(
-    T.Http({
-      method: "POST",
-      path: "/accounts/{account_id}/r2/temp-access-credentials",
-    }),
-  ) as unknown as Schema.Schema<CreateTemporaryCredentialRequest>;
+export const CreateTemporaryCredentialRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  bucket: Schema.String,
+  parentAccessKeyId: Schema.String,
+  permission: Schema.Literals(["admin-read-write", "admin-read-only", "object-read-write", "object-read-only"]),
+  ttlSeconds: Schema.Number,
+  objects: Schema.optional(Schema.Array(Schema.String)),
+  prefixes: Schema.optional(Schema.Array(Schema.String))
+})
+  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/temp-access-credentials" })) as unknown as Schema.Schema<CreateTemporaryCredentialRequest>;
 
 export interface CreateTemporaryCredentialResponse {
   /** ID for new access key. */
@@ -3473,18 +2260,14 @@ export interface CreateTemporaryCredentialResponse {
   sessionToken?: string | null;
 }
 
-export const CreateTemporaryCredentialResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accessKeyId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    secretAccessKey: Schema.optional(
-      Schema.Union([Schema.String, Schema.Null]),
-    ),
-    sessionToken: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<CreateTemporaryCredentialResponse>;
+export const CreateTemporaryCredentialResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accessKeyId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  secretAccessKey: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  sessionToken: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateTemporaryCredentialResponse>;
 
-export type CreateTemporaryCredentialError = DefaultErrors;
+export type CreateTemporaryCredentialError =
+  | DefaultErrors;
 
 export const createTemporaryCredential: API.OperationMethod<
   CreateTemporaryCredentialRequest,


### PR DESCRIPTION
## Summary
- Add `getObject`, `putObject`, and `deleteObject` operations for R2 buckets
- Implemented via patch OpenAPI spec (`specs/cloudflare-patch/r2-object.openapi.yml`) since these endpoints aren't exposed in the upstream Cloudflare TypeScript SDK
- `putObject` supports all standard HTTP headers (content-type, cache-control, etc.) plus `cf-r2-storage-class`
- All operations support optional `cf-r2-jurisdiction` header

## Test plan
- [ ] Verify `deleteObject` works against a live R2 bucket
- [ ] Verify `putObject` uploads an object successfully
- [ ] Verify `getObject` downloads an object successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)