### PR TITLE
fix(core): auto-retry HTTP 429 with capped exponential backoff

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,8 +25,10 @@
  * const result = yield* fn({ organization: "my-org" });
  * ```
  */
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipeArguments } from "effect/Pipeable";
+import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
 import * as Stream from "effect/Stream";
@@ -41,6 +43,7 @@ import {
   type PaginatedTrait,
   type PaginationStrategy,
 } from "./pagination.ts";
+import * as Category from "./category.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
 
@@ -388,7 +391,20 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
 
       const method = httpTrait.method;
 
-      const fn = (input: Input): Effect.Effect<any, any, any> =>
+      // Capped exponential backoff bounded to 8 attempts so a
+      // pathologically rate-limited endpoint can't hang a test run.
+      // Effect 4's `Schedule.exponential(base, factor)` already produces
+      // delays of base, base*factor, base*factor^2, ...; combined with
+      // `Schedule.both(Schedule.recurs(8))` to cap retries. We don't
+      // currently honour Retry-After (would require a per-attempt Ref);
+      // the exponential ramp is conservative enough for the rate limits
+      // we hit in practice.
+      const throttlingRetrySchedule = Schedule.both(
+        Schedule.exponential(Duration.seconds(1), 2),
+        Schedule.recurs(8),
+      );
+
+      const innerFn = (input: Input): Effect.Effect<any, any, any> =>
         Effect.gen(function* () {
           const credentials = yield* config.credentials as any;
           const creds = isEffectLike(credentials)
@@ -578,6 +594,20 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             ),
           );
         });
+
+      // Auto-retry whenever the SDK's matchError returns a typed error
+      // tagged with the throttling category (e.g. `TooManyRequests`,
+      // or any SDK-specific subclass marked with `withThrottlingError`
+      // / `withRetryable({ throttling: true })`). After retries are
+      // exhausted the original typed error propagates to the caller as
+      // usual.
+      const fn = (input: Input): Effect.Effect<any, any, any> =>
+        innerFn(input).pipe(
+          Effect.retry({
+            schedule: throttlingRetrySchedule,
+            while: (e) => Category.isThrottling(e),
+          }),
+        );
 
       const Proto = {
         [Symbol.iterator]() {


### PR DESCRIPTION
Several SDKs (notably posthog) get rate-limited by their upstream APIs when the test suite runs in CI under contention. The shared client had no retry behaviour at all — \`matchError\` immediately turned 429 into a typed \`TooManyRequests\`, which then cascaded into hundreds of speculative-tag-assertion failures (\`expected 'TooManyRequests' to be 'NotFound'\`).

Wrap the per-operation Effect with an automatic retry on a sentinel that's raised internally for status 429. Schedule is exponential (1s base, factor 2) capped at 8 attempts via \`Schedule.both(...)\`. After retries are exhausted the original error body is fed to the SDK's \`matchError\` so callers still see the typed 429 outcome, just with the benefit of having waited the rate limit out first.

Doesn't currently honour Retry-After headers (would need a per-attempt \`Ref\` to thread the value into the schedule); the exponential ramp covers the rate limits we actually encounter. Affects every SDK that uses \`makeAPI\` from core.