### PR TITLE
refactor(core,sdks): unify Retry into a single shared Context.Service

### DIFF
--- a/packages/axiom/src/client.ts
+++ b/packages/axiom/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownAxiomError,
@@ -108,5 +109,6 @@ export const API = makeAPI<Credentials>({
   },
   matchError,
   ParseError: AxiomParseError as any,
+  retry: Retry as any,
   transformResponse: stripNulls,
 });

--- a/packages/axiom/src/retry.ts
+++ b/packages/axiom/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * axiom retry configuration.
+ * Axiom retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * axiom API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/axiom/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Axiom API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Axiom from "@distilled.cloud/axiom";
+ *
+ * myEffect.pipe(Axiom.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Axiom.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Axiom API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("AxiomRetry") {}
+
+/** Provides a custom retry policy to every Axiom API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/axiom/src/retry.ts
+++ b/packages/axiom/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Axiom retry configuration.
+ * axiom retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * axiom API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Axiom API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("AxiomRetry") {}
-
-/**
- * Provides a custom retry policy to all Axiom API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/azure/src/client.ts
+++ b/packages/azure/src/client.ts
@@ -23,6 +23,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   AZURE_ERROR_CODE_MAP,
@@ -158,6 +159,7 @@ export const API = makeAPI<Credentials>({
   },
   matchError,
   ParseError: AzureParseError as any,
+  retry: Retry as any,
 
   /**
    * Inject `subscriptionId` from credentials into the path when the generated

--- a/packages/azure/src/retry.ts
+++ b/packages/azure/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * azure retry configuration.
+ * Azure retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * azure API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/azure/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Azure API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Azure from "@distilled.cloud/azure";
+ *
+ * myEffect.pipe(Azure.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Azure.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Azure API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("AzureRetry") {}
+
+/** Provides a custom retry policy to every Azure API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/azure/src/retry.ts
+++ b/packages/azure/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Azure retry configuration.
+ * azure retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * azure API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Azure API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("AzureRetry") {}
-
-/**
- * Provides a custom retry policy to all Azure API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -32,6 +32,7 @@ import {
   UnknownCloudflareError,
 } from "../errors.ts";
 import { Credentials, formatHeaders } from "../credentials.ts";
+import { Retry } from "../retry.ts";
 import { type ErrorMatcher, getErrorMatchers } from "../traits.ts";
 
 // ============================================================================
@@ -378,6 +379,7 @@ const _API = makeAPI<Credentials>({
   ParseError: CloudflareDecodeError as any,
   transformRequestParts: ({ pathTemplate, parts }) =>
     transformCloudflareRequestParts({ pathTemplate, parts }),
+  retry: Retry as any,
 });
 
 const paginatePageByItems: PaginationStrategy = (

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -32,7 +32,6 @@ import {
   UnknownCloudflareError,
 } from "../errors.ts";
 import { Credentials, formatHeaders } from "../credentials.ts";
-import { Retry } from "../retry.ts";
 import { type ErrorMatcher, getErrorMatchers } from "../traits.ts";
 
 // ============================================================================
@@ -379,7 +378,6 @@ const _API = makeAPI<Credentials>({
   ParseError: CloudflareDecodeError as any,
   transformRequestParts: ({ pathTemplate, parts }) =>
     transformCloudflareRequestParts({ pathTemplate, parts }),
-  retry: Retry as any,
 });
 
 const paginatePageByItems: PaginationStrategy = (

--- a/packages/cloudflare/src/retry.ts
+++ b/packages/cloudflare/src/retry.ts
@@ -1,35 +1,30 @@
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
+/**
+ * Cloudflare retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so callers can install a blanket retry policy that covers every Cloudflare
+ * API call below the layer:
+ *
+ * @example
+ * ```ts
+ * import * as Cloudflare from "@distilled.cloud/cloudflare";
+ *
+ * myEffect.pipe(Cloudflare.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Cloudflare.Retry.Retry, customPolicy));
+ * ```
+ */
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import {
-  type Policy,
-  throttlingOptions,
-  transientOptions,
-} from "@distilled.cloud/core/retry";
-
-export class Retry extends Context.Service<Retry, Policy>()(
-  "CloudflareRetry",
-) {}
-
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);
-
-/** Apply throttling retry policy (retries throttling errors indefinitely) */
-export const throttling = policy(throttlingOptions);
-
-/** Apply transient retry policy (retries all transient errors indefinitely) */
-export const transient = policy(transientOptions);

--- a/packages/cloudflare/src/retry.ts
+++ b/packages/cloudflare/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Cloudflare API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("CloudflareRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "CloudflareRetry",
+) {}
 
 /** Provides a custom retry policy to every Cloudflare API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/cloudflare/src/retry.ts
+++ b/packages/cloudflare/src/retry.ts
@@ -1,9 +1,10 @@
 /**
  * Cloudflare retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so callers can install a blanket retry policy that covers every Cloudflare
- * API call below the layer:
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/cloudflare/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Cloudflare API call below it pick it up:
  *
  * @example
  * ```ts
@@ -13,18 +14,40 @@
  * Effect.provide(myEffect, Layer.succeed(Cloudflare.Retry.Retry, customPolicy));
  * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Cloudflare API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("CloudflareRetry") {}
+
+/** Provides a custom retry policy to every Cloudflare API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/coinbase/src/client.ts
+++ b/packages/coinbase/src/client.ts
@@ -35,6 +35,7 @@ import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import * as crypto from "node:crypto";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   COINBASE_HTTP_STATUS_MAP,
@@ -288,4 +289,5 @@ export const API = makeAPI<Credentials>({
   },
   matchError,
   ParseError: CoinbaseParseError as any,
+  retry: Retry as any,
 });

--- a/packages/coinbase/src/retry.ts
+++ b/packages/coinbase/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * coinbase retry configuration.
+ * Coinbase retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * coinbase API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/coinbase/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Coinbase API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Coinbase from "@distilled.cloud/coinbase";
+ *
+ * myEffect.pipe(Coinbase.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Coinbase.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Coinbase API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("CoinbaseRetry") {}
+
+/** Provides a custom retry policy to every Coinbase API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/coinbase/src/retry.ts
+++ b/packages/coinbase/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Coinbase retry configuration.
+ * coinbase retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * coinbase API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Coinbase API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("CoinbaseRetry") {}
-
-/**
- * Provides a custom retry policy to all Coinbase API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,6 +25,7 @@
  * const result = yield* fn({ organization: "my-org" });
  * ```
  */
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
 import * as Option from "effect/Option";
@@ -46,7 +47,7 @@ import {
   type PaginatedTrait,
   type PaginationStrategy,
 } from "./pagination.ts";
-import { makeDefault, Retry } from "./retry.ts";
+import { makeDefault, type Policy as RetryPolicy } from "./retry.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
 
@@ -170,6 +171,20 @@ export interface ClientConfig<Creds> {
     pathTemplate: string;
     parts: Traits.RequestParts;
   }) => Traits.RequestParts;
+
+  /**
+   * The SDK's `Retry` Context.Service tag. Each per-SDK client wires its
+   * own tag here so callers can install a blanket policy at the layer
+   * level (e.g. `myEffect.pipe(Cloudflare.Retry.transient)`) and have
+   * every API call below it pick it up — same pattern as
+   * `packages/aws/src/client/api.ts`.
+   *
+   * `makeAPI` reads the policy via `Effect.serviceOption(retry)` on every
+   * call and falls back to `Retry.makeDefault` (transient/throttling/server
+   * with capped exponential backoff + jitter, 5 attempts) when no policy
+   * is provided.
+   */
+  retry: Context.Key<any, RetryPolicy>;
 }
 
 /**
@@ -685,18 +700,19 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           );
         });
 
-      // Auto-retry every operation using the shared `Retry` Context.Service.
-      // The policy is read with `Effect.serviceOption(Retry)` and falls back
-      // to `Retry.makeDefault` (transient/throttling/server errors with
-      // capped exponential backoff + jitter, 5 attempts) when no policy has
-      // been provided. This mirrors the AWS pattern in
-      // `packages/aws/src/client/api.ts` and lets callers install a blanket
-      // policy at the layer level instead of wrapping every call site with
-      // `Effect.retry(...)`.
+      // Auto-retry every operation using the SDK's per-client `Retry`
+      // Context.Service. The policy is read with `Effect.serviceOption`
+      // and falls back to `Retry.makeDefault` (transient/throttling/server
+      // errors with capped exponential backoff + jitter, 5 attempts) when
+      // no policy has been provided in context. This mirrors the AWS
+      // pattern in `packages/aws/src/client/api.ts` and lets callers
+      // install a blanket policy at the layer level instead of wrapping
+      // every call site with `Effect.retry(...)`.
+      const retryTag = config.retry;
       const fn = (input: Input): Effect.Effect<any, any, any> => {
         const withRetry = Effect.gen(function* () {
           const lastError = yield* Ref.make<unknown>(undefined);
-          const policy = (yield* Effect.serviceOption(Retry)).pipe(
+          const policy = (yield* Effect.serviceOption(retryTag)).pipe(
             Option.map((value) =>
               typeof value === "function" ? value(lastError) : value,
             ),

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,10 +25,14 @@
  * const result = yield* fn({ organization: "my-org" });
  * ```
  */
+import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import { pipe } from "effect/Function";
+import * as Option from "effect/Option";
 import { pipeArguments } from "effect/Pipeable";
 import { MinimumLogLevel } from "effect/References";
+import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
@@ -46,6 +50,7 @@ import {
   type PaginationStrategy,
 } from "./pagination.ts";
 import * as Category from "./category.ts";
+import { makeDefault, type Policy as RetryPolicy } from "./retry.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
 
@@ -169,6 +174,17 @@ export interface ClientConfig<Creds> {
     pathTemplate: string;
     parts: Traits.RequestParts;
   }) => Traits.RequestParts;
+
+  /**
+   * Optional `Retry` Context.Service tag for this SDK. When provided, every
+   * operation reads the policy via `Effect.serviceOption(retry)` and falls
+   * back to `Retry.makeDefault` if no policy is provided. This lets callers
+   * apply a blanket retry policy (e.g. `Effect.provide(Layer.succeed(Retry,
+   * customPolicy))`) instead of wrapping every call site with
+   * `Effect.retry(...)`. When omitted, only the legacy hard-coded
+   * throttling-only retry runs.
+   */
+  retry?: Context.Key<any, RetryPolicy>;
 }
 
 /**
@@ -697,18 +713,45 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           );
         });
 
-      // Auto-retry whenever the SDK's matchError returns a typed error
-      // tagged with the throttling category (e.g. `TooManyRequests`,
-      // or any SDK-specific subclass marked with `withThrottlingError`
-      // / `withRetryable({ throttling: true })`). After retries are
-      // exhausted the original typed error propagates to the caller as
-      // usual.
+      // Auto-retry on every operation. When the SDK passes a `retry`
+      // Context.Service tag, we read the policy from context (with
+      // `Retry.makeDefault` as a fallback) so callers can install a
+      // blanket retry policy at the layer level — same pattern as
+      // `packages/aws`. When no `retry` tag is configured, fall back to
+      // the legacy hard-coded throttling-only schedule for backward
+      // compatibility with SDKs that haven't opted in yet.
       const fn = (input: Input): Effect.Effect<any, any, any> => {
-        const withRetry = innerFn(input).pipe(
-          Effect.retry({
-            schedule: throttlingRetrySchedule,
-            while: (e) => Category.isThrottling(e),
-          }),
+        const withRetry = config.retry
+          ? Effect.gen(function* () {
+              const lastError = yield* Ref.make<unknown>(undefined);
+              const retryTag = config.retry!;
+              const policy = (yield* Effect.serviceOption(retryTag)).pipe(
+                Option.map((value) =>
+                  typeof value === "function" ? value(lastError) : value,
+                ),
+                Option.getOrElse(() => makeDefault(lastError)),
+              );
+
+              return yield* pipe(
+                innerFn(input),
+                Effect.tapError((error) => Ref.set(lastError, error)),
+                policy.while
+                  ? (eff) =>
+                      Effect.retry(eff, {
+                        while: policy.while,
+                        schedule: policy.schedule,
+                      })
+                  : (eff) => eff,
+              );
+            })
+          : innerFn(input).pipe(
+              Effect.retry({
+                schedule: throttlingRetrySchedule,
+                while: (e) => Category.isThrottling(e),
+              }),
+            );
+
+        const withSpan = withRetry.pipe(
           Effect.withSpan(spanName, {
             attributes: {
               "http.method": method,
@@ -717,8 +760,8 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           }),
         );
         return distilledDebugEnv
-          ? Effect.provideService(withRetry, MinimumLogLevel, "Debug")
-          : withRetry;
+          ? Effect.provideService(withSpan, MinimumLogLevel, "Debug")
+          : withSpan;
       };
 
       const Proto = {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,15 +25,12 @@
  * const result = yield* fn({ organization: "my-org" });
  * ```
  */
-import * as Context from "effect/Context";
-import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
 import * as Option from "effect/Option";
 import { pipeArguments } from "effect/Pipeable";
 import { MinimumLogLevel } from "effect/References";
 import * as Ref from "effect/Ref";
-import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
 import * as Stream from "effect/Stream";
@@ -49,8 +46,7 @@ import {
   type PaginatedTrait,
   type PaginationStrategy,
 } from "./pagination.ts";
-import * as Category from "./category.ts";
-import { makeDefault, type Policy as RetryPolicy } from "./retry.ts";
+import { makeDefault, Retry } from "./retry.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
 
@@ -174,17 +170,6 @@ export interface ClientConfig<Creds> {
     pathTemplate: string;
     parts: Traits.RequestParts;
   }) => Traits.RequestParts;
-
-  /**
-   * Optional `Retry` Context.Service tag for this SDK. When provided, every
-   * operation reads the policy via `Effect.serviceOption(retry)` and falls
-   * back to `Retry.makeDefault` if no policy is provided. This lets callers
-   * apply a blanket retry policy (e.g. `Effect.provide(Layer.succeed(Retry,
-   * customPolicy))`) instead of wrapping every call site with
-   * `Effect.retry(...)`. When omitted, only the legacy hard-coded
-   * throttling-only retry runs.
-   */
-  retry?: Context.Key<any, RetryPolicy>;
 }
 
 /**
@@ -423,19 +408,6 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       }
 
       const method = httpTrait.method;
-
-      // Capped exponential backoff bounded to 8 attempts so a
-      // pathologically rate-limited endpoint can't hang a test run.
-      // Effect 4's `Schedule.exponential(base, factor)` already produces
-      // delays of base, base*factor, base*factor^2, ...; combined with
-      // `Schedule.both(Schedule.recurs(8))` to cap retries. We don't
-      // currently honour Retry-After (would require a per-attempt Ref);
-      // the exponential ramp is conservative enough for the rate limits
-      // we hit in practice.
-      const throttlingRetrySchedule = Schedule.both(
-        Schedule.exponential(Duration.seconds(1), 2),
-        Schedule.recurs(8),
-      );
 
       const spanName = `${method} ${httpTrait.path}`;
 
@@ -713,43 +685,36 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           );
         });
 
-      // Auto-retry on every operation. When the SDK passes a `retry`
-      // Context.Service tag, we read the policy from context (with
-      // `Retry.makeDefault` as a fallback) so callers can install a
-      // blanket retry policy at the layer level — same pattern as
-      // `packages/aws`. When no `retry` tag is configured, fall back to
-      // the legacy hard-coded throttling-only schedule for backward
-      // compatibility with SDKs that haven't opted in yet.
+      // Auto-retry every operation using the shared `Retry` Context.Service.
+      // The policy is read with `Effect.serviceOption(Retry)` and falls back
+      // to `Retry.makeDefault` (transient/throttling/server errors with
+      // capped exponential backoff + jitter, 5 attempts) when no policy has
+      // been provided. This mirrors the AWS pattern in
+      // `packages/aws/src/client/api.ts` and lets callers install a blanket
+      // policy at the layer level instead of wrapping every call site with
+      // `Effect.retry(...)`.
       const fn = (input: Input): Effect.Effect<any, any, any> => {
-        const withRetry = config.retry
-          ? Effect.gen(function* () {
-              const lastError = yield* Ref.make<unknown>(undefined);
-              const retryTag = config.retry!;
-              const policy = (yield* Effect.serviceOption(retryTag)).pipe(
-                Option.map((value) =>
-                  typeof value === "function" ? value(lastError) : value,
-                ),
-                Option.getOrElse(() => makeDefault(lastError)),
-              );
+        const withRetry = Effect.gen(function* () {
+          const lastError = yield* Ref.make<unknown>(undefined);
+          const policy = (yield* Effect.serviceOption(Retry)).pipe(
+            Option.map((value) =>
+              typeof value === "function" ? value(lastError) : value,
+            ),
+            Option.getOrElse(() => makeDefault(lastError)),
+          );
 
-              return yield* pipe(
-                innerFn(input),
-                Effect.tapError((error) => Ref.set(lastError, error)),
-                policy.while
-                  ? (eff) =>
-                      Effect.retry(eff, {
-                        while: policy.while,
-                        schedule: policy.schedule,
-                      })
-                  : (eff) => eff,
-              );
-            })
-          : innerFn(input).pipe(
-              Effect.retry({
-                schedule: throttlingRetrySchedule,
-                while: (e) => Category.isThrottling(e),
-              }),
-            );
+          return yield* pipe(
+            innerFn(input),
+            Effect.tapError((error) => Ref.set(lastError, error)),
+            policy.while
+              ? (eff) =>
+                  Effect.retry(eff, {
+                    while: policy.while,
+                    schedule: policy.schedule,
+                  })
+              : (eff) => eff,
+          );
+        });
 
         const withSpan = withRetry.pipe(
           Effect.withSpan(spanName, {

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -2,24 +2,14 @@
  * Retry Policy System
  *
  * Provides configurable retry policies for API operations.
- * Each SDK creates its own Retry service tag but uses these shared utilities
- * for building retry schedules and policies.
- *
- * @example
- * ```ts
- * import * as Retry from "@distilled.cloud/core/retry";
- *
- * // Use the default retry policy
- * myEffect.pipe(Retry.policy(myRetryService, Retry.makeDefault()))
- *
- * // Disable retries
- * myEffect.pipe(Retry.none(myRetryService))
- * ```
+ * Each SDK creates its own `Retry` Context.Service tag (via
+ * `makeRetryService`) and threads it into `makeAPI({ retry: <SDK>.Retry })`
+ * so that callers can install a blanket retry policy at the layer level
+ * for that SDK without wrapping every call with `Effect.retry`.
  */
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
-import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Context from "effect/Context";
@@ -55,51 +45,20 @@ export type Factory = (lastError: Ref.Ref<unknown>) => Options;
 export type Policy = Options | Factory;
 
 // ============================================================================
-// Shared Retry Service
+// Retry Service Factory
 // ============================================================================
 
 /**
- * Shared `Retry` Context.Service consumed by `@distilled.cloud/core/client`'s
- * `makeAPI`. Every SDK that goes through the shared client (cloudflare,
- * turso, planetscale, neon, stripe, kubernetes, axiom, posthog, gcp, ...)
- * reads its retry policy from this single tag, so an `Effect.provide`
- * (or `Layer.succeed`) at any layer covers every API call below it.
+ * Create a typed Retry service class for an SDK.
+ * Each SDK creates its own Retry service using this factory; the SDK's
+ * client wraps `makeAPI` with `retry: <SDK>.Retry` so the policy applies
+ * to every API call below it.
  *
  * @example
  * ```ts
- * import * as Retry from "@distilled.cloud/core/retry";
- *
- * myEffect.pipe(Retry.transient);
- * Effect.provide(myEffect, Layer.succeed(Retry.Retry, customPolicy));
+ * // packages/<sdk>/src/retry.ts
+ * export class Retry extends makeRetryService("PlanetScaleRetry") {}
  * ```
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "@distilled.cloud/core/Retry",
-) {}
-
-/**
- * Provides a custom retry policy to every API call below it.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);
-
-// ============================================================================
-// Legacy Retry Service Factory (deprecated)
-// ============================================================================
-
-/**
- * @deprecated Use the shared `Retry` Context.Service exported from this
- * module. Per-SDK Retry tags are no longer wired into core's `makeAPI`;
- * keeping a separate tag per SDK means the policy isn't actually consumed.
- * SDK retry modules should re-export `{ Retry, policy, none, throttling,
- * transient }` from `@distilled.cloud/core/retry` directly.
  */
 export const makeRetryService = (name: string) =>
   Context.Service<any, Policy>()(name);
@@ -190,8 +149,3 @@ export const transientOptions: Options = {
   ),
 };
 
-/** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
-
-/** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -55,40 +55,54 @@ export type Factory = (lastError: Ref.Ref<unknown>) => Options;
 export type Policy = Options | Factory;
 
 // ============================================================================
-// Retry Service Factory
+// Shared Retry Service
 // ============================================================================
 
 /**
- * Create a typed Retry service class for an SDK.
- * Each SDK should create its own Retry service using this factory.
+ * Shared `Retry` Context.Service consumed by `@distilled.cloud/core/client`'s
+ * `makeAPI`. Every SDK that goes through the shared client (cloudflare,
+ * turso, planetscale, neon, stripe, kubernetes, axiom, posthog, gcp, ...)
+ * reads its retry policy from this single tag, so an `Effect.provide`
+ * (or `Layer.succeed`) at any layer covers every API call below it.
  *
  * @example
  * ```ts
- * // In planetscale-sdk/src/retry.ts
- * export class Retry extends makeRetryService("PlanetScaleRetry") {}
+ * import * as Retry from "@distilled.cloud/core/retry";
+ *
+ * myEffect.pipe(Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Retry.Retry, customPolicy));
  * ```
  */
-export const makeRetryService = (name: string) =>
-  Context.Service<any, Policy>()(name);
+export class Retry extends Context.Service<Retry, Policy>()(
+  "@distilled.cloud/core/Retry",
+) {}
 
 /**
- * Provides a custom retry policy for API calls.
+ * Provides a custom retry policy to every API call below it.
  */
-export const policy =
-  (Service: any, optionsOrFactory: Policy) =>
-  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    Effect.provide(effect, Layer.succeed(Service, optionsOrFactory) as any);
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
 
 /**
  * Disables all automatic retries.
  */
-export const none =
-  (Service: any) =>
-  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    Effect.provide(
-      effect,
-      Layer.succeed(Service, { while: () => false }) as any,
-    );
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+// ============================================================================
+// Legacy Retry Service Factory (deprecated)
+// ============================================================================
+
+/**
+ * @deprecated Use the shared `Retry` Context.Service exported from this
+ * module. Per-SDK Retry tags are no longer wired into core's `makeAPI`;
+ * keeping a separate tag per SDK means the policy isn't actually consumed.
+ * SDK retry modules should re-export `{ Retry, policy, none, throttling,
+ * transient }` from `@distilled.cloud/core/retry` directly.
+ */
+export const makeRetryService = (name: string) =>
+  Context.Service<any, Policy>()(name);
 
 // ============================================================================
 // Retry Schedule Utilities
@@ -175,3 +189,9 @@ export const transientOptions: Options = {
     jittered,
   ),
 };
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -148,4 +148,3 @@ export const transientOptions: Options = {
     jittered,
   ),
 };
-

--- a/packages/expo-eas/src/client.ts
+++ b/packages/expo-eas/src/client.ts
@@ -23,6 +23,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownEasError,
@@ -138,4 +139,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: EasParseError as any,
+  retry: Retry as any,
 });

--- a/packages/expo-eas/src/retry.ts
+++ b/packages/expo-eas/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Eas retry configuration.
+ * expo-eas retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * expo-eas API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Eas API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("EasRetry") {}
-
-/**
- * Provides a custom retry policy to all Eas API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/expo-eas/src/retry.ts
+++ b/packages/expo-eas/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * expo-eas retry configuration.
+ * ExpoEas retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * expo-eas API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/expo-eas/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * ExpoEas API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as ExpoEas from "@distilled.cloud/expo-eas";
+ *
+ * myEffect.pipe(ExpoEas.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(ExpoEas.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of ExpoEas API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("ExpoEasRetry") {}
+
+/** Provides a custom retry policy to every ExpoEas API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/fly-io/src/client.ts
+++ b/packages/fly-io/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownFlyIoError,
@@ -58,4 +59,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: FlyIoParseError as any,
+  retry: Retry as any,
 });

--- a/packages/fly-io/src/retry.ts
+++ b/packages/fly-io/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * fly-io retry configuration.
+ * FlyIo retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * fly-io API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/fly-io/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * FlyIo API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as FlyIo from "@distilled.cloud/fly-io";
+ *
+ * myEffect.pipe(FlyIo.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(FlyIo.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of FlyIo API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("FlyIoRetry") {}
+
+/** Provides a custom retry policy to every FlyIo API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/fly-io/src/retry.ts
+++ b/packages/fly-io/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Fly-io retry configuration.
+ * fly-io retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * fly-io API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Fly-io API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("Fly-ioRetry") {}
-
-/**
- * Provides a custom retry policy to all Fly-io API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/gcp/src/client/api.ts
+++ b/packages/gcp/src/client/api.ts
@@ -14,6 +14,7 @@ import {
 } from "@distilled.cloud/core/client";
 import { HTTP_STATUS_MAP, UnknownGCPError, GCPParseError } from "../errors.ts";
 import { Credentials } from "../credentials.ts";
+import { Retry } from "../retry.ts";
 
 export type { OperationMethod, PaginatedOperationMethod };
 
@@ -51,6 +52,7 @@ const _API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: GCPParseError as any,
+  retry: Retry as any,
 });
 
 export const make = _API.make;

--- a/packages/gcp/src/retry.ts
+++ b/packages/gcp/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * gcp retry configuration.
+ * GCP retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * gcp API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/gcp/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * GCP API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as GCP from "@distilled.cloud/gcp";
+ *
+ * myEffect.pipe(GCP.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(GCP.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of GCP API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("GCPRetry") {}
+
+/** Provides a custom retry policy to every GCP API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/gcp/src/retry.ts
+++ b/packages/gcp/src/retry.ts
@@ -1,23 +1,22 @@
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
+/**
+ * gcp retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * gcp API call below it.
+ */
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-export class Retry extends Context.Service<Retry, Policy>()("GCPRetry") {}
-
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/kubernetes/src/client/api.ts
+++ b/packages/kubernetes/src/client/api.ts
@@ -19,6 +19,7 @@ import {
   KubernetesParseError,
 } from "../errors.ts";
 import { Credentials } from "../credentials.ts";
+import { Retry } from "../retry.ts";
 
 export type { OperationMethod, PaginatedOperationMethod };
 
@@ -93,6 +94,7 @@ const _API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: KubernetesParseError as any,
+  retry: Retry as any,
 });
 
 export const make = _API.make;

--- a/packages/kubernetes/src/retry.ts
+++ b/packages/kubernetes/src/retry.ts
@@ -1,37 +1,22 @@
 /**
- * Kubernetes retry configuration.
+ * kubernetes retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * kubernetes API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Kubernetes API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "KubernetesRetry",
-) {}
-
-/**
- * Provides a custom retry policy to all Kubernetes API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/kubernetes/src/retry.ts
+++ b/packages/kubernetes/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * kubernetes retry configuration.
+ * Kubernetes retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * kubernetes API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/kubernetes/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Kubernetes API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Kubernetes from "@distilled.cloud/kubernetes";
+ *
+ * myEffect.pipe(Kubernetes.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Kubernetes.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Kubernetes API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("KubernetesRetry") {}
+
+/** Provides a custom retry policy to every Kubernetes API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/kubernetes/src/retry.ts
+++ b/packages/kubernetes/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Kubernetes API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("KubernetesRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "KubernetesRetry",
+) {}
 
 /** Provides a custom retry policy to every Kubernetes API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/mongodb-atlas/src/client.ts
+++ b/packages/mongodb-atlas/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   PaymentRequired,
@@ -73,4 +74,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: MongodbAtlasParseError as any,
+  retry: Retry as any,
 });

--- a/packages/mongodb-atlas/src/retry.ts
+++ b/packages/mongodb-atlas/src/retry.ts
@@ -1,37 +1,22 @@
 /**
- * Mongodb-atlas retry configuration.
+ * mongodb-atlas retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * mongodb-atlas API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Mongodb-atlas API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "Mongodb-atlasRetry",
-) {}
-
-/**
- * Provides a custom retry policy to all Mongodb-atlas API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/mongodb-atlas/src/retry.ts
+++ b/packages/mongodb-atlas/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of MongoDBAtlas API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("MongoDBAtlasRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "MongoDBAtlasRetry",
+) {}
 
 /** Provides a custom retry policy to every MongoDBAtlas API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/mongodb-atlas/src/retry.ts
+++ b/packages/mongodb-atlas/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * mongodb-atlas retry configuration.
+ * MongoDBAtlas retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * mongodb-atlas API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/mongodb-atlas/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * MongoDBAtlas API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as MongoDBAtlas from "@distilled.cloud/mongodb-atlas";
+ *
+ * myEffect.pipe(MongoDBAtlas.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(MongoDBAtlas.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of MongoDBAtlas API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("MongoDBAtlasRetry") {}
+
+/** Provides a custom retry policy to every MongoDBAtlas API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/neon/src/client.ts
+++ b/packages/neon/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import { HTTP_STATUS_MAP, UnknownNeonError, NeonParseError } from "./errors.ts";
 
 // Re-export for backwards compatibility (tests import UnknownNeonError from client)
@@ -56,4 +57,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: NeonParseError as any,
+  retry: Retry as any,
 });

--- a/packages/neon/src/retry.ts
+++ b/packages/neon/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * neon retry configuration.
+ * Neon retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * neon API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/neon/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Neon API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Neon from "@distilled.cloud/neon";
+ *
+ * myEffect.pipe(Neon.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Neon.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Neon API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("NeonRetry") {}
+
+/** Provides a custom retry policy to every Neon API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/neon/src/retry.ts
+++ b/packages/neon/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Neon retry configuration.
+ * neon retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * neon API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Neon API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("NeonRetry") {}
-
-/**
- * Provides a custom retry policy to all Neon API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/planetscale/src/client.ts
+++ b/packages/planetscale/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownPlanetScaleError,
@@ -60,4 +61,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: PlanetScaleParseError as any,
+  retry: Retry as any,
 });

--- a/packages/planetscale/src/retry.ts
+++ b/packages/planetscale/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * planetscale retry configuration.
+ * PlanetScale retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * planetscale API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/planetscale/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * PlanetScale API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as PlanetScale from "@distilled.cloud/planetscale";
+ *
+ * myEffect.pipe(PlanetScale.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(PlanetScale.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of PlanetScale API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("PlanetScaleRetry") {}
+
+/** Provides a custom retry policy to every PlanetScale API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/planetscale/src/retry.ts
+++ b/packages/planetscale/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of PlanetScale API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("PlanetScaleRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "PlanetScaleRetry",
+) {}
 
 /** Provides a custom retry policy to every PlanetScale API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/planetscale/src/retry.ts
+++ b/packages/planetscale/src/retry.ts
@@ -1,39 +1,22 @@
 /**
- * PlanetScale retry configuration.
+ * planetscale retry configuration.
  *
- * Re-exports shared retry utilities and provides a PlanetScale-specific Retry service.
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * planetscale API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of PlanetScale API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "PlanetScaleRetry",
-) {}
-
-/**
- * Provides a custom retry policy to all PlanetScale API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/posthog/src/client.ts
+++ b/packages/posthog/src/client.ts
@@ -7,6 +7,7 @@
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownPosthogError,
@@ -80,4 +81,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: PosthogParseError as any,
+  retry: Retry as any,
 });

--- a/packages/posthog/src/retry.ts
+++ b/packages/posthog/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Posthog retry configuration.
+ * posthog retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * posthog API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Posthog API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("PosthogRetry") {}
-
-/**
- * Provides a custom retry policy to all Posthog API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/posthog/src/retry.ts
+++ b/packages/posthog/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * posthog retry configuration.
+ * PostHog retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * posthog API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/posthog/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * PostHog API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as PostHog from "@distilled.cloud/posthog";
+ *
+ * myEffect.pipe(PostHog.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(PostHog.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of PostHog API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("PostHogRetry") {}
+
+/** Provides a custom retry policy to every PostHog API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/prisma-postgres/src/client.ts
+++ b/packages/prisma-postgres/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownPrismaPostgresError,
@@ -73,4 +74,5 @@ export const API = makeAPI({
   }),
   matchError,
   ParseError: PrismaPostgresParseError as any,
+  retry: Retry as any,
 });

--- a/packages/prisma-postgres/src/retry.ts
+++ b/packages/prisma-postgres/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of PrismaPostgres API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("PrismaPostgresRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "PrismaPostgresRetry",
+) {}
 
 /** Provides a custom retry policy to every PrismaPostgres API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/prisma-postgres/src/retry.ts
+++ b/packages/prisma-postgres/src/retry.ts
@@ -1,37 +1,22 @@
 /**
- * Prisma Postgres retry configuration.
+ * prisma-postgres retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * prisma-postgres API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Prisma Postgres API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "PrismaPostgresRetry",
-) {}
-
-/**
- * Provides a custom retry policy to all Prisma Postgres API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/prisma-postgres/src/retry.ts
+++ b/packages/prisma-postgres/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * prisma-postgres retry configuration.
+ * PrismaPostgres retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * prisma-postgres API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/prisma-postgres/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * PrismaPostgres API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as PrismaPostgres from "@distilled.cloud/prisma-postgres";
+ *
+ * myEffect.pipe(PrismaPostgres.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(PrismaPostgres.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of PrismaPostgres API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("PrismaPostgresRetry") {}
+
+/** Provides a custom retry policy to every PrismaPostgres API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   STRIPE_HTTP_STATUS_MAP,
@@ -159,4 +160,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: StripeParseError as any,
+  retry: Retry as any,
 });

--- a/packages/stripe/src/retry.ts
+++ b/packages/stripe/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Stripe retry configuration.
+ * stripe retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * stripe API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Stripe API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("StripeRetry") {}
-
-/**
- * Provides a custom retry policy to all Stripe API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/stripe/src/retry.ts
+++ b/packages/stripe/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * stripe retry configuration.
+ * Stripe retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * stripe API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/stripe/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Stripe API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Stripe from "@distilled.cloud/stripe";
+ *
+ * myEffect.pipe(Stripe.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Stripe.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Stripe API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("StripeRetry") {}
+
+/** Provides a custom retry policy to every Stripe API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownSupabaseError,
@@ -60,4 +61,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: SupabaseParseError as any,
+  retry: Retry as any,
 });

--- a/packages/supabase/src/retry.ts
+++ b/packages/supabase/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Supabase retry configuration.
+ * supabase retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * supabase API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Supabase API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("SupabaseRetry") {}
-
-/**
- * Provides a custom retry policy to all Supabase API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/supabase/src/retry.ts
+++ b/packages/supabase/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * supabase retry configuration.
+ * Supabase retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * supabase API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/supabase/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Supabase API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Supabase from "@distilled.cloud/supabase";
+ *
+ * myEffect.pipe(Supabase.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Supabase.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Supabase API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("SupabaseRetry") {}
+
+/** Provides a custom retry policy to every Supabase API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/turso/src/client.ts
+++ b/packages/turso/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownTursoError,
@@ -61,4 +62,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: TursoParseError as any,
+  retry: Retry as any,
 });

--- a/packages/turso/src/retry.ts
+++ b/packages/turso/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Turso retry configuration.
+ * turso retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * turso API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Turso API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("TursoRetry") {}
-
-/**
- * Provides a custom retry policy to all Turso API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/turso/src/retry.ts
+++ b/packages/turso/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * turso retry configuration.
+ * Turso retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * turso API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/turso/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Turso API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Turso from "@distilled.cloud/turso";
+ *
+ * myEffect.pipe(Turso.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Turso.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Turso API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("TursoRetry") {}
+
+/** Provides a custom retry policy to every Turso API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/typesense/src/client.ts
+++ b/packages/typesense/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownTypesenseError,
@@ -58,4 +59,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: TypesenseParseError as any,
+  retry: Retry as any,
 });

--- a/packages/typesense/src/retry.ts
+++ b/packages/typesense/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Typesense retry configuration.
+ * typesense retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * typesense API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Typesense API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("TypesenseRetry") {}
-
-/**
- * Provides a custom retry policy to all Typesense API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/typesense/src/retry.ts
+++ b/packages/typesense/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * typesense retry configuration.
+ * Typesense retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * typesense API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/typesense/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Typesense API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Typesense from "@distilled.cloud/typesense";
+ *
+ * myEffect.pipe(Typesense.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Typesense.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Typesense API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("TypesenseRetry") {}
+
+/** Provides a custom retry policy to every Typesense API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/workos/src/client.ts
+++ b/packages/workos/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownWorkosError,
@@ -83,4 +84,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: WorkosParseError as any,
+  retry: Retry as any,
 });

--- a/packages/workos/src/retry.ts
+++ b/packages/workos/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Workos retry configuration.
+ * workos retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * workos API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Workos API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("WorkosRetry") {}
-
-/**
- * Provides a custom retry policy to all Workos API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/workos/src/retry.ts
+++ b/packages/workos/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * workos retry configuration.
+ * WorkOS retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * workos API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/workos/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * WorkOS API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as WorkOS from "@distilled.cloud/workos";
+ *
+ * myEffect.pipe(WorkOS.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(WorkOS.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of WorkOS API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("WorkOSRetry") {}
+
+/** Provides a custom retry policy to every WorkOS API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);


### PR DESCRIPTION
## Summary

Per-SDK `Retry` Context.Service tags were never actually consumed: each `packages/<sdk>/src/retry.ts` declared its own `Retry` class but the shared `makeAPI` in `@distilled.cloud/core/client` had no way to look up N different tags and just ran a hard-coded throttling-only schedule. So `Cloudflare.Retry.transient(eff)`, `Turso.Retry.policy(...)`, etc. all compiled and provided a layer — but nothing read it.

This PR keeps the per-SDK tag (so policies don't bleed across SDKs — `Cloudflare.Retry.transient` only retries Cloudflare calls, not turso underneath) and just has each SDK's client wire its own tag into `makeAPI` automatically. End users just write `myEffect.pipe(Cloudflare.Retry.transient)` — no per-SDK config to remember.

This mirrors the AWS pattern in `packages/aws/src/client/api.ts` (`outerFn` reads `Retry` with `Retry.makeDefault` as fallback).

### Changes

- **`packages/core/src/client.ts`** — `ClientConfig.retry` is now a required `Context.Key<any, RetryPolicy>`. `makeAPI` always reads the configured tag with `Effect.serviceOption` and falls back to `Retry.makeDefault` (transient/throttling/server with capped exponential backoff + jitter, 5 attempts). Removed the legacy hard-coded throttling-only branch.
- **`packages/core/src/retry.ts`** — kept `makeRetryService` as the primary API for SDKs, removed the short-lived shared `Retry` tag from the previous commit.
- **18 per-SDK `retry.ts` files** (cloudflare, turso, planetscale, neon, stripe, kubernetes, axiom, posthog, gcp, coinbase, supabase, expo-eas, fly-io, mongodb-atlas, typesense, workos, prisma-postgres, azure) — each declares its own `Retry` tag plus matching `policy`, `none`, `throttling`, `transient` helpers (added `throttling`/`transient` everywhere for parity — previously only cloudflare had them).
- **18 per-SDK `client.ts` / `client/api.ts` files** — each imports its local `Retry` and passes it as `retry: Retry as any` into the `makeAPI` config.

AWS continues to use its own client and `Retry` tag, unchanged.

### Caller-facing result

```ts
import * as Cloudflare from "@distilled.cloud/cloudflare";
import * as Turso from "@distilled.cloud/turso";

myEffect.pipe(Cloudflare.Retry.transient);
myEffect.pipe(Turso.Retry.policy({ while: isMyError, schedule: mySchedule }));
```

Every Cloudflare/Turso/etc. API call below transparently retries transient/throttling/server errors — no per-resource `Effect.retry` blocks, and policies stay scoped to each SDK.

## Test plan

- [x] tsgo typecheck clean for core, aws, and 17 of 18 SDKs (cloudflare, turso, planetscale, neon, stripe, kubernetes, axiom, posthog, coinbase, supabase, fly-io, mongodb-atlas, typesense, workos, prisma-postgres, azure, expo-eas). gcp has a pre-existing unrelated readonly-array error verified against main.
- [x] Cloudflare unit tests pass (client-api, credentials, spec-emission).
- [ ] CI: live test suites that already call `Retry.transient` in their test harnesses now exercise the real wiring instead of being no-ops.