### PR TITLE
fix(posthog): declare @effect/platform-node + @effect/vitest devDeps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -250,6 +250,8 @@
         "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-node": "catalog:",
+        "@effect/vitest": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "dotenv": "catalog:",

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -77,6 +77,8 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/platform-node": "catalog:",
+    "@effect/vitest": "catalog:",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "dotenv": "catalog:",


### PR DESCRIPTION
\`packages/posthog/test/test.ts\` imports \`NodeServices\` from \`@effect/platform-node\` and helpers from \`@effect/vitest\`, but neither dep was declared. Local runs resolved them transitively through the workspace; CI couldn't find them and the suite blew up at module resolution before any test ran. Add both to devDependencies (catalog:) so the suite runs cleanly in CI.