### PR TITLE
fix(cloudflare): make ingress hostname optional for cfd tunnel configuration

### DIFF
--- a/packages/cloudflare/patches/zero-trust/getTunnelCloudflaredConfiguration.json
+++ b/packages/cloudflare/patches/zero-trust/getTunnelCloudflaredConfiguration.json
@@ -1,5 +1,10 @@
 {
   "errors": {
     "TunnelConfigurationNotFound": [{ "code": 1055 }]
+  },
+  "response": {
+    "properties": {
+      "config.ingress[].hostname": { "optional": true }
+    }
   }
 }

--- a/packages/cloudflare/patches/zero-trust/putTunnelCloudflaredConfiguration.json
+++ b/packages/cloudflare/patches/zero-trust/putTunnelCloudflaredConfiguration.json
@@ -1,5 +1,15 @@
 {
   "errors": {
     "TunnelNotFound": [{ "code": 1002 }]
+  },
+  "request": {
+    "properties": {
+      "config.ingress[].hostname": { "optional": true }
+    }
+  },
+  "response": {
+    "properties": {
+      "config.ingress[].hostname": { "optional": true }
+    }
   }
 }

--- a/packages/cloudflare/specs/cloudflare/zero-trust.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/zero-trust.openapi.yml
@@ -119745,7 +119745,6 @@ paths:
                               type: string
                               description: Requests with this path route to this public hostname.
                           required:
-                            - hostname
                             - service
                         description: List of public hostname definitions. At least one ingress rule
                           needs to be defined for the tunnel.
@@ -120001,7 +120000,6 @@ paths:
                             type: string
                             description: Requests with this path route to this public hostname.
                         required:
-                          - hostname
                           - service
                       description: List of public hostname definitions. At least one ingress rule
                         needs to be defined for the tunnel.
@@ -120223,7 +120221,6 @@ paths:
                               type: string
                               description: Requests with this path route to this public hostname.
                           required:
-                            - hostname
                             - service
                         description: List of public hostname definitions. At least one ingress rule
                           needs to be defined for the tunnel.

--- a/packages/cloudflare/src/services/zero-trust.ts
+++ b/packages/cloudflare/src/services/zero-trust.ts
@@ -99705,7 +99705,7 @@ export interface GetTunnelCloudflaredConfigurationResponse {
   config?: {
     ingress?:
       | {
-          hostname: string;
+          hostname?: string | null;
           service: string;
           originRequest?: {
             access?: {
@@ -99772,7 +99772,9 @@ export const GetTunnelCloudflaredConfigurationResponse =
             Schema.Union([
               Schema.Array(
                 Schema.Struct({
-                  hostname: Schema.String,
+                  hostname: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
                   service: Schema.String,
                   originRequest: Schema.optional(
                     Schema.Union([
@@ -99951,7 +99953,7 @@ export interface PutTunnelCloudflaredConfigurationRequest {
   /** Body param: The tunnel configuration and ingress rules. */
   config?: {
     ingress?: {
-      hostname: string;
+      hostname?: string;
       service: string;
       originRequest?: {
         access?: { audTag: string[]; teamName: string; required?: boolean };
@@ -100001,7 +100003,7 @@ export const PutTunnelCloudflaredConfigurationRequest =
         ingress: Schema.optional(
           Schema.Array(
             Schema.Struct({
-              hostname: Schema.String,
+              hostname: Schema.optional(Schema.String),
               service: Schema.String,
               originRequest: Schema.optional(
                 Schema.Struct({
@@ -100073,7 +100075,7 @@ export interface PutTunnelCloudflaredConfigurationResponse {
   config?: {
     ingress?:
       | {
-          hostname: string;
+          hostname?: string | null;
           service: string;
           originRequest?: {
             access?: {
@@ -100140,7 +100142,9 @@ export const PutTunnelCloudflaredConfigurationResponse =
             Schema.Union([
               Schema.Array(
                 Schema.Struct({
-                  hostname: Schema.String,
+                  hostname: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
                   service: Schema.String,
                   originRequest: Schema.optional(
                     Schema.Union([

--- a/packages/cloudflare/test/zero-trust-tunnel-config.test.ts
+++ b/packages/cloudflare/test/zero-trust-tunnel-config.test.ts
@@ -1,0 +1,162 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildRequestParts, getHttpTrait } from "@distilled.cloud/core/traits";
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import {
+  GetTunnelCloudflaredConfigurationResponse,
+  PutTunnelCloudflaredConfigurationRequest,
+  PutTunnelCloudflaredConfigurationResponse,
+} from "~/services/zero-trust";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const zeroTrustSpecPath = path.join(
+  testDir,
+  "..",
+  "specs",
+  "cloudflare",
+  "zero-trust.openapi.yml",
+);
+
+describe("ZeroTrust > Tunnel > configuration ingress hostname is optional", () => {
+  it("encodes a put request with a catch-all ingress rule (no hostname)", () => {
+    const httpTrait = getHttpTrait(PutTunnelCloudflaredConfigurationRequest.ast);
+    expect(httpTrait).toBeDefined();
+
+    const parts = buildRequestParts(
+      PutTunnelCloudflaredConfigurationRequest.ast,
+      httpTrait!,
+      {
+        accountId: "account-123",
+        tunnelId: "tunnel-abc",
+        config: {
+          ingress: [
+            { hostname: "test.example.com", service: "http://localhost:8080" },
+            { service: "http_status:404" },
+          ],
+        },
+      },
+      PutTunnelCloudflaredConfigurationRequest,
+    );
+
+    expect(parts.body).toEqual({
+      config: {
+        ingress: [
+          { hostname: "test.example.com", service: "http://localhost:8080" },
+          { service: "http_status:404" },
+        ],
+      },
+    });
+  });
+
+  it("decodes a get response containing a catch-all ingress rule (no hostname)", () => {
+    const decoded = Schema.decodeUnknownSync(
+      GetTunnelCloudflaredConfigurationResponse,
+    )({
+      accountId: "account-123",
+      config: {
+        ingress: [
+          { hostname: "test.example.com", service: "http://localhost:8080" },
+          { service: "http_status:404" },
+        ],
+      },
+      source: "cloudflare",
+      tunnelId: "tunnel-abc",
+      version: 1,
+    });
+
+    expect(decoded.config?.ingress).toEqual([
+      { hostname: "test.example.com", service: "http://localhost:8080" },
+      { service: "http_status:404" },
+    ]);
+  });
+
+  it("decodes a put response containing a catch-all ingress rule (no hostname)", () => {
+    const decoded = Schema.decodeUnknownSync(
+      PutTunnelCloudflaredConfigurationResponse,
+    )({
+      accountId: "account-123",
+      config: {
+        ingress: [{ service: "http_status:404" }],
+      },
+      source: "cloudflare",
+      tunnelId: "tunnel-abc",
+      version: 1,
+    });
+
+    expect(decoded.config?.ingress).toEqual([{ service: "http_status:404" }]);
+  });
+
+  it("emits ingress without hostname in the required array of the canonical spec", () => {
+    const spec = parseYaml(fs.readFileSync(zeroTrustSpecPath, "utf8")) as {
+      paths: Record<
+        string,
+        Record<
+          string,
+          {
+            operationId?: string;
+            requestBody?: {
+              content: {
+                "application/json": {
+                  schema: {
+                    properties?: {
+                      config?: {
+                        properties?: {
+                          ingress?: { items?: { required?: string[] } };
+                        };
+                      };
+                    };
+                  };
+                };
+              };
+            };
+            responses?: Record<
+              string,
+              {
+                content?: {
+                  "application/json": {
+                    schema: {
+                      properties?: {
+                        config?: {
+                          properties?: {
+                            ingress?: { items?: { required?: string[] } };
+                          };
+                        };
+                      };
+                    };
+                  };
+                };
+              }
+            >;
+          }
+        >
+      >;
+    };
+
+    const configPath =
+      spec.paths["/accounts/{account_id}/cfd_tunnel/{tunnelId}/configurations"];
+
+    const putRequestIngressRequired =
+      configPath?.put?.requestBody?.content["application/json"].schema
+        .properties?.config?.properties?.ingress?.items?.required;
+    expect(putRequestIngressRequired).toBeDefined();
+    expect(putRequestIngressRequired).not.toContain("hostname");
+    expect(putRequestIngressRequired).toContain("service");
+
+    const putResponseIngressRequired =
+      configPath?.put?.responses?.["200"].content?.["application/json"].schema
+        .properties?.config?.properties?.ingress?.items?.required;
+    expect(putResponseIngressRequired).toBeDefined();
+    expect(putResponseIngressRequired).not.toContain("hostname");
+    expect(putResponseIngressRequired).toContain("service");
+
+    const getResponseIngressRequired =
+      configPath?.get?.responses?.["200"].content?.["application/json"].schema
+        .properties?.config?.properties?.ingress?.items?.required;
+    expect(getResponseIngressRequired).toBeDefined();
+    expect(getResponseIngressRequired).not.toContain("hostname");
+    expect(getResponseIngressRequired).toContain("service");
+  });
+});


### PR DESCRIPTION
The Cloudflare Zero Trust Tunnel API requires the last ingress rule to be a catch-all (e.g. `{ service: "http_status:404" }`) that omits `hostname`, but the upstream cloudflare-typescript SDK marks `ingress[].hostname` as required, so any valid configuration fails Schema validation before the request leaves the process.

Patches `putTunnelCloudflaredConfiguration` (request + response) and `getTunnelCloudflaredConfiguration` (response) so `config.ingress[].hostname` is `optional: true` on both the write and read paths.

```diff
 await ZeroTrust.putTunnelCloudflaredConfiguration({
   accountId, tunnelId,
   config: {
     ingress: [
       { hostname: "test.example.com", service: "http://localhost:8080" },
-      // previously failed Schema validation: Missing key at config.ingress[1].hostname
       { service: "http_status:404" },
     ],
   },
 });
```

After this lands, alchemy can drop the `as { hostname: string; service: string }[]` cast in `packages/alchemy/src/Cloudflare/Tunnel/Tunnel.ts`.
