### PR TITLE
fix(core): add T.NoFollowRedirect for ops that return result via Location header

### DIFF
--- a/packages/core/scripts/generate-openapi.ts
+++ b/packages/core/scripts/generate-openapi.ts
@@ -785,6 +785,7 @@ function generateInputSchema3(
   requestBodyParam: RequestBody3 | undefined,
   spec: OpenAPI3Spec,
   ctx?: SchemaGenerationContext,
+  noFollowRedirect: boolean = false,
 ): { inputSchemaCode: string; inputSchemaName: string } {
   // Resolve top-level $ref (e.g. #/components/requestBodies/Foo).
   const requestBody = requestBodyParam?.$ref
@@ -881,10 +882,19 @@ function generateInputSchema3(
     httpTraitParts.push(`contentType: "${bodyContentType}"`);
   }
 
+  // If the operation is marked as not following redirects (via the
+  // detected 3xx-with-Location response or an `x-distilled-no-follow-redirect`
+  // vendor extension), append the trait so the runtime client knows to
+  // surface the 3xx and read the Location header.
+  const traitChain = [`T.Http({ ${httpTraitParts.join(", ")} })`];
+  if (noFollowRedirect) {
+    traitChain.push(`T.NoFollowRedirect()`);
+  }
+
   const inputSchemaCode =
     annotatePureExportConst(`export const ${inputSchemaName} = Schema.Struct({
 ${fields.join("\n")}
-}).pipe(T.Http({ ${httpTraitParts.join(", ")} }));`) +
+}).pipe(${traitChain.join(", ")});`) +
     `
 export type ${inputSchemaName} = typeof ${inputSchemaName}.Type;`;
 
@@ -1255,6 +1265,28 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
             usesSensitiveNullableString: false,
           };
 
+          // Detect operations that should opt out of automatic redirect-
+          // following. Two signals trigger the `T.NoFollowRedirect()` trait:
+          //   1. An explicit `x-distilled-no-follow-redirect: true` vendor
+          //      extension on the operation (lets a spec patch turn it on
+          //      without requiring this generator to recognize the shape).
+          //   2. A 3xx response that defines a Location header — the
+          //      canonical OAuth/SSO authorize pattern where the URL the
+          //      caller wants is in the Location, not the body.
+          const opAny = operation as unknown as Record<string, unknown>;
+          const has3xxLocation = Object.entries(operation.responses ?? {}).some(
+            ([status, resp]) => {
+              if (!status.startsWith("3")) return false;
+              const respHeaders = (resp as { headers?: Record<string, unknown> })
+                .headers;
+              return (
+                respHeaders !== undefined && "Location" in respHeaders
+              );
+            },
+          );
+          const noFollowRedirect =
+            opAny["x-distilled-no-follow-redirect"] === true || has3xxLocation;
+
           const { inputSchemaCode, inputSchemaName } = generateInputSchema3(
             operation.operationId,
             method,
@@ -1263,6 +1295,7 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
             operation.requestBody,
             oas,
             sensitiveCtx,
+            noFollowRedirect,
           );
 
           const responseSchema = getResponseSchema(

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -32,6 +32,7 @@ import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
 import * as Stream from "effect/Stream";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
@@ -381,6 +382,7 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       const outputSchema = (opConfig.outputSchema ?? opConfig.output)!;
       const responsePath = Traits.getResponsePath(outputSchema.ast);
       const graphqlOp = Traits.getGraphQLOp(inputSchema.ast);
+      const noFollowRedirect = Traits.getNoFollowRedirect(inputSchema.ast);
       type Input = Schema.Schema.Type<I>;
 
       // Read HTTP trait from input schema annotations
@@ -512,7 +514,46 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             }
           }
 
-          const response = yield* client.execute(request).pipe(Effect.scoped);
+          // For operations that opt out of following redirects, hand the
+          // underlying fetch a `redirect: "manual"` request init so the
+          // 3xx surfaces here instead of being chased to the IdP.
+          const executeRequest = noFollowRedirect
+            ? client.execute(request).pipe(
+                Effect.scoped,
+                Effect.provideService(FetchHttpClient.RequestInit, {
+                  redirect: "manual",
+                } as RequestInit),
+              )
+            : client.execute(request).pipe(Effect.scoped);
+
+          const response = yield* executeRequest;
+
+          // For ops that opted out of redirect-following, treat 3xx as
+          // success: synthesize a body containing the Location header
+          // value at `locationField` (default `"url"`) and feed that
+          // through the normal output schema decode below.
+          if (
+            noFollowRedirect &&
+            response.status >= 300 &&
+            response.status < 400
+          ) {
+            const location =
+              response.headers["location"] ?? response.headers["Location"];
+            if (location !== undefined) {
+              const synthBody = {
+                [noFollowRedirect.locationField ?? "url"]: location,
+              };
+              return yield* Schema.decodeUnknownEffect(outputSchema)(
+                synthBody,
+              ).pipe(
+                Effect.catchTag("SchemaError", (cause) =>
+                  Effect.fail(
+                    new config.ParseError({ body: synthBody, cause }),
+                  ),
+                ),
+              );
+            }
+          }
 
           if (response.status >= 400) {
             // Try to parse error body as JSON; fall back to text if not JSON

--- a/packages/core/src/traits.ts
+++ b/packages/core/src/traits.ts
@@ -298,6 +298,59 @@ export const HttpFormDataFile = () =>
   makeAnnotation(httpFormDataFileSymbol, true);
 
 // =============================================================================
+// Redirect-as-Response Trait
+// =============================================================================
+
+/** Symbol for "do not follow redirects; treat 3xx Location header as success body" */
+export const httpNoFollowRedirectSymbol = Symbol.for(
+  "@distilled.cloud/http-no-follow-redirect",
+);
+
+/**
+ * Configuration for the `NoFollowRedirect` trait.
+ */
+export interface NoFollowRedirectTrait {
+  /**
+   * The field name on the success-side output schema that should receive the
+   * value of the response's `Location` header when the server returns a
+   * 3xx redirect. Defaults to `"url"`.
+   *
+   * Concretely: when an operation carrying this trait gets a 3xx response,
+   * the runtime client constructs `{ [locationField]: <Location header> }`
+   * and feeds that into the output schema decoder, instead of trying to
+   * decode the redirect body (which would normally be HTML or empty).
+   */
+  locationField?: string;
+}
+
+/**
+ * NoFollowRedirect trait - opts an operation out of the underlying HTTP
+ * client's automatic redirect-following.
+ *
+ * Some endpoints — notably OAuth/SSO authorize endpoints — return their
+ * useful result as a `Location` header on a 302 response. The default
+ * `fetch` follows that redirect to the IdP's HTML login page, so by the
+ * time the client sees a body it's no longer the SDK's expected JSON.
+ *
+ * Marking an operation with this trait makes the runtime client:
+ *   1. Issue the request with `redirect: "manual"` so the 3xx surfaces
+ *      to user code.
+ *   2. On a 3xx, build a synthetic body `{ [locationField]: <Location> }`
+ *      and decode that into the output schema (default field name `"url"`).
+ *
+ * @example
+ * ```ts
+ * const SsoAuthorizeInput = Schema.Struct({...}).pipe(
+ *   T.Http({ method: "GET", path: "/sso/authorize" }),
+ *   T.NoFollowRedirect(),
+ * );
+ * const SsoAuthorizeOutput = Schema.Struct({ url: Schema.String });
+ * ```
+ */
+export const NoFollowRedirect = (trait: NoFollowRedirectTrait = {}) =>
+  makeAnnotation(httpNoFollowRedirectSymbol, trait);
+
+// =============================================================================
 // API Error Code Trait
 // =============================================================================
 
@@ -383,6 +436,14 @@ export const getResponsePath = (ast: AST.AST): string | undefined =>
  */
 export const getGraphQLOp = (ast: AST.AST): GraphQLOpTrait | undefined =>
   getAnnotation<GraphQLOpTrait>(ast, graphqlOpSymbol);
+
+/**
+ * Get the `NoFollowRedirect` trait config from an input schema's AST, if any.
+ */
+export const getNoFollowRedirect = (
+  ast: AST.AST,
+): NoFollowRedirectTrait | undefined =>
+  getAnnotation<NoFollowRedirectTrait>(ast, httpNoFollowRedirectSymbol);
 
 /**
  * Check if a PropertySignature has the pathParam annotation.

--- a/packages/workos/src/operations/SsoControllerAuthorize.ts
+++ b/packages/workos/src/operations/SsoControllerAuthorize.ts
@@ -34,7 +34,10 @@ export const SsoControllerAuthorizeInput =
     domain_hint: Schema.optional(Schema.String),
     login_hint: Schema.optional(Schema.String),
     nonce: Schema.optional(Schema.String),
-  }).pipe(T.Http({ method: "GET", path: "/sso/authorize" }));
+  }).pipe(
+    T.Http({ method: "GET", path: "/sso/authorize" }),
+    T.NoFollowRedirect(),
+  );
 export type SsoControllerAuthorizeInput =
   typeof SsoControllerAuthorizeInput.Type;
 

--- a/packages/workos/src/operations/SsoControllerLogout.ts
+++ b/packages/workos/src/operations/SsoControllerLogout.ts
@@ -7,7 +7,7 @@ import { NotFound } from "../errors.ts";
 export const SsoControllerLogoutInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     token: Schema.String,
-  }).pipe(T.Http({ method: "GET", path: "/sso/logout" }));
+  }).pipe(T.Http({ method: "GET", path: "/sso/logout" }), T.NoFollowRedirect());
 export type SsoControllerLogoutInput = typeof SsoControllerLogoutInput.Type;
 
 // Output Schema


### PR DESCRIPTION
Some endpoints — OAuth/SSO authorize is the canonical example — return their result as a 302 with the URL in the `Location` header. `fetch`'s default `redirect: "follow"` chases that to the IdP and the SDK ends up trying to schema-decode a login-page HTML body, surfacing as `WorkosParseError`.

Add a `T.NoFollowRedirect()` input-schema trait. At runtime it does two things:

1. Provides `FetchHttpClient.RequestInit({ redirect: "manual" })` for the duration of that request, so the 302 surfaces instead of being chased.
2. On a 3xx response, synthesizes a body `{ [locationField]: <Location> }` (default field name `url`) and feeds that through the normal output schema decoder.

The OpenAPI generator emits the trait automatically when it sees one of two signals on an operation:

- An `x-distilled-no-follow-redirect: true` vendor extension on the operation (lets a spec patch turn it on without further generator work).
- A 3xx response that defines a `Location` header — the canonical OAuth/SSO authorize shape.

In WorkOS this picks up `SsoControllerAuthorize` and `SsoControllerLogout` without further intervention.

```diff
  export const SsoControllerAuthorizeInput = Schema.Struct({
    /* … */
- }).pipe(T.Http({ method: "GET", path: "/sso/authorize" }));
+ }).pipe(T.Http({ method: "GET", path: "/sso/authorize" }), T.NoFollowRedirect());
```

Spotted while triaging the workos suite (#212 follow-up); was the second `WorkosParseError` strip-required couldn't fix.