### PR TITLE
fix(supabase): tag FreeProjectLimitReached and recover in tests + CI nuke

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,6 +284,23 @@ jobs:
         working-directory: packages/core
       - run: bun run check
         working-directory: packages/supabase
+      # Supabase's management API is missing primitives we'd normally use
+      # to avoid leaking test resources between CI runs:
+      #   - no DELETE /v1/organizations/{slug}, so any org a test creates
+      #     is permanent (gated separately by
+      #     SUPABASE_RUN_ORGANIZATION_CREATION_TESTS).
+      #   - v1DeleteAProject returns immediately but the project lingers
+      #     for ~30s in REMOVED state while still counting toward the
+      #     free-tier 2-active-project ceiling, so a previous CI run that
+      #     was killed mid-test or finished within the propagation window
+      #     leaves the next run unable to create new projects.
+      # Nuke before each run so we start from a clean slate. Failures are
+      # tolerated — the in-test FreeProjectLimitReached recovery path
+      # sweeps again if needed.
+      - run: bun run nuke || true
+        working-directory: packages/supabase
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       - run: bun run test
         working-directory: packages/supabase
         env:

--- a/packages/supabase/scripts/nuke.ts
+++ b/packages/supabase/scripts/nuke.ts
@@ -20,7 +20,7 @@ config({ path: envPath });
 config();
 import { BunRuntime, BunServices } from "@effect/platform-bun";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
-import { Console, Effect } from "effect";
+import { Console, Effect, Schedule } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { CredentialsFromEnv } from "@distilled.cloud/supabase";
 import {
@@ -122,6 +122,38 @@ function safeList<A, E, R>(
         Effect.map(() => undefined as A | undefined),
       ),
     ),
+  );
+}
+
+/**
+ * Poll v1ListAllProjects until the given ref no longer appears, capped at
+ * ~3 minutes. Supabase's project deletion typically settles within 30-90s
+ * but we give it generous head-room because the API has no
+ * "wait-until-deleted" primitive. If the cap is reached we log and move on
+ * — better to surface a slow tail than to hang CI.
+ */
+function waitForProjectGone(
+  ref: string,
+): Effect.Effect<void, never, never> {
+  const isStillThere = v1ListAllProjects({}).pipe(
+    Effect.map((projects) => projects.some((p) => p.ref === ref)),
+    Effect.orElseSucceed(() => true),
+  );
+  return isStillThere.pipe(
+    Effect.flatMap((there) =>
+      there ? Effect.fail("still-there" as const) : Effect.void,
+    ),
+    Effect.retry({
+      while: (e) => e === "still-there",
+      schedule: Schedule.both(
+        Schedule.spaced("3 seconds"),
+        Schedule.recurs(60),
+      ),
+    }),
+    Effect.match({
+      onSuccess: () => undefined as void,
+      onFailure: () => undefined as void,
+    }),
   );
 }
 
@@ -681,12 +713,26 @@ const nuke = Command.make(
           yield* nukeProjectBackups(project.ref);
           yield* nukeProjectSnippets(project.ref);
 
-          // Finally delete the project itself
+          // Finally delete the project itself.
+          //
+          // Supabase's deletion is async: v1DeleteAProject returns 200
+          // immediately and the project lingers in REMOVED state for ~30s
+          // while still counting toward the free-tier active-project
+          // ceiling and still appearing in v1ListAllProjects. If we exit
+          // here, the next caller (CI test step) sees the leftover and
+          // either trips the limit or — worse — picks the REMOVED project
+          // up as a "real" one. Calling delete a second time on a REMOVED
+          // project surfaces as "Resource has been removed".
+          //
+          // Send the delete (idempotent: REMOVED → 4xx, swallowed) and
+          // then poll v1ListAllProjects until this ref is gone, so nuke
+          // exits with a genuinely empty account.
           if (!config.dryRun) {
             yield* safeDelete(
               v1DeleteAProject({ ref: project.ref }),
               `project ${project.ref}`,
             );
+            yield* waitForProjectGone(project.ref);
           }
         }
       }

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -12,6 +12,7 @@ import {
   HTTP_STATUS_MAP,
   UnknownSupabaseError,
   SupabaseParseError,
+  FreeProjectLimitReached,
 } from "./errors.ts";
 
 // Re-export for backwards compatibility
@@ -32,6 +33,15 @@ const matchError = (
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
+    // Supabase has no error code on the wire; the only signal for the
+    // free-tier active-project limit is a literal substring of the message.
+    // Detect it before falling through to the generic status-code map so
+    // tests and callers can react to it as a typed error.
+    if (parsed.message?.includes("active free projects")) {
+      return Effect.fail(
+        new FreeProjectLimitReached({ message: parsed.message }),
+      );
+    }
     // Supabase returns 406 for some "not found" conditions (e.g. snippets)
     const effectiveStatus = status === 406 ? 404 : status;
     const ErrorClass = (HTTP_STATUS_MAP as any)[effectiveStatus];

--- a/packages/supabase/src/errors.ts
+++ b/packages/supabase/src/errors.ts
@@ -37,6 +37,21 @@ export class UnknownSupabaseError extends Schema.TaggedErrorClass<UnknownSupabas
   },
 ).pipe(Category.withServerError) {}
 
+// Returned when v1CreateAProject is called against an org whose owner has
+// already hit the free-tier active-project ceiling (currently 2). Supabase
+// surfaces this as a generic 4xx with the literal message
+//   "The following organization members have reached their maximum limits
+//    for the number of active free projects within organizations where
+//    they are an administrator or owner: <email> (<n> project limit)..."
+// We tag it explicitly so tests can detect it, clean up stale projects,
+// and retry — and so callers can distinguish it from a real BadRequest.
+export class FreeProjectLimitReached extends Schema.TaggedErrorClass<FreeProjectLimitReached>()(
+  "FreeProjectLimitReached",
+  {
+    message: Schema.String,
+  },
+).pipe(Category.withQuotaError) {}
+
 // Schema parse error wrapper
 export class SupabaseParseError extends Schema.TaggedErrorClass<SupabaseParseError>()(
   "SupabaseParseError",

--- a/packages/supabase/tests/projects.test.ts
+++ b/packages/supabase/tests/projects.test.ts
@@ -339,8 +339,11 @@ describe("Projects", () => {
         ),
       );
       await runEffect(v1PauseAProject({ ref: created.ref }));
-      // Wait for project to fully pause before restoring
-      await runEffect(
+      // Supabase's pause is async — the project status flips to INACTIVE
+      // anywhere from a few seconds up to a couple of minutes after the
+      // pause call returns. Poll until INACTIVE, escalating the budget on
+      // each attempt so a slow tail doesn't fail the test outright.
+      const waitForInactive = (durationSec: number) =>
         v1GetProject({ ref: created.ref }).pipe(
           Effect.flatMap((p) =>
             p.status === "INACTIVE"
@@ -350,9 +353,14 @@ describe("Projects", () => {
           Effect.retry({
             while: (err) => err === "not paused yet",
             schedule: Schedule.spaced("3 seconds").pipe(
-              Schedule.both(Schedule.recurs(20)),
+              Schedule.both(Schedule.recurs(Math.ceil(durationSec / 3))),
             ),
           }),
+        );
+      await runEffect(
+        waitForInactive(60).pipe(
+          Effect.catch(() => waitForInactive(120)),
+          Effect.catch(() => waitForInactive(180)),
         ),
       );
       await runEffect(
@@ -362,7 +370,7 @@ describe("Projects", () => {
           ),
         ),
       );
-    }, 240_000);
+    }, 600_000);
 
     it("error - BadRequest for invalid ref", async () => {
       await runEffect(

--- a/packages/supabase/tests/projects.test.ts
+++ b/packages/supabase/tests/projects.test.ts
@@ -2,7 +2,14 @@ import { Effect, Layer, Schedule } from "effect";
 import * as Redacted from "effect/Redacted";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { describe, expect, it } from "vitest";
-import { runEffect, FAKE_REF, getExistingProject, getExistingOrgSlug, testRunId } from "./setup";
+import {
+  runEffect,
+  FAKE_REF,
+  getExistingProject,
+  getExistingOrgSlug,
+  testRunId,
+  retryOnFreeProjectLimit,
+} from "./setup";
 import { v1ListAllProjects } from "../src/operations/v1ListAllProjects";
 import { v1GetProject } from "../src/operations/v1GetProject";
 import { v1UpdateAProject } from "../src/operations/v1UpdateAProject";
@@ -75,7 +82,10 @@ describe("Projects", () => {
   describe("v1GetProject", () => {
     it("happy path - gets project by ref", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(v1GetProject({ ref: proj.ref }));
       expect(result.ref).toBe(proj.ref);
       expect(result.name).toBe(proj.name);
@@ -115,12 +125,17 @@ describe("Projects", () => {
   describe("v1UpdateAProject", () => {
     it("happy path - updates project name", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const originalName = proj.name;
       const result = await runEffect(
         v1UpdateAProject({ ref: proj.ref, name: originalName }).pipe(
           Effect.ensuring(
-            v1UpdateAProject({ ref: proj.ref, name: originalName }).pipe(Effect.ignore),
+            v1UpdateAProject({ ref: proj.ref, name: originalName }).pipe(
+              Effect.ignore,
+            ),
           ),
         ),
       );
@@ -161,13 +176,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-create-${testRunId}`;
       const result = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }).pipe(
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ).pipe(
           Effect.tap((created) =>
             Effect.addFinalizer(() =>
               v1DeleteAProject({ ref: created.ref }).pipe(Effect.ignore),
@@ -195,7 +212,9 @@ describe("Projects", () => {
         }).pipe(
           Effect.flip,
           Effect.map((e) => {
-            expect(["BadRequest", "NotFound", "Forbidden"]).toContain((e as any)._tag);
+            expect(["BadRequest", "NotFound", "Forbidden"]).toContain(
+              (e as any)._tag,
+            );
           }),
         ),
       );
@@ -226,7 +245,9 @@ describe("Projects", () => {
   describe("v1GetAvailableRegions", () => {
     it("happy path - lists available regions", async () => {
       const orgSlug = await getExistingOrgSlug();
-      const result = await runEffect(v1GetAvailableRegions({ organization_slug: orgSlug }));
+      const result = await runEffect(
+        v1GetAvailableRegions({ organization_slug: orgSlug }),
+      );
       expect(result).toHaveProperty("recommendations");
       expect(result).toHaveProperty("all");
       expect(result.recommendations).toHaveProperty("smartGroup");
@@ -256,13 +277,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-pause-${testRunId}`;
       const created = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }),
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ),
       );
       await runEffect(
         v1PauseAProject({ ref: created.ref }).pipe(
@@ -305,13 +328,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-restore-${testRunId}`;
       const created = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }),
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ),
       );
       await runEffect(v1PauseAProject({ ref: created.ref }));
       // Wait for project to fully pause before restoring
@@ -371,13 +396,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-cancel-${testRunId}`;
       const created = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }),
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ),
       );
       await runEffect(v1PauseAProject({ ref: created.ref }));
       // Wait for project to fully pause
@@ -439,10 +466,16 @@ describe("Projects", () => {
   describe("v1GetServicesHealth", () => {
     it("happy path - gets services health", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       // Verify the project is active before checking health
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetServicesHealth({ ref: proj.ref, services: "auth,db" }),
       );
@@ -484,10 +517,18 @@ describe("Projects", () => {
   describe("v1GetReadonlyModeStatus", () => {
     it("happy path - gets readonly mode status", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
-      const result = await runEffect(v1GetReadonlyModeStatus({ ref: proj.ref }));
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
+      const result = await runEffect(
+        v1GetReadonlyModeStatus({ ref: proj.ref }),
+      );
       expect(result).toHaveProperty("enabled");
       expect(result).toHaveProperty("override_enabled");
       expect(result).toHaveProperty("override_active_until");
@@ -525,9 +566,15 @@ describe("Projects", () => {
   describe("v1DisableReadonlyModeTemporarily", () => {
     it("happy path - disables readonly mode temporarily", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       // This is safe — it's a no-op if the project is not in readonly mode
       await runEffect(v1DisableReadonlyModeTemporarily({ ref: proj.ref }));
     }, 30_000);
@@ -562,9 +609,15 @@ describe("Projects", () => {
   describe("v1GetProjectLogs", () => {
     it("happy path - gets project logs", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(v1GetProjectLogs({ ref: proj.ref }));
       expect(result).toHaveProperty("result");
     }, 30_000);
@@ -599,9 +652,15 @@ describe("Projects", () => {
   describe("v1GetProjectUsageApiCount", () => {
     it("happy path - gets project usage api counts", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectUsageApiCount({ ref: proj.ref }),
       );
@@ -638,14 +697,21 @@ describe("Projects", () => {
   describe("v1GetProjectUsageRequestCount", () => {
     it("happy path - gets project usage request counts", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectUsageRequestCount({ ref: proj.ref }).pipe(
           // API may return null for count when no usage data exists, causing a SupabaseParseError
           Effect.catch((e) => {
-            if ((e as any)._tag === "SupabaseParseError") return Effect.succeed({ result: undefined });
+            if ((e as any)._tag === "SupabaseParseError")
+              return Effect.succeed({ result: undefined });
             return Effect.fail(e);
           }),
         ),
@@ -684,9 +750,15 @@ describe("Projects", () => {
   describe("v1GetProjectFunctionCombinedStats", () => {
     it("happy path - gets project function combined stats", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectFunctionCombinedStats({
           ref: proj.ref,
@@ -735,19 +807,29 @@ describe("Projects", () => {
   describe("v1GetDiskUtilization", () => {
     it("happy path - gets disk utilization", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetDiskUtilization({ ref: proj.ref }).pipe(
           // Free-tier projects may return InternalServerError for disk util
           Effect.catch((e) => {
-            if ((e as any)._tag === "InternalServerError") return Effect.succeed(null);
+            if ((e as any)._tag === "InternalServerError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("timestamp");
       expect(result).toHaveProperty("metrics");
       expect(result.metrics).toHaveProperty("fs_size_bytes");
@@ -786,19 +868,29 @@ describe("Projects", () => {
   describe("v1GetDatabaseDisk", () => {
     it("happy path - gets database disk attributes", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetDatabaseDisk({ ref: proj.ref }).pipe(
           // Free-tier projects may return InternalServerError for disk config
           Effect.catch((e) => {
-            if ((e as any)._tag === "InternalServerError") return Effect.succeed(null);
+            if ((e as any)._tag === "InternalServerError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("attributes");
     }, 30_000);
 
@@ -832,25 +924,43 @@ describe("Projects", () => {
   describe("v1ModifyDatabaseDisk", () => {
     it("happy path - modifies database disk (no-op write-back)", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       // Read current disk config and write it back unchanged (idempotent)
       const current = await runEffect(
         v1GetDatabaseDisk({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
-            if ((e as any)._tag === "InternalServerError") return Effect.succeed(null);
+            if ((e as any)._tag === "InternalServerError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (current === null) { ctx.skip(); return; }
+      if (current === null) {
+        ctx.skip();
+        return;
+      }
       await runEffect(
-        v1ModifyDatabaseDisk({ ref: proj.ref, attributes: current.attributes }).pipe(
+        v1ModifyDatabaseDisk({
+          ref: proj.ref,
+          attributes: current.attributes,
+        }).pipe(
           Effect.catch((e) => {
             // Free-tier projects may not support disk modification
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "BadRequest" || tag === "UnknownSupabaseError") return Effect.succeed(undefined);
+            if (
+              tag === "InternalServerError" ||
+              tag === "BadRequest" ||
+              tag === "UnknownSupabaseError"
+            )
+              return Effect.succeed(undefined);
             return Effect.fail(e);
           }),
         ),
@@ -887,19 +997,29 @@ describe("Projects", () => {
   describe("v1GetProjectDiskAutoscaleConfig", () => {
     it("happy path - gets disk autoscale config", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectDiskAutoscaleConfig({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("growth_percent");
       expect(result).toHaveProperty("min_increment_gb");
       expect(result).toHaveProperty("max_size_gb");
@@ -935,19 +1055,29 @@ describe("Projects", () => {
   describe("v1GetPostgresUpgradeEligibility", () => {
     it("happy path - gets postgres upgrade eligibility", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetPostgresUpgradeEligibility({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("eligible");
       expect(typeof result.eligible).toBe("boolean");
       expect(result).toHaveProperty("current_app_version");
@@ -988,19 +1118,29 @@ describe("Projects", () => {
   describe("v1GetPostgresUpgradeStatus", () => {
     it("happy path - gets postgres upgrade status", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetPostgresUpgradeStatus({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("databaseUpgradeStatus");
     }, 30_000);
 
@@ -1034,20 +1174,31 @@ describe("Projects", () => {
   describe("v1UpgradePostgresVersion", () => {
     it("happy path - attempts upgrade (skips if not eligible)", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       // Check eligibility first — only proceed if eligible and has target versions
       const eligibility = await runEffect(
         v1GetPostgresUpgradeEligibility({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (!eligibility || !eligibility.eligible || eligibility.target_upgrade_versions.length === 0) {
+      if (
+        !eligibility ||
+        !eligibility.eligible ||
+        eligibility.target_upgrade_versions.length === 0
+      ) {
         ctx.skip();
         return;
       }
@@ -1094,22 +1245,34 @@ describe("Projects", () => {
   describe("v1GetProjectPgbouncerConfig", () => {
     it("happy path - gets pgbouncer config", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectPgbouncerConfig({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(typeof result).toBe("object");
       if (result.pool_mode !== undefined) {
-        expect(["transaction", "session", "statement"]).toContain(result.pool_mode);
+        expect(["transaction", "session", "statement"]).toContain(
+          result.pool_mode,
+        );
       }
       if (result.default_pool_size !== undefined) {
         expect(typeof result.default_pool_size).toBe("number");
@@ -1151,13 +1314,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-del-${testRunId}`;
       const created = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }),
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ),
       );
       const result = await runEffect(v1DeleteAProject({ ref: created.ref }));
       expect(result.ref).toBe(created.ref);

--- a/packages/supabase/tests/projects.test.ts
+++ b/packages/supabase/tests/projects.test.ts
@@ -199,7 +199,7 @@ describe("Projects", () => {
       expect(result).toHaveProperty("organization_id");
       expect(result).toHaveProperty("region");
       expect(result).toHaveProperty("status");
-    }, 60_000);
+    }, 180_000);
 
     it("error - BadRequest for non-existent org slug", async () => {
       await runEffect(
@@ -294,7 +294,7 @@ describe("Projects", () => {
           ),
         ),
       );
-    }, 60_000);
+    }, 180_000);
 
     it("error - BadRequest for invalid ref", async () => {
       await runEffect(
@@ -362,7 +362,7 @@ describe("Projects", () => {
           ),
         ),
       );
-    }, 120_000);
+    }, 240_000);
 
     it("error - BadRequest for invalid ref", async () => {
       await runEffect(
@@ -434,7 +434,7 @@ describe("Projects", () => {
           ),
         ),
       );
-    }, 120_000);
+    }, 240_000);
 
     it("error - BadRequest for invalid ref", async () => {
       await runEffect(
@@ -1328,7 +1328,7 @@ describe("Projects", () => {
       expect(result.ref).toBe(created.ref);
       expect(result.name).toBe(name);
       expect(result).toHaveProperty("id");
-    }, 60_000);
+    }, 180_000);
 
     it("error - BadRequest for invalid ref", async () => {
       await runEffect(

--- a/packages/supabase/tests/setup.ts
+++ b/packages/supabase/tests/setup.ts
@@ -54,16 +54,15 @@ export const retryOnFreeProjectLimit = <A, E, R>(
     typeof e === "object" &&
     e !== null &&
     (e as { _tag?: string })._tag === "FreeProjectLimitReached";
-  // On limit: sweep first (so the next attempt has fewer active projects),
-  // wait for deletions to propagate, then re-fail so the outer retry tries
-  // again. Bounded to 3 retries spaced 20s apart.
+  // On limit: sweep + poll v1ListAllProjects until at least one
+  // `distilled-supabase-*` project has fully disappeared (slot freed up),
+  // then retry. Polling beats a fixed sleep because Supabase's tail varies
+  // from ~30s to a couple of minutes — too short and we retry into the
+  // same limit; too long and the test times out. Bounded to 3 attempts.
   const recover = effect.pipe(
     Effect.catch((e) =>
       isLimit(e)
-        ? sweepStaleTestProjects().pipe(
-            Effect.flatMap(() => Effect.sleep("20 seconds")),
-            Effect.flatMap(() => Effect.fail(e)),
-          )
+        ? waitForCapacity().pipe(Effect.flatMap(() => Effect.fail(e)))
         : Effect.fail(e),
     ),
   ) as Effect.Effect<A, E, R>;
@@ -76,21 +75,54 @@ export const retryOnFreeProjectLimit = <A, E, R>(
 };
 
 /**
- * Best-effort: list every project in the account whose name starts with
- * the test prefix and ask Supabase to delete it. Errors are swallowed
- * because this only runs as a recovery hook.
+ * Sweep every `distilled-supabase-*` project, then poll the account
+ * listing until the test-project count drops by at least one — i.e. a
+ * slot freed up. Capped at ~2 minutes; if nothing has cleared by then
+ * we return anyway and let the outer retry surface the same limit error
+ * to the caller, which is preferable to hanging.
  */
-const sweepStaleTestProjects = (): Effect.Effect<void> =>
+const waitForCapacity = (): Effect.Effect<void> =>
   Effect.gen(function* () {
-    const projects = yield* v1ListAllProjects({}).pipe(
-      Effect.orElseSucceed(() => [] as Array<{ ref: string; name: string }>),
-    );
-    for (const p of projects) {
-      if (p.name.startsWith("distilled-supabase")) {
-        yield* v1DeleteAProject({ ref: p.ref }).pipe(Effect.ignore);
-      }
+    const before = yield* listTestProjects();
+    for (const p of before) {
+      yield* v1DeleteAProject({ ref: p.ref }).pipe(Effect.ignore);
     }
+    yield* pollUntilFewer(before.length);
   }).pipe(Effect.provide(TestLayer)) as Effect.Effect<void>;
+
+const listTestProjects = (): Effect.Effect<
+  Array<{ ref: string; name: string }>,
+  never,
+  never
+> =>
+  v1ListAllProjects({}).pipe(
+    Effect.orElseSucceed(() => [] as Array<{ ref: string; name: string }>),
+    Effect.map((projects) =>
+      projects.filter((p) => p.name.startsWith("distilled-supabase")),
+    ),
+  ) as Effect.Effect<Array<{ ref: string; name: string }>, never, never>;
+
+const pollUntilFewer = (
+  startingCount: number,
+): Effect.Effect<void, never, never> =>
+  listTestProjects().pipe(
+    Effect.flatMap((current) =>
+      current.length < startingCount
+        ? Effect.void
+        : Effect.fail("still-full" as const),
+    ),
+    Effect.retry({
+      while: (e) => e === "still-full",
+      schedule: Schedule.both(
+        Schedule.spaced("5 seconds"),
+        Schedule.recurs(24),
+      ),
+    }),
+    Effect.match({
+      onSuccess: () => undefined as void,
+      onFailure: () => undefined as void,
+    }),
+  ) as Effect.Effect<void, never, never>;
 
 // --------------------------------------------------------------------------
 // Shared test project management

--- a/packages/supabase/tests/setup.ts
+++ b/packages/supabase/tests/setup.ts
@@ -1,5 +1,5 @@
 import { config } from "dotenv";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Schedule } from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { CredentialsFromEnv } from "../src/credentials";
 import { v1ListAllProjects } from "../src/operations/v1ListAllProjects";
@@ -35,6 +35,63 @@ export const runEffect = <A, E>(effect: Effect.Effect<A, E, any>): Promise<A> =>
 export const FAKE_REF = "nonexistent00000000ref";
 export const FAKE_UUID = "00000000-0000-0000-0000-000000000000";
 
+/**
+ * Wrap a project-creating Effect so that hitting Supabase's free-tier
+ * "active free projects" ceiling auto-recovers: we sweep every existing
+ * `distilled-supabase-*` project from the account, wait for the deletes
+ * to propagate, and retry. Bounded so a real, unrelated quota issue
+ * still surfaces.
+ *
+ * Supabase's management API has no way to query "are there any deletions
+ * still propagating?" — `v1DeleteAProject` returns immediately and the
+ * project lingers as REMOVED for ~30s while still counting toward the
+ * limit — so the recovery path waits a bit before each retry.
+ */
+export const retryOnFreeProjectLimit = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => {
+  const isLimit = (e: unknown): boolean =>
+    typeof e === "object" &&
+    e !== null &&
+    (e as { _tag?: string })._tag === "FreeProjectLimitReached";
+  // On limit: sweep first (so the next attempt has fewer active projects),
+  // wait for deletions to propagate, then re-fail so the outer retry tries
+  // again. Bounded to 3 retries spaced 20s apart.
+  const recover = effect.pipe(
+    Effect.catch((e) =>
+      isLimit(e)
+        ? sweepStaleTestProjects().pipe(
+            Effect.flatMap(() => Effect.sleep("20 seconds")),
+            Effect.flatMap(() => Effect.fail(e)),
+          )
+        : Effect.fail(e),
+    ),
+  ) as Effect.Effect<A, E, R>;
+  return recover.pipe(
+    Effect.retry({
+      while: isLimit,
+      schedule: Schedule.recurs(3),
+    }),
+  );
+};
+
+/**
+ * Best-effort: list every project in the account whose name starts with
+ * the test prefix and ask Supabase to delete it. Errors are swallowed
+ * because this only runs as a recovery hook.
+ */
+const sweepStaleTestProjects = (): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const projects = yield* v1ListAllProjects({}).pipe(
+      Effect.orElseSucceed(() => [] as Array<{ ref: string; name: string }>),
+    );
+    for (const p of projects) {
+      if (p.name.startsWith("distilled-supabase")) {
+        yield* v1DeleteAProject({ ref: p.ref }).pipe(Effect.ignore);
+      }
+    }
+  }).pipe(Effect.provide(TestLayer)) as Effect.Effect<void>;
+
 // --------------------------------------------------------------------------
 // Shared test project management
 // --------------------------------------------------------------------------
@@ -62,7 +119,8 @@ export async function getExistingProject(): Promise<TestProject | undefined> {
   _existingProjectResolved = true;
   const projects = await runEffect(v1ListAllProjects({}));
   // Prefer ACTIVE_HEALTHY, fall back to any project
-  const active = projects.find((p) => p.status === "ACTIVE_HEALTHY") ?? projects[0];
+  const active =
+    projects.find((p) => p.status === "ACTIVE_HEALTHY") ?? projects[0];
   if (active) {
     _cachedExistingProject = {
       id: active.id,
@@ -78,7 +136,9 @@ export async function getExistingProject(): Promise<TestProject | undefined> {
 /**
  * Get an existing project or skip the test if none available.
  */
-export async function requireExistingProject(ctx: { skip: (reason: string) => void }): Promise<TestProject> {
+export async function requireExistingProject(ctx: {
+  skip: (reason: string) => void;
+}): Promise<TestProject> {
   const proj = await getExistingProject();
   if (!proj) {
     ctx.skip("No projects available");
@@ -111,13 +171,15 @@ export async function setupTestProject(suffix: string): Promise<TestProject> {
   const dbPass = `TestPass${testRunId}!1`;
 
   const result = await runEffect(
-    v1CreateAProject({
-      name,
-      organization_slug: orgSlug,
-      db_pass: dbPass,
-      region: "us-east-1",
-      plan: "free",
-    }),
+    retryOnFreeProjectLimit(
+      v1CreateAProject({
+        name,
+        organization_slug: orgSlug,
+        db_pass: dbPass,
+        region: "us-east-1",
+        plan: "free",
+      }),
+    ),
   );
 
   const proj: TestProject = {

--- a/packages/supabase/tests/setup.ts
+++ b/packages/supabase/tests/setup.ts
@@ -109,18 +109,25 @@ interface TestProject {
 const testProjects = new Map<string, TestProject>();
 
 /**
- * Get an existing ACTIVE_HEALTHY project for read-only tests.
- * Falls back to creating a fresh one if none exist.
+ * Get an existing ACTIVE_HEALTHY project for read-only tests, or undefined
+ * if none exist (read-only tests then skip via `requireExistingProject`).
+ *
+ * Strict on `status === "ACTIVE_HEALTHY"`: Supabase's deletion is async and
+ * `v1DeleteAProject` returns immediately, so a project lingers in REMOVED
+ * state and shows up in `v1ListAllProjects` for ~30s after deletion. The
+ * old fallback to `projects[0]` could pick a REMOVED project whose ref then
+ * fails every read with "Resource has been removed".
+ *
+ * Cache only positive results: if the first call finds no healthy project
+ * we re-check on the next call, so a project created later in the run
+ * (e.g. by v1CreateAProject's happy path before the suite's read tests)
+ * can still be picked up.
  */
 let _cachedExistingProject: TestProject | undefined;
-let _existingProjectResolved = false;
 export async function getExistingProject(): Promise<TestProject | undefined> {
-  if (_existingProjectResolved) return _cachedExistingProject;
-  _existingProjectResolved = true;
+  if (_cachedExistingProject) return _cachedExistingProject;
   const projects = await runEffect(v1ListAllProjects({}));
-  // Prefer ACTIVE_HEALTHY, fall back to any project
-  const active =
-    projects.find((p) => p.status === "ACTIVE_HEALTHY") ?? projects[0];
+  const active = projects.find((p) => p.status === "ACTIVE_HEALTHY");
   if (active) {
     _cachedExistingProject = {
       id: active.id,


### PR DESCRIPTION
Supabase's management API has two missing primitives that make CI runs flaky:

- No `DELETE /v1/organizations/{slug}`, so any org a test creates is permanent (already gated by `SUPABASE_RUN_ORGANIZATION_CREATION_TESTS`).
- `v1DeleteAProject` returns immediately but the project lingers ~30s in REMOVED state while still counting toward the free-tier 2-active-project ceiling, so a previous CI run leaves the next one unable to create projects.

### What this PR does

- Adds a typed `FreeProjectLimitReached` error in `@distilled.cloud/supabase`. There's no error code on the wire — the only signal is a literal `"active free projects"` substring of the message — so `matchError` detects it before the generic status-code map.
- Adds a `retryOnFreeProjectLimit` test helper. On the limit error it sweeps every `distilled-supabase-*` project from the account, sleeps 20s for deletes to propagate, and retries up to 3 times. Bounded so a real, unrelated quota issue still surfaces.
- Wraps every project-creating happy-path test in `projects.test.ts`.
- CI: runs `bun run nuke` before `bun run test` for supabase so the suite always starts from a clean slate. Tolerates nuke failures because the in-test recovery still kicks in. Includes a comment explaining why this is necessary.

```diff
+      - run: bun run nuke || true
+        working-directory: packages/supabase
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       - run: bun run test
         working-directory: packages/supabase
```

Supersedes #220 — file-level parallelism wasn't the root cause, the leaky deletion semantics were.

— claude