### PR TITLE
fix(core): preserve File/Blob/builtins in unwrapRedactedDeep

### DIFF
--- a/packages/core/src/traits.ts
+++ b/packages/core/src/traits.ts
@@ -606,6 +606,14 @@ const unwrapRedactedDeep = (value: unknown): unknown => {
   if (Redacted.isRedacted(value)) return Redacted.value(value);
   if (Array.isArray(value)) return value.map(unwrapRedactedDeep);
   if (value !== null && typeof value === "object") {
+    // Only walk into plain objects. Builtins like File, Blob, FormData,
+    // ArrayBuffer, TypedArrays, Map/Set, Date, Streams, etc. don't contain
+    // Redacted values and would be destroyed by Object.entries() — `new
+    // File([], "x")` has no own enumerable keys, so a recursive copy returns
+    // `{}` and the schema encoder later rejects the empty object with
+    // "Expected File, got {}". Preserve any non-plain object as-is.
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== null && proto !== Object.prototype) return value;
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
       out[k] = unwrapRedactedDeep(v);

--- a/packages/core/test/redacted-encoding.test.ts
+++ b/packages/core/test/redacted-encoding.test.ts
@@ -115,6 +115,30 @@ describe("buildRequestParts — Redacted unwrap", () => {
     expect(parts.body).toEqual({ tokens: ["a", "b", "c"] });
   });
 
+  it("preserves File/Blob instances (don't recursively walk builtins)", () => {
+    // Regression for cloudflare workers.test.ts: walking File/Blob with
+    // Object.entries() returns {} (no own enumerable keys) and the schema
+    // encoder then rejects with "Expected File, got {}".
+    const Input = Schema.Struct({
+      // Schema.Any so encodeSync passes the object through unchanged.
+      file: Schema.Any,
+      blob: Schema.Any,
+    }).pipe(T.Http({ method: "POST", path: "/v1/upload" }));
+
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+    const blob = new Blob(["world"], { type: "text/plain" });
+    const parts = T.buildRequestParts(
+      Input.ast,
+      T.getHttpTrait(Input.ast)!,
+      { file, blob },
+      Input,
+    );
+
+    expect(parts.body).toBeDefined();
+    expect((parts.body as { file: unknown }).file).toBe(file);
+    expect((parts.body as { blob: unknown }).blob).toBe(blob);
+  });
+
   it("plain string still works (no regression)", () => {
     const Input = Schema.Struct({
       token: Schema.String,


### PR DESCRIPTION
Regression from #213. \`unwrapRedactedDeep\` walked into any object via \`Object.entries()\` to find \`Redacted\` values, but builtins like \`File\`, \`Blob\`, \`FormData\`, \`ArrayBuffer\`, \`TypedArray\`, \`Map\`/\`Set\`, \`Date\`, streams, etc. have no own enumerable string keys — recursing through them returns \`{}\`, which the schema encoder later rejects with `Expected File, got {}`.

This is what's blocking the entire cloudflare test suite (46 failures, all `Expected File, got {}` / `Expected Blob, got {}` in `workers.test.ts`).

Fix: skip recursion for any object whose prototype isn't \`Object.prototype\`. Plain JSON-shaped inputs still get walked for nested \`Redacted\` values; binary uploads pass through unchanged.

```diff
 const unwrapRedactedDeep = (value: unknown): unknown => {
   if (Redacted.isRedacted(value)) return Redacted.value(value);
   if (Array.isArray(value)) return value.map(unwrapRedactedDeep);
   if (value !== null && typeof value === "object") {
+    // Only walk into plain objects. Builtins like File, Blob, FormData,
+    // ArrayBuffer, TypedArrays, Map/Set, Date, Streams, etc. don't contain
+    // Redacted values and would be destroyed by Object.entries().
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== null && proto !== Object.prototype) return value;
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
       out[k] = unwrapRedactedDeep(v);
     }
```

Adds a regression test to `redacted-encoding.test.ts` that asserts \`File\` and \`Blob\` instances pass through identically.

— claude