### PR TITLE
test(supabase): disable file parallelism

### DIFF
--- a/packages/supabase/vitest.config.ts
+++ b/packages/supabase/vitest.config.ts
@@ -1,6 +1,16 @@
 import { config } from "dotenv";
 import { resolve } from "path";
+import { defineConfig } from "vitest/config";
 
 config({ path: resolve(__dirname, "../../.env") });
 
-export default {};
+// Supabase free-tier accounts have a 2-active-project ceiling. Running test
+// files in parallel means concurrent v1CreateAProject calls can blow that
+// ceiling before the previous test's deletion has propagated, surfacing as
+// "organization members have reached their maximum limits". Force serial
+// execution so create→delete pairs always finish before the next test starts.
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
Supabase's free tier caps each org at 2 active projects. When vitest runs test files in parallel, concurrent `v1CreateAProject` calls can exceed that ceiling before the previous test's deletion has propagated — surfacing as `organization members have reached their maximum limits` and failing the `v1CreateAProject` / `v1PauseAProject` / `v1RestoreAProject` happy paths in [run 25237016325](https://github.com/alchemy-run/distilled/actions/runs/25237016325).

Set `test.fileParallelism: false` so files run sequentially. Tests inside a single file already run sequentially by default; this just stops `organizations.test.ts` and `projects.test.ts` from racing each other.

```diff
+import { defineConfig } from "vitest/config";
+
 config({ path: resolve(__dirname, "../../.env") });

-export default {};
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+  },
+});
```

— claude