### PR TITLE
feat(core): debug logging and per-operation spans

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,6 +284,23 @@ jobs:
         working-directory: packages/core
       - run: bun run check
         working-directory: packages/supabase
+      # Supabase's management API is missing primitives we'd normally use
+      # to avoid leaking test resources between CI runs:
+      #   - no DELETE /v1/organizations/{slug}, so any org a test creates
+      #     is permanent (gated separately by
+      #     SUPABASE_RUN_ORGANIZATION_CREATION_TESTS).
+      #   - v1DeleteAProject returns immediately but the project lingers
+      #     for ~30s in REMOVED state while still counting toward the
+      #     free-tier 2-active-project ceiling, so a previous CI run that
+      #     was killed mid-test or finished within the propagation window
+      #     leaves the next run unable to create new projects.
+      # Nuke before each run so we start from a clean slate. Failures are
+      # tolerated — the in-test FreeProjectLimitReached recovery path
+      # sweeps again if needed.
+      - run: bun run nuke || true
+        working-directory: packages/supabase
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       - run: bun run test
         working-directory: packages/supabase
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,12 @@ When you automatically open a PR, it MUST follow this structure:
 
 The summary goes at the very top of the description as plain prose — NO heading above it, no `### Summary`, nothing. The PR title already serves as the title; do not repeat or re-title it. Only add `###` subheadings further down if the description genuinely has multiple sections worth separating.
 
+**Markdown — write it plainly, do not escape:**
+- Inline code uses single backticks: `` `MyThing` ``. Block code uses triple backticks. That's it.
+- NEVER pad backticks with spaces (`` ` ` `MyThing` ` ` ``). NEVER escape them. The result looks like garbage and is never what the user wants.
+- When passing a PR body to `gh`, write it to a file and use `--body-file` (or `gh api -F body=@file`). Do NOT inline it in a heredoc you then try to escape — that is what causes the broken backticks.
+- If `gh pr edit` fails (it can fail on some repos due to a Projects-classic GraphQL deprecation), retry via `gh api -X PATCH repos/{owner}/{repo}/pulls/{n} -F body=@file.md`.
+
 Example PR description (good):
 
 ```

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -28,6 +28,7 @@
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipeArguments } from "effect/Pipeable";
+import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
@@ -47,6 +48,19 @@ import {
 import * as Category from "./category.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
+
+// `DISTILLED_DEBUG=1` forces the MinimumLogLevel to Debug for SDK operations,
+// independent of the caller's logger config. Users who set `MinimumLogLevel`
+// to Debug themselves get the same logs without needing the env var.
+const distilledDebugEnv: boolean = (() => {
+  try {
+    return (
+      typeof process !== "undefined" && process.env?.DISTILLED_DEBUG === "1"
+    );
+  } catch {
+    return false;
+  }
+})();
 
 // ============================================================================
 // Client Types
@@ -407,6 +421,8 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
         Schedule.recurs(8),
       );
 
+      const spanName = `${method} ${httpTrait.path}`;
+
       const innerFn = (input: Input): Effect.Effect<any, any, any> =>
         Effect.gen(function* () {
           const credentials = yield* config.credentials as any;
@@ -514,6 +530,9 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             }
           }
 
+          const requestUrl = baseUrl + parts.path;
+          yield* Effect.logDebug(`→ ${method} ${requestUrl}`);
+
           // For operations that opt out of following redirects, hand the
           // underlying fetch a `redirect: "manual"` request init so the
           // 3xx surfaces here instead of being chased to the IdP.
@@ -527,6 +546,9 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             : client.execute(request).pipe(Effect.scoped);
 
           const response = yield* executeRequest;
+          yield* Effect.logDebug(
+            `← ${response.status} ${method} ${requestUrl}`,
+          );
 
           // For ops that opted out of redirect-following, treat 3xx as
           // success: synthesize a body containing the Location header
@@ -681,13 +703,23 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       // / `withRetryable({ throttling: true })`). After retries are
       // exhausted the original typed error propagates to the caller as
       // usual.
-      const fn = (input: Input): Effect.Effect<any, any, any> =>
-        innerFn(input).pipe(
+      const fn = (input: Input): Effect.Effect<any, any, any> => {
+        const withRetry = innerFn(input).pipe(
           Effect.retry({
             schedule: throttlingRetrySchedule,
             while: (e) => Category.isThrottling(e),
           }),
+          Effect.withSpan(spanName, {
+            attributes: {
+              "http.method": method,
+              "http.route": httpTrait.path,
+            },
+          }),
         );
+        return distilledDebugEnv
+          ? Effect.provideService(withRetry, MinimumLogLevel, "Debug")
+          : withRetry;
+      };
 
       const Proto = {
         [Symbol.iterator]() {

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -12,6 +12,7 @@ import {
   HTTP_STATUS_MAP,
   UnknownSupabaseError,
   SupabaseParseError,
+  FreeProjectLimitReached,
 } from "./errors.ts";
 
 // Re-export for backwards compatibility
@@ -32,6 +33,15 @@ const matchError = (
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
+    // Supabase has no error code on the wire; the only signal for the
+    // free-tier active-project limit is a literal substring of the message.
+    // Detect it before falling through to the generic status-code map so
+    // tests and callers can react to it as a typed error.
+    if (parsed.message?.includes("active free projects")) {
+      return Effect.fail(
+        new FreeProjectLimitReached({ message: parsed.message }),
+      );
+    }
     // Supabase returns 406 for some "not found" conditions (e.g. snippets)
     const effectiveStatus = status === 406 ? 404 : status;
     const ErrorClass = (HTTP_STATUS_MAP as any)[effectiveStatus];

--- a/packages/supabase/src/errors.ts
+++ b/packages/supabase/src/errors.ts
@@ -37,6 +37,21 @@ export class UnknownSupabaseError extends Schema.TaggedErrorClass<UnknownSupabas
   },
 ).pipe(Category.withServerError) {}
 
+// Returned when v1CreateAProject is called against an org whose owner has
+// already hit the free-tier active-project ceiling (currently 2). Supabase
+// surfaces this as a generic 4xx with the literal message
+//   "The following organization members have reached their maximum limits
+//    for the number of active free projects within organizations where
+//    they are an administrator or owner: <email> (<n> project limit)..."
+// We tag it explicitly so tests can detect it, clean up stale projects,
+// and retry — and so callers can distinguish it from a real BadRequest.
+export class FreeProjectLimitReached extends Schema.TaggedErrorClass<FreeProjectLimitReached>()(
+  "FreeProjectLimitReached",
+  {
+    message: Schema.String,
+  },
+).pipe(Category.withQuotaError) {}
+
 // Schema parse error wrapper
 export class SupabaseParseError extends Schema.TaggedErrorClass<SupabaseParseError>()(
   "SupabaseParseError",

--- a/packages/supabase/tests/projects.test.ts
+++ b/packages/supabase/tests/projects.test.ts
@@ -2,7 +2,14 @@ import { Effect, Layer, Schedule } from "effect";
 import * as Redacted from "effect/Redacted";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { describe, expect, it } from "vitest";
-import { runEffect, FAKE_REF, getExistingProject, getExistingOrgSlug, testRunId } from "./setup";
+import {
+  runEffect,
+  FAKE_REF,
+  getExistingProject,
+  getExistingOrgSlug,
+  testRunId,
+  retryOnFreeProjectLimit,
+} from "./setup";
 import { v1ListAllProjects } from "../src/operations/v1ListAllProjects";
 import { v1GetProject } from "../src/operations/v1GetProject";
 import { v1UpdateAProject } from "../src/operations/v1UpdateAProject";
@@ -75,7 +82,10 @@ describe("Projects", () => {
   describe("v1GetProject", () => {
     it("happy path - gets project by ref", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(v1GetProject({ ref: proj.ref }));
       expect(result.ref).toBe(proj.ref);
       expect(result.name).toBe(proj.name);
@@ -115,12 +125,17 @@ describe("Projects", () => {
   describe("v1UpdateAProject", () => {
     it("happy path - updates project name", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const originalName = proj.name;
       const result = await runEffect(
         v1UpdateAProject({ ref: proj.ref, name: originalName }).pipe(
           Effect.ensuring(
-            v1UpdateAProject({ ref: proj.ref, name: originalName }).pipe(Effect.ignore),
+            v1UpdateAProject({ ref: proj.ref, name: originalName }).pipe(
+              Effect.ignore,
+            ),
           ),
         ),
       );
@@ -161,13 +176,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-create-${testRunId}`;
       const result = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }).pipe(
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ).pipe(
           Effect.tap((created) =>
             Effect.addFinalizer(() =>
               v1DeleteAProject({ ref: created.ref }).pipe(Effect.ignore),
@@ -195,7 +212,9 @@ describe("Projects", () => {
         }).pipe(
           Effect.flip,
           Effect.map((e) => {
-            expect(["BadRequest", "NotFound", "Forbidden"]).toContain((e as any)._tag);
+            expect(["BadRequest", "NotFound", "Forbidden"]).toContain(
+              (e as any)._tag,
+            );
           }),
         ),
       );
@@ -226,7 +245,9 @@ describe("Projects", () => {
   describe("v1GetAvailableRegions", () => {
     it("happy path - lists available regions", async () => {
       const orgSlug = await getExistingOrgSlug();
-      const result = await runEffect(v1GetAvailableRegions({ organization_slug: orgSlug }));
+      const result = await runEffect(
+        v1GetAvailableRegions({ organization_slug: orgSlug }),
+      );
       expect(result).toHaveProperty("recommendations");
       expect(result).toHaveProperty("all");
       expect(result.recommendations).toHaveProperty("smartGroup");
@@ -256,13 +277,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-pause-${testRunId}`;
       const created = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }),
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ),
       );
       await runEffect(
         v1PauseAProject({ ref: created.ref }).pipe(
@@ -305,13 +328,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-restore-${testRunId}`;
       const created = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }),
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ),
       );
       await runEffect(v1PauseAProject({ ref: created.ref }));
       // Wait for project to fully pause before restoring
@@ -371,13 +396,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-cancel-${testRunId}`;
       const created = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }),
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ),
       );
       await runEffect(v1PauseAProject({ ref: created.ref }));
       // Wait for project to fully pause
@@ -439,10 +466,16 @@ describe("Projects", () => {
   describe("v1GetServicesHealth", () => {
     it("happy path - gets services health", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       // Verify the project is active before checking health
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetServicesHealth({ ref: proj.ref, services: "auth,db" }),
       );
@@ -484,10 +517,18 @@ describe("Projects", () => {
   describe("v1GetReadonlyModeStatus", () => {
     it("happy path - gets readonly mode status", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
-      const result = await runEffect(v1GetReadonlyModeStatus({ ref: proj.ref }));
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
+      const result = await runEffect(
+        v1GetReadonlyModeStatus({ ref: proj.ref }),
+      );
       expect(result).toHaveProperty("enabled");
       expect(result).toHaveProperty("override_enabled");
       expect(result).toHaveProperty("override_active_until");
@@ -525,9 +566,15 @@ describe("Projects", () => {
   describe("v1DisableReadonlyModeTemporarily", () => {
     it("happy path - disables readonly mode temporarily", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       // This is safe — it's a no-op if the project is not in readonly mode
       await runEffect(v1DisableReadonlyModeTemporarily({ ref: proj.ref }));
     }, 30_000);
@@ -562,9 +609,15 @@ describe("Projects", () => {
   describe("v1GetProjectLogs", () => {
     it("happy path - gets project logs", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(v1GetProjectLogs({ ref: proj.ref }));
       expect(result).toHaveProperty("result");
     }, 30_000);
@@ -599,9 +652,15 @@ describe("Projects", () => {
   describe("v1GetProjectUsageApiCount", () => {
     it("happy path - gets project usage api counts", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectUsageApiCount({ ref: proj.ref }),
       );
@@ -638,14 +697,21 @@ describe("Projects", () => {
   describe("v1GetProjectUsageRequestCount", () => {
     it("happy path - gets project usage request counts", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectUsageRequestCount({ ref: proj.ref }).pipe(
           // API may return null for count when no usage data exists, causing a SupabaseParseError
           Effect.catch((e) => {
-            if ((e as any)._tag === "SupabaseParseError") return Effect.succeed({ result: undefined });
+            if ((e as any)._tag === "SupabaseParseError")
+              return Effect.succeed({ result: undefined });
             return Effect.fail(e);
           }),
         ),
@@ -684,9 +750,15 @@ describe("Projects", () => {
   describe("v1GetProjectFunctionCombinedStats", () => {
     it("happy path - gets project function combined stats", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectFunctionCombinedStats({
           ref: proj.ref,
@@ -735,19 +807,29 @@ describe("Projects", () => {
   describe("v1GetDiskUtilization", () => {
     it("happy path - gets disk utilization", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetDiskUtilization({ ref: proj.ref }).pipe(
           // Free-tier projects may return InternalServerError for disk util
           Effect.catch((e) => {
-            if ((e as any)._tag === "InternalServerError") return Effect.succeed(null);
+            if ((e as any)._tag === "InternalServerError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("timestamp");
       expect(result).toHaveProperty("metrics");
       expect(result.metrics).toHaveProperty("fs_size_bytes");
@@ -786,19 +868,29 @@ describe("Projects", () => {
   describe("v1GetDatabaseDisk", () => {
     it("happy path - gets database disk attributes", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetDatabaseDisk({ ref: proj.ref }).pipe(
           // Free-tier projects may return InternalServerError for disk config
           Effect.catch((e) => {
-            if ((e as any)._tag === "InternalServerError") return Effect.succeed(null);
+            if ((e as any)._tag === "InternalServerError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("attributes");
     }, 30_000);
 
@@ -832,25 +924,43 @@ describe("Projects", () => {
   describe("v1ModifyDatabaseDisk", () => {
     it("happy path - modifies database disk (no-op write-back)", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       // Read current disk config and write it back unchanged (idempotent)
       const current = await runEffect(
         v1GetDatabaseDisk({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
-            if ((e as any)._tag === "InternalServerError") return Effect.succeed(null);
+            if ((e as any)._tag === "InternalServerError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (current === null) { ctx.skip(); return; }
+      if (current === null) {
+        ctx.skip();
+        return;
+      }
       await runEffect(
-        v1ModifyDatabaseDisk({ ref: proj.ref, attributes: current.attributes }).pipe(
+        v1ModifyDatabaseDisk({
+          ref: proj.ref,
+          attributes: current.attributes,
+        }).pipe(
           Effect.catch((e) => {
             // Free-tier projects may not support disk modification
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "BadRequest" || tag === "UnknownSupabaseError") return Effect.succeed(undefined);
+            if (
+              tag === "InternalServerError" ||
+              tag === "BadRequest" ||
+              tag === "UnknownSupabaseError"
+            )
+              return Effect.succeed(undefined);
             return Effect.fail(e);
           }),
         ),
@@ -887,19 +997,29 @@ describe("Projects", () => {
   describe("v1GetProjectDiskAutoscaleConfig", () => {
     it("happy path - gets disk autoscale config", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectDiskAutoscaleConfig({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("growth_percent");
       expect(result).toHaveProperty("min_increment_gb");
       expect(result).toHaveProperty("max_size_gb");
@@ -935,19 +1055,29 @@ describe("Projects", () => {
   describe("v1GetPostgresUpgradeEligibility", () => {
     it("happy path - gets postgres upgrade eligibility", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetPostgresUpgradeEligibility({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("eligible");
       expect(typeof result.eligible).toBe("boolean");
       expect(result).toHaveProperty("current_app_version");
@@ -988,19 +1118,29 @@ describe("Projects", () => {
   describe("v1GetPostgresUpgradeStatus", () => {
     it("happy path - gets postgres upgrade status", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetPostgresUpgradeStatus({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(result).toHaveProperty("databaseUpgradeStatus");
     }, 30_000);
 
@@ -1034,20 +1174,31 @@ describe("Projects", () => {
   describe("v1UpgradePostgresVersion", () => {
     it("happy path - attempts upgrade (skips if not eligible)", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       // Check eligibility first — only proceed if eligible and has target versions
       const eligibility = await runEffect(
         v1GetPostgresUpgradeEligibility({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (!eligibility || !eligibility.eligible || eligibility.target_upgrade_versions.length === 0) {
+      if (
+        !eligibility ||
+        !eligibility.eligible ||
+        eligibility.target_upgrade_versions.length === 0
+      ) {
         ctx.skip();
         return;
       }
@@ -1094,22 +1245,34 @@ describe("Projects", () => {
   describe("v1GetProjectPgbouncerConfig", () => {
     it("happy path - gets pgbouncer config", async (ctx) => {
       const proj = await getExistingProject();
-      if (!proj) { ctx.skip(); return; }
+      if (!proj) {
+        ctx.skip();
+        return;
+      }
       const projDetails = await runEffect(v1GetProject({ ref: proj.ref }));
-      if (projDetails.status !== "ACTIVE_HEALTHY") { ctx.skip(); return; }
+      if (projDetails.status !== "ACTIVE_HEALTHY") {
+        ctx.skip();
+        return;
+      }
       const result = await runEffect(
         v1GetProjectPgbouncerConfig({ ref: proj.ref }).pipe(
           Effect.catch((e) => {
             const tag = (e as any)._tag;
-            if (tag === "InternalServerError" || tag === "UnknownSupabaseError") return Effect.succeed(null);
+            if (tag === "InternalServerError" || tag === "UnknownSupabaseError")
+              return Effect.succeed(null);
             return Effect.fail(e);
           }),
         ),
       );
-      if (result === null) { ctx.skip(); return; }
+      if (result === null) {
+        ctx.skip();
+        return;
+      }
       expect(typeof result).toBe("object");
       if (result.pool_mode !== undefined) {
-        expect(["transaction", "session", "statement"]).toContain(result.pool_mode);
+        expect(["transaction", "session", "statement"]).toContain(
+          result.pool_mode,
+        );
       }
       if (result.default_pool_size !== undefined) {
         expect(typeof result.default_pool_size).toBe("number");
@@ -1151,13 +1314,15 @@ describe("Projects", () => {
       const orgSlug = await getExistingOrgSlug();
       const name = `distilled-supabase-del-${testRunId}`;
       const created = await runEffect(
-        v1CreateAProject({
-          name,
-          organization_slug: orgSlug,
-          db_pass: `TestPass${testRunId}!1`,
-          region: "us-east-1",
-          plan: "free",
-        }),
+        retryOnFreeProjectLimit(
+          v1CreateAProject({
+            name,
+            organization_slug: orgSlug,
+            db_pass: `TestPass${testRunId}!1`,
+            region: "us-east-1",
+            plan: "free",
+          }),
+        ),
       );
       const result = await runEffect(v1DeleteAProject({ ref: created.ref }));
       expect(result.ref).toBe(created.ref);

--- a/packages/supabase/tests/setup.ts
+++ b/packages/supabase/tests/setup.ts
@@ -1,5 +1,5 @@
 import { config } from "dotenv";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Schedule } from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { CredentialsFromEnv } from "../src/credentials";
 import { v1ListAllProjects } from "../src/operations/v1ListAllProjects";
@@ -35,6 +35,63 @@ export const runEffect = <A, E>(effect: Effect.Effect<A, E, any>): Promise<A> =>
 export const FAKE_REF = "nonexistent00000000ref";
 export const FAKE_UUID = "00000000-0000-0000-0000-000000000000";
 
+/**
+ * Wrap a project-creating Effect so that hitting Supabase's free-tier
+ * "active free projects" ceiling auto-recovers: we sweep every existing
+ * `distilled-supabase-*` project from the account, wait for the deletes
+ * to propagate, and retry. Bounded so a real, unrelated quota issue
+ * still surfaces.
+ *
+ * Supabase's management API has no way to query "are there any deletions
+ * still propagating?" — `v1DeleteAProject` returns immediately and the
+ * project lingers as REMOVED for ~30s while still counting toward the
+ * limit — so the recovery path waits a bit before each retry.
+ */
+export const retryOnFreeProjectLimit = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => {
+  const isLimit = (e: unknown): boolean =>
+    typeof e === "object" &&
+    e !== null &&
+    (e as { _tag?: string })._tag === "FreeProjectLimitReached";
+  // On limit: sweep first (so the next attempt has fewer active projects),
+  // wait for deletions to propagate, then re-fail so the outer retry tries
+  // again. Bounded to 3 retries spaced 20s apart.
+  const recover = effect.pipe(
+    Effect.catch((e) =>
+      isLimit(e)
+        ? sweepStaleTestProjects().pipe(
+            Effect.flatMap(() => Effect.sleep("20 seconds")),
+            Effect.flatMap(() => Effect.fail(e)),
+          )
+        : Effect.fail(e),
+    ),
+  ) as Effect.Effect<A, E, R>;
+  return recover.pipe(
+    Effect.retry({
+      while: isLimit,
+      schedule: Schedule.recurs(3),
+    }),
+  );
+};
+
+/**
+ * Best-effort: list every project in the account whose name starts with
+ * the test prefix and ask Supabase to delete it. Errors are swallowed
+ * because this only runs as a recovery hook.
+ */
+const sweepStaleTestProjects = (): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const projects = yield* v1ListAllProjects({}).pipe(
+      Effect.orElseSucceed(() => [] as Array<{ ref: string; name: string }>),
+    );
+    for (const p of projects) {
+      if (p.name.startsWith("distilled-supabase")) {
+        yield* v1DeleteAProject({ ref: p.ref }).pipe(Effect.ignore);
+      }
+    }
+  }).pipe(Effect.provide(TestLayer)) as Effect.Effect<void>;
+
 // --------------------------------------------------------------------------
 // Shared test project management
 // --------------------------------------------------------------------------
@@ -62,7 +119,8 @@ export async function getExistingProject(): Promise<TestProject | undefined> {
   _existingProjectResolved = true;
   const projects = await runEffect(v1ListAllProjects({}));
   // Prefer ACTIVE_HEALTHY, fall back to any project
-  const active = projects.find((p) => p.status === "ACTIVE_HEALTHY") ?? projects[0];
+  const active =
+    projects.find((p) => p.status === "ACTIVE_HEALTHY") ?? projects[0];
   if (active) {
     _cachedExistingProject = {
       id: active.id,
@@ -78,7 +136,9 @@ export async function getExistingProject(): Promise<TestProject | undefined> {
 /**
  * Get an existing project or skip the test if none available.
  */
-export async function requireExistingProject(ctx: { skip: (reason: string) => void }): Promise<TestProject> {
+export async function requireExistingProject(ctx: {
+  skip: (reason: string) => void;
+}): Promise<TestProject> {
   const proj = await getExistingProject();
   if (!proj) {
     ctx.skip("No projects available");
@@ -111,13 +171,15 @@ export async function setupTestProject(suffix: string): Promise<TestProject> {
   const dbPass = `TestPass${testRunId}!1`;
 
   const result = await runEffect(
-    v1CreateAProject({
-      name,
-      organization_slug: orgSlug,
-      db_pass: dbPass,
-      region: "us-east-1",
-      plan: "free",
-    }),
+    retryOnFreeProjectLimit(
+      v1CreateAProject({
+        name,
+        organization_slug: orgSlug,
+        db_pass: dbPass,
+        region: "us-east-1",
+        plan: "free",
+      }),
+    ),
   );
 
   const proj: TestProject = {


### PR DESCRIPTION
Add debug logging and tracing spans to the shared API client so operations are observable without per-SDK plumbing.

- Each operation now emits two `Effect.logDebug` lines: `→ {METHOD} {url}` before the request and `← {status} {METHOD} {url}` after the response.
- Each operation is wrapped in `Effect.withSpan` named `{METHOD} {pathTemplate}` with `http.method` and `http.route` attributes — picked up automatically by any tracer the user provides.
- `DISTILLED_DEBUG=1` forces `MinimumLogLevel` to `Debug` for SDK operations, independent of the caller's logger config. Users who set `MinimumLogLevel` to `Debug` themselves get the same logs without the env var.

```
DISTILLED_DEBUG=1 bun run my-script.ts
# → GET https://api.example.com/v1/things
# ← 200 GET https://api.example.com/v1/things
```
