### PR TITLE
fix(core): unwrap Redacted values during request input encoding

### DIFF
--- a/packages/core/src/traits.ts
+++ b/packages/core/src/traits.ts
@@ -19,6 +19,7 @@
  * );
  * ```
  */
+import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
 
@@ -475,13 +476,49 @@ export interface RequestParts {
  * schema's encoding pipeline (e.g., `encodeKeys` for camelCase → snake_case mapping).
  * The encoded output is used for body construction, ensuring wire-format key names.
  */
+/**
+ * Recursively unwrap any `Redacted<T>` values in a structure into their
+ * underlying `T`.
+ *
+ * Sensitive response fields surface to callers as `Redacted<string>` (so
+ * they don't accidentally land in logs). Those same values often need to be
+ * passed straight back into a follow-up request — e.g. WorkOS's password
+ * reset flow returns a redacted `password_reset_token` whose shape is
+ * `Redacted<string>` and which is then sent into `ResetPassword({ token })`,
+ * where `token` is declared as plain `Schema.String`. Without this unwrap
+ * the input encoder sees a `Redacted` (whose toString is `"<redacted>"`)
+ * and rejects the value with `Expected string, got <redacted>`.
+ *
+ * Doing the unwrap right before `Schema.encodeSync` keeps the contract
+ * simple: callers can hand a `Redacted` to any field and the wire payload
+ * still contains the underlying value. Schemas that *want* a `Redacted` on
+ * the wire (i.e. `SensitiveString`) handle it through their own encode
+ * transform, so they're unaffected — by the time encodeSync sees the value
+ * it's already a plain string, which is what the wire format wants anyway.
+ */
+const unwrapRedactedDeep = (value: unknown): unknown => {
+  if (Redacted.isRedacted(value)) return Redacted.value(value);
+  if (Array.isArray(value)) return value.map(unwrapRedactedDeep);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = unwrapRedactedDeep(v);
+    }
+    return out;
+  }
+  return value;
+};
+
 export const buildRequestParts = (
   ast: AST.AST,
   httpTrait: HttpTrait,
-  input: Record<string, unknown>,
+  rawInput: Record<string, unknown>,
   // biome-ignore lint: using any for generic schema parameter
   inputSchema?: any,
 ): RequestParts => {
+  // Unwrap any `Redacted<T>` values in the input up front so the schema
+  // encoder never sees them. See `unwrapRedactedDeep` for rationale.
+  const input = unwrapRedactedDeep(rawInput) as Record<string, unknown>;
   let path = httpTrait.path;
   const query: Record<string, string | string[]> = {};
   const headers: Record<string, string> = {};


### PR DESCRIPTION
Sensitive response fields surface as `Redacted<string>` so they don't land in logs by accident. Those same values are sometimes the input to a follow-up request — WorkOS's password reset flow returns a redacted `password_reset_token` whose type is `Redacted<string>`, then the caller hands it straight into `UserlandUsersControllerResetPassword({ token })` where `token` is declared as plain `Schema.String`.

Pre-fix the encoder saw the `Redacted`, ran its toString into the schema parser, and bailed with `Expected string, got <redacted>` — the test never even reached the wire.

Walk the input one pass before `Schema.encodeSync` and convert every `Redacted<T>` to its underlying `T` (recursively, into arrays and nested objects). Sensitive-marked fields are unaffected: by the time their schema's encode transform runs the value is already the plain underlying type, which is what the wire wants anyway.

```ts
// Before:
ResetPassword({ token: tokenResult.token.password_reset_token })
//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//                     Redacted<string> — encoder rejected this with
//                     `Expected string, got <redacted>`.

// After: same call site works, plain underlying string is what hits the wire.
```

Spotted while triaging the workos suite (#212 follow-up); noted in #211 as one of the parse-failures the strip-required patch couldn't fix.