### PR TITLE
feat(ci): pass with no tests across every package + scaffold

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -71,7 +71,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/api-models-aws && git -C specs/api-models-aws checkout -- . && git submodule update --force --init --recursive --depth=1 specs/aws-sdk-js-v3 && git -C specs/aws-sdk-js-v3 checkout -- . && git submodule update --force --init --recursive --depth=1 specs/smithy && git -C specs/smithy checkout -- . && git submodule update --force --init --recursive --depth=1 specs/smithy-typescript && git -C specs/smithy-typescript checkout -- .",

--- a/packages/axiom/package.json
+++ b/packages/axiom/package.json
@@ -71,7 +71,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test",
+    "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/docs && git -C specs/docs checkout -- .",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -66,7 +66,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/azure-rest-api-specs && git -C specs/azure-rest-api-specs checkout -- .",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -56,7 +56,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "vitest run --exclude specs",
+    "test": "vitest run --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/cloudflare-typescript && git -C specs/cloudflare-typescript checkout -- .",

--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -66,7 +66,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/cdp-sdk && git -C specs/cdp-sdk checkout -- .",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public"
   },
   "dependencies": {

--- a/packages/fly-io/package.json
+++ b/packages/fly-io/package.json
@@ -67,7 +67,7 @@
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-fly-io && git -C specs/distilled-spec-fly-io checkout -- .",

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -50,7 +50,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-gcp && git -C specs/distilled-spec-gcp checkout -- .",

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -67,7 +67,7 @@
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/kubernetes && git -C specs/kubernetes checkout -- .",

--- a/packages/mongodb-atlas/package.json
+++ b/packages/mongodb-atlas/package.json
@@ -67,7 +67,7 @@
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-mongodb-atlas && git -C specs/distilled-spec-mongodb-atlas checkout -- .",

--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -67,7 +67,7 @@
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-neon && git -C specs/distilled-spec-neon checkout -- .",

--- a/packages/planetscale/package.json
+++ b/packages/planetscale/package.json
@@ -66,7 +66,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-planetscale && git -C specs/distilled-spec-planetscale checkout -- .",

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -66,7 +66,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test",
+    "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-posthog && git -C specs/distilled-spec-posthog checkout -- .",

--- a/packages/prisma-postgres/package.json
+++ b/packages/prisma-postgres/package.json
@@ -67,7 +67,7 @@
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-prisma-postgres && git -C specs/distilled-spec-prisma-postgres checkout -- .",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -67,7 +67,7 @@
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/stripe-openapi && git -C specs/stripe-openapi checkout -- .",

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -67,7 +67,7 @@
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-supabase && git -C specs/distilled-spec-supabase checkout -- .",

--- a/packages/turso/package.json
+++ b/packages/turso/package.json
@@ -67,7 +67,7 @@
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
-    "test": "bunx vitest run test --exclude specs",
+    "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/turso-docs && git -C specs/turso-docs checkout -- .",

--- a/packages/typesense/package.json
+++ b/packages/typesense/package.json
@@ -66,7 +66,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test",
+    "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/typesense-api-spec && git -C specs/typesense-api-spec checkout -- .",

--- a/packages/workos/package.json
+++ b/packages/workos/package.json
@@ -66,7 +66,7 @@
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
     "check": "tsgo && oxlint src && oxfmt --check src",
-    "test": "bunx vitest run test",
+    "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/openapi-spec && git -C specs/openapi-spec checkout -- .",

--- a/scripts/create-sdk.ts
+++ b/scripts/create-sdk.ts
@@ -959,7 +959,7 @@ const scaffoldPackage = (
               fmt: "oxfmt --write src",
               lint: "oxlint --fix src",
               check: "tsgo && oxlint src && oxfmt --check src",
-              test: "bunx vitest run test",
+              test: "bunx vitest run test --passWithNoTests",
               "publish:npm": "bun run build && bun publish --access public",
               generate:
                 "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",


### PR DESCRIPTION
Add `--passWithNoTests` to every package's vitest `test` script so a `bun run test` succeeds when an SDK has its CI test step wired up but no `*.test.ts` files exist yet — this caught `ci-neon`, which currently ships only `tests/setup.ts`. Mirror the flag in the `create-sdk` template so newly scaffolded SDKs inherit the same behaviour out of the box.