### PR TITLE
feat(core): debug logging and per-operation spans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,12 @@ When you automatically open a PR, it MUST follow this structure:
 
 The summary goes at the very top of the description as plain prose — NO heading above it, no `### Summary`, nothing. The PR title already serves as the title; do not repeat or re-title it. Only add `###` subheadings further down if the description genuinely has multiple sections worth separating.
 
+**Markdown — write it plainly, do not escape:**
+- Inline code uses single backticks: `` `MyThing` ``. Block code uses triple backticks. That's it.
+- NEVER pad backticks with spaces (`` ` ` `MyThing` ` ` ``). NEVER escape them. The result looks like garbage and is never what the user wants.
+- When passing a PR body to `gh`, write it to a file and use `--body-file` (or `gh api -F body=@file`). Do NOT inline it in a heredoc you then try to escape — that is what causes the broken backticks.
+- If `gh pr edit` fails (it can fail on some repos due to a Projects-classic GraphQL deprecation), retry via `gh api -X PATCH repos/{owner}/{repo}/pulls/{n} -F body=@file.md`.
+
 Example PR description (good):
 
 ```

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -28,6 +28,7 @@
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipeArguments } from "effect/Pipeable";
+import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
@@ -47,6 +48,19 @@ import {
 import * as Category from "./category.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
+
+// `DISTILLED_DEBUG=1` forces the MinimumLogLevel to Debug for SDK operations,
+// independent of the caller's logger config. Users who set `MinimumLogLevel`
+// to Debug themselves get the same logs without needing the env var.
+const distilledDebugEnv: boolean = (() => {
+  try {
+    return (
+      typeof process !== "undefined" && process.env?.DISTILLED_DEBUG === "1"
+    );
+  } catch {
+    return false;
+  }
+})();
 
 // ============================================================================
 // Client Types
@@ -407,6 +421,8 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
         Schedule.recurs(8),
       );
 
+      const spanName = `${method} ${httpTrait.path}`;
+
       const innerFn = (input: Input): Effect.Effect<any, any, any> =>
         Effect.gen(function* () {
           const credentials = yield* config.credentials as any;
@@ -514,6 +530,9 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             }
           }
 
+          const requestUrl = baseUrl + parts.path;
+          yield* Effect.logDebug(`→ ${method} ${requestUrl}`);
+
           // For operations that opt out of following redirects, hand the
           // underlying fetch a `redirect: "manual"` request init so the
           // 3xx surfaces here instead of being chased to the IdP.
@@ -527,6 +546,9 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             : client.execute(request).pipe(Effect.scoped);
 
           const response = yield* executeRequest;
+          yield* Effect.logDebug(
+            `← ${response.status} ${method} ${requestUrl}`,
+          );
 
           // For ops that opted out of redirect-following, treat 3xx as
           // success: synthesize a body containing the Location header
@@ -681,13 +703,23 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       // / `withRetryable({ throttling: true })`). After retries are
       // exhausted the original typed error propagates to the caller as
       // usual.
-      const fn = (input: Input): Effect.Effect<any, any, any> =>
-        innerFn(input).pipe(
+      const fn = (input: Input): Effect.Effect<any, any, any> => {
+        const withRetry = innerFn(input).pipe(
           Effect.retry({
             schedule: throttlingRetrySchedule,
             while: (e) => Category.isThrottling(e),
           }),
+          Effect.withSpan(spanName, {
+            attributes: {
+              "http.method": method,
+              "http.route": httpTrait.path,
+            },
+          }),
         );
+        return distilledDebugEnv
+          ? Effect.provideService(withRetry, MinimumLogLevel, "Debug")
+          : withRetry;
+      };
 
       const Proto = {
         [Symbol.iterator]() {


### PR DESCRIPTION
Add debug logging and tracing spans to the shared API client so operations are observable without per-SDK plumbing.

- Each operation now emits two `Effect.logDebug` lines: `→ {METHOD} {url}` before the request and `← {status} {METHOD} {url}` after the response.
- Each operation is wrapped in `Effect.withSpan` named `{METHOD} {pathTemplate}` with `http.method` and `http.route` attributes — picked up automatically by any tracer the user provides.
- `DISTILLED_DEBUG=1` forces `MinimumLogLevel` to `Debug` for SDK operations, independent of the caller's logger config. Users who set `MinimumLogLevel` to `Debug` themselves get the same logs without the env var.

```
DISTILLED_DEBUG=1 bun run my-script.ts
# → GET https://api.example.com/v1/things
# ← 200 GET https://api.example.com/v1/things
```

Also documents in `AGENTS.md` the rule to never pad/escape backticks in PR bodies and to pass `--body-file` to `gh` (with REST PATCH fallback for the Projects-classic GraphQL deprecation hitting `gh pr edit`).
