### PR TITLE
chore(release): brand Discord release notification as Distilled

### DIFF
--- a/scripts/discord-notify.ts
+++ b/scripts/discord-notify.ts
@@ -72,9 +72,10 @@ const res = await fetch(webhook, {
   method: "POST",
   headers: { "content-type": "application/json" },
   body: JSON.stringify({
+    username: "Distilled Releases",
     embeds: [
       {
-        title: `${tag} (${channel}) released`,
+        title: `Distilled ${tag} (${channel}) released`,
         url: releaseUrl,
         description,
       },


### PR DESCRIPTION
Distilled and Alchemy releases currently post to Discord from the same `Alchemy Releases` webhook with identical-looking titles (`vX.Y.Z (release) released`), making them indistinguishable in the feed.

- Override the webhook `username` to `Distilled Releases` so the bot name in the channel reads correctly.
- Prefix the embed title with `Distilled` so even without the username override the message identifies its source: `Distilled v0.15.0 (release) released`.

```diff
   body: JSON.stringify({
+    username: "Distilled Releases",
     embeds: [
       {
-        title: `${tag} (${channel}) released`,
+        title: `Distilled ${tag} (${channel}) released`,
         url: releaseUrl,
```

— claude