### PR TITLE
feat(core): parse Retry-After / Ratelimit headers and honor them in retry policy

### DIFF
--- a/packages/axiom/src/client.ts
+++ b/packages/axiom/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -44,6 +45,8 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   const ErrorClass = (HTTP_STATUS_MAP as any)[status];
   let message = "";
@@ -58,7 +61,9 @@ const matchError = (
     }
   }
   if (ErrorClass) {
-    return Effect.fail(new ErrorClass({ message }));
+    return Effect.fail(
+      new ErrorClass({ message, retryAfter: parseServerRetryHint(headers) }),
+    );
   }
   return Effect.fail(
     new UnknownAxiomError({

--- a/packages/axiom/src/client.ts
+++ b/packages/axiom/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -62,7 +62,10 @@ const matchError = (
   }
   if (ErrorClass) {
     return Effect.fail(
-      new ErrorClass({ message, retryAfter: parseServerRetryHint(headers) }),
+      new ErrorClass({
+        message,
+        retryAfter: parseRetryAfterForStatus(status, headers),
+      }),
     );
   }
   return Effect.fail(

--- a/packages/axiom/src/client.ts
+++ b/packages/axiom/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownAxiomError,
@@ -108,5 +109,6 @@ export const API = makeAPI<Credentials>({
   },
   matchError,
   ParseError: AxiomParseError as any,
+  retry: Retry as any,
   transformResponse: stripNulls,
 });

--- a/packages/axiom/src/retry.ts
+++ b/packages/axiom/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * axiom retry configuration.
+ * Axiom retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * axiom API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/axiom/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Axiom API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Axiom from "@distilled.cloud/axiom";
+ *
+ * myEffect.pipe(Axiom.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Axiom.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Axiom API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("AxiomRetry") {}
+
+/** Provides a custom retry policy to every Axiom API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/axiom/src/retry.ts
+++ b/packages/axiom/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Axiom retry configuration.
+ * axiom retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * axiom API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Axiom API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("AxiomRetry") {}
-
-/**
- * Provides a custom retry policy to all Axiom API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/axiom/src/retry.ts
+++ b/packages/axiom/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Axiom API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/azure/src/client.ts
+++ b/packages/azure/src/client.ts
@@ -23,6 +23,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   AZURE_ERROR_CODE_MAP,
@@ -158,6 +159,7 @@ export const API = makeAPI<Credentials>({
   },
   matchError,
   ParseError: AzureParseError as any,
+  retry: Retry as any,
 
   /**
    * Inject `subscriptionId` from credentials into the path when the generated

--- a/packages/azure/src/client.ts
+++ b/packages/azure/src/client.ts
@@ -23,7 +23,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -97,7 +97,7 @@ const matchError = (
       return Effect.fail(
         new CoreErrorClass({
           message: err.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }
@@ -119,7 +119,7 @@ const matchError = (
         return Effect.fail(
           new ErrorClass({
             message: parsed.message ?? "",
-            retryAfter: parseServerRetryHint(headers),
+            retryAfter: parseRetryAfterForStatus(status, headers),
           }),
         );
       }

--- a/packages/azure/src/client.ts
+++ b/packages/azure/src/client.ts
@@ -23,6 +23,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -70,6 +71,8 @@ const FlatErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   // Try the ARM envelope format first: { error: { code, message } }
   try {
@@ -91,7 +94,12 @@ const matchError = (
     // Fall back to standard HTTP status errors
     const CoreErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (CoreErrorClass) {
-      return Effect.fail(new CoreErrorClass({ message: err.message ?? "" }));
+      return Effect.fail(
+        new CoreErrorClass({
+          message: err.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
 
     return Effect.fail(
@@ -108,7 +116,12 @@ const matchError = (
       const parsed = Schema.decodeUnknownSync(FlatErrorResponse)(errorBody);
       const ErrorClass = (HTTP_STATUS_MAP as any)[status];
       if (ErrorClass) {
-        return Effect.fail(new ErrorClass({ message: parsed.message ?? "" }));
+        return Effect.fail(
+          new ErrorClass({
+            message: parsed.message ?? "",
+            retryAfter: parseServerRetryHint(headers),
+          }),
+        );
       }
       return Effect.fail(
         new UnknownAzureError({

--- a/packages/azure/src/retry.ts
+++ b/packages/azure/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * azure retry configuration.
+ * Azure retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * azure API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/azure/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Azure API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Azure from "@distilled.cloud/azure";
+ *
+ * myEffect.pipe(Azure.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Azure.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Azure API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("AzureRetry") {}
+
+/** Provides a custom retry policy to every Azure API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/azure/src/retry.ts
+++ b/packages/azure/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Azure retry configuration.
+ * azure retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * azure API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Azure API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("AzureRetry") {}
-
-/**
- * Provides a custom retry policy to all Azure API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/azure/src/retry.ts
+++ b/packages/azure/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Azure API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -21,6 +21,7 @@ import {
   paginateWithDefaults,
   type PaginationStrategy,
 } from "@distilled.cloud/core/pagination";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { getPath, type RequestParts } from "@distilled.cloud/core/traits";
 import {
   CloudflareHttpError,
@@ -43,9 +44,13 @@ import { type ErrorMatcher, getErrorMatchers } from "../traits.ts";
  * Cloudflare error codes that map to global/default errors regardless of operation.
  * These are infrastructure-level errors that can occur on any endpoint.
  */
-const GLOBAL_ERROR_CODE_MAP: Record<number, (message: string) => unknown> = {
+const GLOBAL_ERROR_CODE_MAP: Record<
+  number,
+  (message: string, headers?: Record<string, string | undefined>) => unknown
+> = {
   // "Please wait and consider throttling your request speed"
-  971: (message) => new TooManyRequests({ message }),
+  971: (message, headers) =>
+    new TooManyRequests({ message, retryAfter: parseServerRetryHint(headers) }),
   // Authentication-related error codes — surfaced regardless of HTTP status
   // (Cloudflare frequently returns these inside a 400 envelope rather than 401).
   // 6003: Invalid request headers (e.g. missing/invalid auth headers)
@@ -69,17 +74,30 @@ const GLOBAL_ERROR_CODE_MAP: Record<number, (message: string) => unknown> = {
  * returns the properly categorized error (with retry categories for 5xx).
  * For unmapped 5xx codes (e.g., Cloudflare-specific 520-530), returns a
  * CloudflareHttpError so the status is preserved.
+ *
+ * Retryable errors carry an optional `retryAfter` parsed from the standard
+ * `Retry-After` / `RateLimit` response headers; the retry policy honors it.
  */
-function httpStatusError(status: number, body?: string): unknown {
+function httpStatusError(
+  status: number,
+  body?: string,
+  headers?: Record<string, string | undefined>,
+): unknown {
   const ErrorClass = HTTP_STATUS_MAP[status as keyof typeof HTTP_STATUS_MAP];
   const message = body ?? String(status);
   if (ErrorClass) {
-    return new ErrorClass({ message });
+    return new ErrorClass({
+      message,
+      retryAfter: parseServerRetryHint(headers),
+    });
   }
   // For unmapped 5xx codes (e.g., Cloudflare-specific 520-530), use
   // InternalServerError so they get ServerError + Retryable categories
   if (status >= 500) {
-    return new InternalServerError({ message });
+    return new InternalServerError({
+      message,
+      retryAfter: parseServerRetryHint(headers),
+    });
   }
   return new CloudflareHttpError({
     status,
@@ -193,6 +211,7 @@ const matchError = (
   status: number,
   errorBody: unknown,
   errors?: readonly ApiErrorClass[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   // Handle non-JSON error responses (e.g., HTML from malformed URLs, 520 pages)
   const isNonJsonError =
@@ -203,7 +222,7 @@ const matchError = (
     const message = String((errorBody as any).body);
     // For 5xx errors, return a properly categorized error so retries work
     if (status >= 500) {
-      return Effect.fail(httpStatusError(status, message));
+      return Effect.fail(httpStatusError(status, message, headers));
     }
     return Effect.fail(
       new CloudflareHttpError({
@@ -246,7 +265,7 @@ const matchError = (
     const bodyStr =
       typeof errorBody === "string" ? errorBody : JSON.stringify(errorBody);
     if (status >= 500) {
-      return Effect.fail(httpStatusError(status, bodyStr));
+      return Effect.fail(httpStatusError(status, bodyStr, headers));
     }
     return Effect.fail(
       new CloudflareHttpError({
@@ -306,7 +325,7 @@ const matchError = (
 
   // Check global error codes before falling through to unknown
   if (errorCode !== undefined && errorCode in GLOBAL_ERROR_CODE_MAP) {
-    return Effect.fail(GLOBAL_ERROR_CODE_MAP[errorCode](errorMessage));
+    return Effect.fail(GLOBAL_ERROR_CODE_MAP[errorCode](errorMessage, headers));
   }
 
   // Heuristic fallback:

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -21,7 +21,10 @@ import {
   paginateWithDefaults,
   type PaginationStrategy,
 } from "@distilled.cloud/core/pagination";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import {
+  parseRetryAfterForStatus,
+  parseServerRetryHint,
+} from "@distilled.cloud/core/retry-after";
 import { getPath, type RequestParts } from "@distilled.cloud/core/traits";
 import {
   CloudflareHttpError,
@@ -49,8 +52,14 @@ const GLOBAL_ERROR_CODE_MAP: Record<
   (message: string, headers?: Record<string, string | undefined>) => unknown
 > = {
   // "Please wait and consider throttling your request speed"
+  // Cloudflare returns this code inside an envelope with arbitrary HTTP status
+  // (often 200), so we don't gate on status — TooManyRequests always declares
+  // `retryAfter`.
   971: (message, headers) =>
-    new TooManyRequests({ message, retryAfter: parseServerRetryHint(headers) }),
+    new TooManyRequests({
+      message,
+      retryAfter: parseServerRetryHint(headers),
+    }),
   // Authentication-related error codes — surfaced regardless of HTTP status
   // (Cloudflare frequently returns these inside a 400 envelope rather than 401).
   // 6003: Invalid request headers (e.g. missing/invalid auth headers)
@@ -88,7 +97,7 @@ function httpStatusError(
   if (ErrorClass) {
     return new ErrorClass({
       message,
-      retryAfter: parseServerRetryHint(headers),
+      retryAfter: parseRetryAfterForStatus(status, headers),
     });
   }
   // For unmapped 5xx codes (e.g., Cloudflare-specific 520-530), use
@@ -96,7 +105,7 @@ function httpStatusError(
   if (status >= 500) {
     return new InternalServerError({
       message,
-      retryAfter: parseServerRetryHint(headers),
+      retryAfter: parseRetryAfterForStatus(status, headers),
     });
   }
   return new CloudflareHttpError({

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -32,6 +32,7 @@ import {
   UnknownCloudflareError,
 } from "../errors.ts";
 import { Credentials, formatHeaders } from "../credentials.ts";
+import { Retry } from "../retry.ts";
 import { type ErrorMatcher, getErrorMatchers } from "../traits.ts";
 
 // ============================================================================
@@ -378,6 +379,7 @@ const _API = makeAPI<Credentials>({
   ParseError: CloudflareDecodeError as any,
   transformRequestParts: ({ pathTemplate, parts }) =>
     transformCloudflareRequestParts({ pathTemplate, parts }),
+  retry: Retry as any,
 });
 
 const paginatePageByItems: PaginationStrategy = (

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -32,7 +32,6 @@ import {
   UnknownCloudflareError,
 } from "../errors.ts";
 import { Credentials, formatHeaders } from "../credentials.ts";
-import { Retry } from "../retry.ts";
 import { type ErrorMatcher, getErrorMatchers } from "../traits.ts";
 
 // ============================================================================
@@ -379,7 +378,6 @@ const _API = makeAPI<Credentials>({
   ParseError: CloudflareDecodeError as any,
   transformRequestParts: ({ pathTemplate, parts }) =>
     transformCloudflareRequestParts({ pathTemplate, parts }),
-  retry: Retry as any,
 });
 
 const paginatePageByItems: PaginationStrategy = (

--- a/packages/cloudflare/src/retry.ts
+++ b/packages/cloudflare/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Cloudflare API calls. */
@@ -49,7 +51,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/cloudflare/src/retry.ts
+++ b/packages/cloudflare/src/retry.ts
@@ -1,35 +1,30 @@
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
+/**
+ * Cloudflare retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so callers can install a blanket retry policy that covers every Cloudflare
+ * API call below the layer:
+ *
+ * @example
+ * ```ts
+ * import * as Cloudflare from "@distilled.cloud/cloudflare";
+ *
+ * myEffect.pipe(Cloudflare.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Cloudflare.Retry.Retry, customPolicy));
+ * ```
+ */
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import {
-  type Policy,
-  throttlingOptions,
-  transientOptions,
-} from "@distilled.cloud/core/retry";
-
-export class Retry extends Context.Service<Retry, Policy>()(
-  "CloudflareRetry",
-) {}
-
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);
-
-/** Apply throttling retry policy (retries throttling errors indefinitely) */
-export const throttling = policy(throttlingOptions);
-
-/** Apply transient retry policy (retries all transient errors indefinitely) */
-export const transient = policy(transientOptions);

--- a/packages/cloudflare/src/retry.ts
+++ b/packages/cloudflare/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Cloudflare API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("CloudflareRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "CloudflareRetry",
+) {}
 
 /** Provides a custom retry policy to every Cloudflare API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/cloudflare/src/retry.ts
+++ b/packages/cloudflare/src/retry.ts
@@ -1,9 +1,10 @@
 /**
  * Cloudflare retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so callers can install a blanket retry policy that covers every Cloudflare
- * API call below the layer:
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/cloudflare/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Cloudflare API call below it pick it up:
  *
  * @example
  * ```ts
@@ -13,18 +14,40 @@
  * Effect.provide(myEffect, Layer.succeed(Cloudflare.Retry.Retry, customPolicy));
  * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Cloudflare API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("CloudflareRetry") {}
+
+/** Provides a custom retry policy to every Cloudflare API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/coinbase/src/client.ts
+++ b/packages/coinbase/src/client.ts
@@ -35,7 +35,7 @@ import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import * as crypto from "node:crypto";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -243,7 +243,7 @@ const matchError = (
       return Effect.fail(
         new StandardErrorClass({
           message: parsed.errorMessage ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }
@@ -254,7 +254,7 @@ const matchError = (
       return Effect.fail(
         new CoreErrorClass({
           message: parsed.errorMessage ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/coinbase/src/client.ts
+++ b/packages/coinbase/src/client.ts
@@ -35,6 +35,7 @@ import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import * as crypto from "node:crypto";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -215,6 +216,8 @@ const CoinbaseErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(CoinbaseErrorResponse)(errorBody);
@@ -238,7 +241,10 @@ const matchError = (
     const StandardErrorClass = STANDARD_ERROR_TYPE_MAP[parsed.errorType];
     if (StandardErrorClass) {
       return Effect.fail(
-        new StandardErrorClass({ message: parsed.errorMessage ?? "" }),
+        new StandardErrorClass({
+          message: parsed.errorMessage ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
       );
     }
 
@@ -246,7 +252,10 @@ const matchError = (
     const CoreErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (CoreErrorClass) {
       return Effect.fail(
-        new CoreErrorClass({ message: parsed.errorMessage ?? "" }),
+        new CoreErrorClass({
+          message: parsed.errorMessage ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
       );
     }
 

--- a/packages/coinbase/src/client.ts
+++ b/packages/coinbase/src/client.ts
@@ -35,6 +35,7 @@ import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import * as crypto from "node:crypto";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   COINBASE_HTTP_STATUS_MAP,
@@ -288,4 +289,5 @@ export const API = makeAPI<Credentials>({
   },
   matchError,
   ParseError: CoinbaseParseError as any,
+  retry: Retry as any,
 });

--- a/packages/coinbase/src/retry.ts
+++ b/packages/coinbase/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * coinbase retry configuration.
+ * Coinbase retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * coinbase API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/coinbase/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Coinbase API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Coinbase from "@distilled.cloud/coinbase";
+ *
+ * myEffect.pipe(Coinbase.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Coinbase.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Coinbase API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("CoinbaseRetry") {}
+
+/** Provides a custom retry policy to every Coinbase API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/coinbase/src/retry.ts
+++ b/packages/coinbase/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Coinbase API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/coinbase/src/retry.ts
+++ b/packages/coinbase/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Coinbase retry configuration.
+ * coinbase retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * coinbase API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Coinbase API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("CoinbaseRetry") {}
-
-/**
- * Provides a custom retry policy to all Coinbase API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,11 @@
       "bun": "./src/retry.ts",
       "default": "./lib/retry.js"
     },
+    "./retry-after": {
+      "types": "./lib/retry-after.d.ts",
+      "bun": "./src/retry-after.ts",
+      "default": "./lib/retry-after.js"
+    },
     "./sensitive": {
       "types": "./lib/sensitive.d.ts",
       "bun": "./src/sensitive.ts",

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -145,11 +145,16 @@ export interface ClientConfig<Creds> {
    *  Should return Effect.fail(error) for known errors,
    *  or Effect.fail(fallbackError) for unknown errors.
    *  The optional `errors` parameter provides per-operation typed error classes.
+   *  The optional `headers` parameter is the response header bag (lowercase
+   *  keys) — implementations should use `parseServerRetryHint(headers)` from
+   *  `@distilled.cloud/core/retry-after` to populate `retryAfter` on
+   *  retryable errors so the retry policy can honor server hints.
    */
   matchError: (
     status: number,
     body: unknown,
     errors?: readonly ApiErrorClass[],
+    headers?: Record<string, string | undefined>,
   ) => Effect.Effect<never, unknown>;
 
   /** Parse error class for schema decode failures */
@@ -606,6 +611,7 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
               response.status,
               errorBody,
               opConfig.errors,
+              response.headers,
             );
           }
 
@@ -654,6 +660,7 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
                 response.status,
                 envelope,
                 opConfig.errors,
+                response.headers,
               );
             }
             responseBody = envelope?.data ?? null;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -146,9 +146,11 @@ export interface ClientConfig<Creds> {
    *  or Effect.fail(fallbackError) for unknown errors.
    *  The optional `errors` parameter provides per-operation typed error classes.
    *  The optional `headers` parameter is the response header bag (lowercase
-   *  keys) — implementations should use `parseServerRetryHint(headers)` from
-   *  `@distilled.cloud/core/retry-after` to populate `retryAfter` on
-   *  retryable errors so the retry policy can honor server hints.
+   *  keys) — implementations should use `parseRetryAfterForStatus(status, headers)`
+   *  from `@distilled.cloud/core/retry-after` to populate `retryAfter` on
+   *  retryable errors so the retry policy can honor server hints. The
+   *  status-gated helper avoids attaching stale `retryAfter` to non-retryable
+   *  classes (BadRequest/Unauthorized/etc.) whose schemas don't declare it.
    */
   matchError: (
     status: number,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,6 +25,7 @@
  * const result = yield* fn({ organization: "my-org" });
  * ```
  */
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
 import * as Option from "effect/Option";
@@ -46,7 +47,7 @@ import {
   type PaginatedTrait,
   type PaginationStrategy,
 } from "./pagination.ts";
-import { makeDefault, Retry } from "./retry.ts";
+import { makeDefault, type Policy as RetryPolicy } from "./retry.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
 
@@ -170,6 +171,20 @@ export interface ClientConfig<Creds> {
     pathTemplate: string;
     parts: Traits.RequestParts;
   }) => Traits.RequestParts;
+
+  /**
+   * The SDK's `Retry` Context.Service tag. Each per-SDK client wires its
+   * own tag here so callers can install a blanket policy at the layer
+   * level (e.g. `myEffect.pipe(Cloudflare.Retry.transient)`) and have
+   * every API call below it pick it up — same pattern as
+   * `packages/aws/src/client/api.ts`.
+   *
+   * `makeAPI` reads the policy via `Effect.serviceOption(retry)` on every
+   * call and falls back to `Retry.makeDefault` (transient/throttling/server
+   * with capped exponential backoff + jitter, 5 attempts) when no policy
+   * is provided.
+   */
+  retry: Context.Key<any, RetryPolicy>;
 }
 
 /**
@@ -685,18 +700,19 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           );
         });
 
-      // Auto-retry every operation using the shared `Retry` Context.Service.
-      // The policy is read with `Effect.serviceOption(Retry)` and falls back
-      // to `Retry.makeDefault` (transient/throttling/server errors with
-      // capped exponential backoff + jitter, 5 attempts) when no policy has
-      // been provided. This mirrors the AWS pattern in
-      // `packages/aws/src/client/api.ts` and lets callers install a blanket
-      // policy at the layer level instead of wrapping every call site with
-      // `Effect.retry(...)`.
+      // Auto-retry every operation using the SDK's per-client `Retry`
+      // Context.Service. The policy is read with `Effect.serviceOption`
+      // and falls back to `Retry.makeDefault` (transient/throttling/server
+      // errors with capped exponential backoff + jitter, 5 attempts) when
+      // no policy has been provided in context. This mirrors the AWS
+      // pattern in `packages/aws/src/client/api.ts` and lets callers
+      // install a blanket policy at the layer level instead of wrapping
+      // every call site with `Effect.retry(...)`.
+      const retryTag = config.retry;
       const fn = (input: Input): Effect.Effect<any, any, any> => {
         const withRetry = Effect.gen(function* () {
           const lastError = yield* Ref.make<unknown>(undefined);
-          const policy = (yield* Effect.serviceOption(Retry)).pipe(
+          const policy = (yield* Effect.serviceOption(retryTag)).pipe(
             Option.map((value) =>
               typeof value === "function" ? value(lastError) : value,
             ),

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -146,11 +146,14 @@ export interface ClientConfig<Creds> {
    *  or Effect.fail(fallbackError) for unknown errors.
    *  The optional `errors` parameter provides per-operation typed error classes.
    *  The optional `headers` parameter is the response header bag (lowercase
-   *  keys) — implementations should use `parseRetryAfterForStatus(status, headers)`
-   *  from `@distilled.cloud/core/retry-after` to populate `retryAfter` on
-   *  retryable errors so the retry policy can honor server hints. The
-   *  status-gated helper avoids attaching stale `retryAfter` to non-retryable
-   *  classes (BadRequest/Unauthorized/etc.) whose schemas don't declare it.
+   *  keys) — for retryable status codes, pass `retryAfter: parseRetryAfterForStatus(status, headers)`
+   *  from `@distilled.cloud/core/retry-after` when a standard `Retry-After` /
+   *  `RateLimit` hint is present; omit `retryAfter` when there is no hint (the
+   *  default retry policy still uses exponential backoff). The status-gated
+   *  helper avoids attaching stale `retryAfter` to non-retryable classes
+   *  (BadRequest/401/404/etc.). The maximum honored hint is capped (default
+   *  60s) — override with \`DISTILLED_SERVER_RETRY_HINT_CAP_MS\` or provide
+   *  \`ServerRetryHintCapMs\` via \`Layer\` from \`@distilled.cloud/core/retry\`.
    */
   matchError: (
     status: number,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,10 +25,14 @@
  * const result = yield* fn({ organization: "my-org" });
  * ```
  */
+import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import { pipe } from "effect/Function";
+import * as Option from "effect/Option";
 import { pipeArguments } from "effect/Pipeable";
 import { MinimumLogLevel } from "effect/References";
+import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
@@ -46,6 +50,7 @@ import {
   type PaginationStrategy,
 } from "./pagination.ts";
 import * as Category from "./category.ts";
+import { makeDefault, type Policy as RetryPolicy } from "./retry.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
 
@@ -169,6 +174,17 @@ export interface ClientConfig<Creds> {
     pathTemplate: string;
     parts: Traits.RequestParts;
   }) => Traits.RequestParts;
+
+  /**
+   * Optional `Retry` Context.Service tag for this SDK. When provided, every
+   * operation reads the policy via `Effect.serviceOption(retry)` and falls
+   * back to `Retry.makeDefault` if no policy is provided. This lets callers
+   * apply a blanket retry policy (e.g. `Effect.provide(Layer.succeed(Retry,
+   * customPolicy))`) instead of wrapping every call site with
+   * `Effect.retry(...)`. When omitted, only the legacy hard-coded
+   * throttling-only retry runs.
+   */
+  retry?: Context.Key<any, RetryPolicy>;
 }
 
 /**
@@ -697,18 +713,45 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           );
         });
 
-      // Auto-retry whenever the SDK's matchError returns a typed error
-      // tagged with the throttling category (e.g. `TooManyRequests`,
-      // or any SDK-specific subclass marked with `withThrottlingError`
-      // / `withRetryable({ throttling: true })`). After retries are
-      // exhausted the original typed error propagates to the caller as
-      // usual.
+      // Auto-retry on every operation. When the SDK passes a `retry`
+      // Context.Service tag, we read the policy from context (with
+      // `Retry.makeDefault` as a fallback) so callers can install a
+      // blanket retry policy at the layer level — same pattern as
+      // `packages/aws`. When no `retry` tag is configured, fall back to
+      // the legacy hard-coded throttling-only schedule for backward
+      // compatibility with SDKs that haven't opted in yet.
       const fn = (input: Input): Effect.Effect<any, any, any> => {
-        const withRetry = innerFn(input).pipe(
-          Effect.retry({
-            schedule: throttlingRetrySchedule,
-            while: (e) => Category.isThrottling(e),
-          }),
+        const withRetry = config.retry
+          ? Effect.gen(function* () {
+              const lastError = yield* Ref.make<unknown>(undefined);
+              const retryTag = config.retry!;
+              const policy = (yield* Effect.serviceOption(retryTag)).pipe(
+                Option.map((value) =>
+                  typeof value === "function" ? value(lastError) : value,
+                ),
+                Option.getOrElse(() => makeDefault(lastError)),
+              );
+
+              return yield* pipe(
+                innerFn(input),
+                Effect.tapError((error) => Ref.set(lastError, error)),
+                policy.while
+                  ? (eff) =>
+                      Effect.retry(eff, {
+                        while: policy.while,
+                        schedule: policy.schedule,
+                      })
+                  : (eff) => eff,
+              );
+            })
+          : innerFn(input).pipe(
+              Effect.retry({
+                schedule: throttlingRetrySchedule,
+                while: (e) => Category.isThrottling(e),
+              }),
+            );
+
+        const withSpan = withRetry.pipe(
           Effect.withSpan(spanName, {
             attributes: {
               "http.method": method,
@@ -717,8 +760,8 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           }),
         );
         return distilledDebugEnv
-          ? Effect.provideService(withRetry, MinimumLogLevel, "Debug")
-          : withRetry;
+          ? Effect.provideService(withSpan, MinimumLogLevel, "Debug")
+          : withSpan;
       };
 
       const Proto = {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,15 +25,12 @@
  * const result = yield* fn({ organization: "my-org" });
  * ```
  */
-import * as Context from "effect/Context";
-import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
 import * as Option from "effect/Option";
 import { pipeArguments } from "effect/Pipeable";
 import { MinimumLogLevel } from "effect/References";
 import * as Ref from "effect/Ref";
-import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as AST from "effect/SchemaAST";
 import * as Stream from "effect/Stream";
@@ -49,8 +46,7 @@ import {
   type PaginatedTrait,
   type PaginationStrategy,
 } from "./pagination.ts";
-import * as Category from "./category.ts";
-import { makeDefault, type Policy as RetryPolicy } from "./retry.ts";
+import { makeDefault, Retry } from "./retry.ts";
 import * as Traits from "./traits.ts";
 import { getPath } from "./traits.ts";
 
@@ -174,17 +170,6 @@ export interface ClientConfig<Creds> {
     pathTemplate: string;
     parts: Traits.RequestParts;
   }) => Traits.RequestParts;
-
-  /**
-   * Optional `Retry` Context.Service tag for this SDK. When provided, every
-   * operation reads the policy via `Effect.serviceOption(retry)` and falls
-   * back to `Retry.makeDefault` if no policy is provided. This lets callers
-   * apply a blanket retry policy (e.g. `Effect.provide(Layer.succeed(Retry,
-   * customPolicy))`) instead of wrapping every call site with
-   * `Effect.retry(...)`. When omitted, only the legacy hard-coded
-   * throttling-only retry runs.
-   */
-  retry?: Context.Key<any, RetryPolicy>;
 }
 
 /**
@@ -423,19 +408,6 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       }
 
       const method = httpTrait.method;
-
-      // Capped exponential backoff bounded to 8 attempts so a
-      // pathologically rate-limited endpoint can't hang a test run.
-      // Effect 4's `Schedule.exponential(base, factor)` already produces
-      // delays of base, base*factor, base*factor^2, ...; combined with
-      // `Schedule.both(Schedule.recurs(8))` to cap retries. We don't
-      // currently honour Retry-After (would require a per-attempt Ref);
-      // the exponential ramp is conservative enough for the rate limits
-      // we hit in practice.
-      const throttlingRetrySchedule = Schedule.both(
-        Schedule.exponential(Duration.seconds(1), 2),
-        Schedule.recurs(8),
-      );
 
       const spanName = `${method} ${httpTrait.path}`;
 
@@ -713,43 +685,36 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           );
         });
 
-      // Auto-retry on every operation. When the SDK passes a `retry`
-      // Context.Service tag, we read the policy from context (with
-      // `Retry.makeDefault` as a fallback) so callers can install a
-      // blanket retry policy at the layer level — same pattern as
-      // `packages/aws`. When no `retry` tag is configured, fall back to
-      // the legacy hard-coded throttling-only schedule for backward
-      // compatibility with SDKs that haven't opted in yet.
+      // Auto-retry every operation using the shared `Retry` Context.Service.
+      // The policy is read with `Effect.serviceOption(Retry)` and falls back
+      // to `Retry.makeDefault` (transient/throttling/server errors with
+      // capped exponential backoff + jitter, 5 attempts) when no policy has
+      // been provided. This mirrors the AWS pattern in
+      // `packages/aws/src/client/api.ts` and lets callers install a blanket
+      // policy at the layer level instead of wrapping every call site with
+      // `Effect.retry(...)`.
       const fn = (input: Input): Effect.Effect<any, any, any> => {
-        const withRetry = config.retry
-          ? Effect.gen(function* () {
-              const lastError = yield* Ref.make<unknown>(undefined);
-              const retryTag = config.retry!;
-              const policy = (yield* Effect.serviceOption(retryTag)).pipe(
-                Option.map((value) =>
-                  typeof value === "function" ? value(lastError) : value,
-                ),
-                Option.getOrElse(() => makeDefault(lastError)),
-              );
+        const withRetry = Effect.gen(function* () {
+          const lastError = yield* Ref.make<unknown>(undefined);
+          const policy = (yield* Effect.serviceOption(Retry)).pipe(
+            Option.map((value) =>
+              typeof value === "function" ? value(lastError) : value,
+            ),
+            Option.getOrElse(() => makeDefault(lastError)),
+          );
 
-              return yield* pipe(
-                innerFn(input),
-                Effect.tapError((error) => Ref.set(lastError, error)),
-                policy.while
-                  ? (eff) =>
-                      Effect.retry(eff, {
-                        while: policy.while,
-                        schedule: policy.schedule,
-                      })
-                  : (eff) => eff,
-              );
-            })
-          : innerFn(input).pipe(
-              Effect.retry({
-                schedule: throttlingRetrySchedule,
-                while: (e) => Category.isThrottling(e),
-              }),
-            );
+          return yield* pipe(
+            innerFn(input),
+            Effect.tapError((error) => Ref.set(lastError, error)),
+            policy.while
+              ? (eff) =>
+                  Effect.retry(eff, {
+                    while: policy.while,
+                    schedule: policy.schedule,
+                  })
+              : (eff) => eff,
+          );
+        });
 
         const withSpan = withRetry.pipe(
           Effect.withSpan(spanName, {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -179,6 +179,18 @@ export const HTTP_STATUS_MAP = {
 export const DEFAULT_ERROR_STATUSES = new Set([401, 429, 500, 502, 503, 504]);
 
 /**
+ * HTTP status codes whose corresponding error class in {@link HTTP_STATUS_MAP}
+ * declares a `retryAfter` field. The retry policy honors `error.retryAfter`
+ * with precedence over the default backoff for these.
+ *
+ * `matchError` implementations should only pass `retryAfter` into the
+ * constructor when the status is in this set; passing it on non-retryable
+ * classes (BadRequest/Unauthorized/etc.) would silently retain it as a
+ * stale field on the instance and pollute serialized output.
+ */
+export const RETRYABLE_HTTP_STATUSES = new Set([423, 429, 500, 502, 503, 504]);
+
+/**
  * All common API error classes.
  */
 export const API_ERRORS = [

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -5,8 +5,26 @@
  * using the category system. This module provides base error types and utilities
  * that are used across all SDKs.
  */
+import * as Duration from "effect/Duration";
 import * as Schema from "effect/Schema";
 import * as Category from "./category.ts";
+
+// ============================================================================
+// Shared Schema Helpers
+// ============================================================================
+
+/**
+ * Opaque schema for an Effect `Duration.Duration` value.
+ *
+ * Used on retryable errors to carry a server-provided wait hint (e.g. parsed
+ * from `Retry-After` or the IETF `Ratelimit` header). Core does not encode/decode
+ * this field over the wire — it is constructed at runtime by `matchError` from
+ * whatever the service actually returns (delay-seconds, HTTP-date, epoch, etc.)
+ * and consumed at runtime by the retry policy.
+ */
+export const DurationSchema = Schema.declare<Duration.Duration>(
+  Duration.isDuration,
+);
 
 // ============================================================================
 // Common HTTP Status Error Classes
@@ -63,7 +81,10 @@ export class UnprocessableEntity extends Schema.TaggedErrorClass<UnprocessableEn
  */
 export class TooManyRequests extends Schema.TaggedErrorClass<TooManyRequests>()(
   "TooManyRequests",
-  { message: Schema.String },
+  {
+    message: Schema.String,
+    retryAfter: Schema.optional(DurationSchema),
+  },
 ).pipe(
   Category.withThrottlingError,
   Category.withRetryable({ throttling: true }),
@@ -74,6 +95,7 @@ export class TooManyRequests extends Schema.TaggedErrorClass<TooManyRequests>()(
  */
 export class Locked extends Schema.TaggedErrorClass<Locked>()("Locked", {
   message: Schema.String,
+  retryAfter: Schema.optional(DurationSchema),
 }).pipe(Category.withLockedError, Category.withRetryable()) {}
 
 /**
@@ -81,7 +103,10 @@ export class Locked extends Schema.TaggedErrorClass<Locked>()("Locked", {
  */
 export class InternalServerError extends Schema.TaggedErrorClass<InternalServerError>()(
   "InternalServerError",
-  { message: Schema.String },
+  {
+    message: Schema.String,
+    retryAfter: Schema.optional(DurationSchema),
+  },
 ).pipe(Category.withServerError, Category.withRetryable()) {}
 
 /**
@@ -89,7 +114,10 @@ export class InternalServerError extends Schema.TaggedErrorClass<InternalServerE
  */
 export class BadGateway extends Schema.TaggedErrorClass<BadGateway>()(
   "BadGateway",
-  { message: Schema.String },
+  {
+    message: Schema.String,
+    retryAfter: Schema.optional(DurationSchema),
+  },
 ).pipe(Category.withServerError, Category.withRetryable()) {}
 
 /**
@@ -97,7 +125,10 @@ export class BadGateway extends Schema.TaggedErrorClass<BadGateway>()(
  */
 export class ServiceUnavailable extends Schema.TaggedErrorClass<ServiceUnavailable>()(
   "ServiceUnavailable",
-  { message: Schema.String },
+  {
+    message: Schema.String,
+    retryAfter: Schema.optional(DurationSchema),
+  },
 ).pipe(Category.withServerError, Category.withRetryable()) {}
 
 /**
@@ -105,7 +136,10 @@ export class ServiceUnavailable extends Schema.TaggedErrorClass<ServiceUnavailab
  */
 export class GatewayTimeout extends Schema.TaggedErrorClass<GatewayTimeout>()(
   "GatewayTimeout",
-  { message: Schema.String },
+  {
+    message: Schema.String,
+    retryAfter: Schema.optional(DurationSchema),
+  },
 ).pipe(Category.withServerError, Category.withRetryable()) {}
 
 /**

--- a/packages/core/src/retry-after.ts
+++ b/packages/core/src/retry-after.ts
@@ -15,6 +15,7 @@
  * helpers for the standard cases.
  */
 import * as Duration from "effect/Duration";
+import { RETRYABLE_HTTP_STATUSES } from "./errors.ts";
 
 /**
  * Header bag — case-insensitive lookup is the caller's responsibility.
@@ -111,3 +112,20 @@ export const parseServerRetryHint = (
   headers: Headers,
 ): Duration.Duration | undefined =>
   parseRetryAfter(headers) ?? parseRatelimit(headers);
+
+/**
+ * Status-gated variant of {@link parseServerRetryHint}. Returns `undefined`
+ * unless `status` is one whose error class actually declares a `retryAfter`
+ * field (see `RETRYABLE_HTTP_STATUSES`). Use this in `matchError` when you
+ * dispatch off a generic `HTTP_STATUS_MAP` lookup that includes both
+ * retryable (429/5xx/423) and non-retryable (4xx) classes — it prevents
+ * stale `retryAfter` properties from being attached to errors like
+ * `BadRequest` or `NotFound` (which would otherwise leak into JSON output).
+ */
+export const parseRetryAfterForStatus = (
+  status: number,
+  headers: Headers,
+): Duration.Duration | undefined => {
+  if (!RETRYABLE_HTTP_STATUSES.has(status)) return undefined;
+  return parseServerRetryHint(headers);
+};

--- a/packages/core/src/retry-after.ts
+++ b/packages/core/src/retry-after.ts
@@ -1,0 +1,113 @@
+/**
+ * Server-provided retry hint parsing.
+ *
+ * Standardizes parsing of:
+ *   - `Retry-After` (RFC 7231 §7.1.3): `delay-seconds` (integer) or `HTTP-date`.
+ *   - `RateLimit` (IETF draft-ietf-httpapi-ratelimit-headers): structured
+ *     dictionary `r=<remaining>, t=<seconds-until-reset>`.
+ *
+ * Each SDK's `matchError` calls these helpers and attaches the resulting
+ * `Duration` to retryable errors via the optional `retryAfter` field, where
+ * the retry policy will honor it with precedence over the default backoff.
+ *
+ * Services that use bespoke headers or body fields are expected to do their
+ * own parsing in the SDK's `matchError`, optionally falling back to these
+ * helpers for the standard cases.
+ */
+import * as Duration from "effect/Duration";
+
+/**
+ * Header bag — case-insensitive lookup is the caller's responsibility.
+ *
+ * The helpers in this module read lowercase keys (`retry-after`, `ratelimit`)
+ * because most HTTP clients normalize headers to lowercase. If your client
+ * preserves case, normalize before passing in.
+ */
+export type Headers = Record<string, string | undefined> | undefined;
+
+/**
+ * Parse the standard `Retry-After` HTTP header per RFC 7231 §7.1.3.
+ *
+ * Accepts either a non-negative integer number of seconds (the common case)
+ * or an HTTP-date. HTTP-dates in the past produce a zero duration.
+ *
+ * Returns `undefined` when the header is missing or unparseable.
+ */
+export const parseRetryAfter = (
+  headers: Headers,
+): Duration.Duration | undefined => {
+  const raw = headers?.["retry-after"];
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+
+  // delay-seconds: 1*DIGIT (non-negative decimal integer per RFC).
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return Duration.seconds(seconds);
+    }
+  }
+
+  // Reject anything that *looks* numeric but isn't a valid delay-seconds.
+  // Without this, `Date.parse("-5")` happens to return 0 on some engines and
+  // would silently yield a zero-duration instead of the expected undefined.
+  if (/^[-+]?\d+(?:\.\d+)?$/.test(trimmed)) return undefined;
+
+  // HTTP-date: try Date.parse, which handles RFC 1123 / RFC 850 / asctime.
+  const ts = Date.parse(trimmed);
+  if (!Number.isNaN(ts)) {
+    const ms = Math.max(0, ts - Date.now());
+    return Duration.millis(ms);
+  }
+
+  return undefined;
+};
+
+/**
+ * Parse the IETF `RateLimit` structured header.
+ *
+ * Examples:
+ *   `RateLimit: limit=100, remaining=0, reset=30`           (older draft)
+ *   `RateLimit: "default";r=0;t=30`                          (newer draft)
+ *   `RateLimit: r=0, t=30`                                   (compact form)
+ *
+ * Returns the `t` (seconds until reset) value as a Duration, but only when
+ * `r` (remaining quota) is present and equals `0` — i.e., we're actually
+ * rate-limited right now. Returns `undefined` otherwise.
+ */
+export const parseRatelimit = (
+  headers: Headers,
+): Duration.Duration | undefined => {
+  const raw = headers?.["ratelimit"];
+  if (!raw) return undefined;
+
+  let remaining: number | undefined;
+  let reset: number | undefined;
+
+  // Tokenize on commas and semicolons; tolerate `key=value` and `key =value`.
+  for (const piece of raw.split(/[,;]/)) {
+    const eq = piece.indexOf("=");
+    if (eq < 0) continue;
+    const key = piece.slice(0, eq).trim().toLowerCase();
+    const value = piece.slice(eq + 1).trim();
+    const num = Number(value);
+    if (!Number.isFinite(num)) continue;
+
+    if (key === "r" || key === "remaining") remaining = num;
+    else if (key === "t" || key === "reset") reset = num;
+  }
+
+  if (remaining !== undefined && remaining > 0) return undefined;
+  if (reset === undefined || reset < 0) return undefined;
+  return Duration.seconds(reset);
+};
+
+/**
+ * Convenience: try `Retry-After` first, then `RateLimit`. Returns the first
+ * successful parse, or `undefined` if neither header yields a usable value.
+ */
+export const parseServerRetryHint = (
+  headers: Headers,
+): Duration.Duration | undefined =>
+  parseRetryAfter(headers) ?? parseRatelimit(headers);

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -2,24 +2,14 @@
  * Retry Policy System
  *
  * Provides configurable retry policies for API operations.
- * Each SDK creates its own Retry service tag but uses these shared utilities
- * for building retry schedules and policies.
- *
- * @example
- * ```ts
- * import * as Retry from "@distilled.cloud/core/retry";
- *
- * // Use the default retry policy
- * myEffect.pipe(Retry.policy(myRetryService, Retry.makeDefault()))
- *
- * // Disable retries
- * myEffect.pipe(Retry.none(myRetryService))
- * ```
+ * Each SDK creates its own `Retry` Context.Service tag (via
+ * `makeRetryService`) and threads it into `makeAPI({ retry: <SDK>.Retry })`
+ * so that callers can install a blanket retry policy at the layer level
+ * for that SDK without wrapping every call with `Effect.retry`.
  */
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
-import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Context from "effect/Context";
@@ -55,51 +45,20 @@ export type Factory = (lastError: Ref.Ref<unknown>) => Options;
 export type Policy = Options | Factory;
 
 // ============================================================================
-// Shared Retry Service
+// Retry Service Factory
 // ============================================================================
 
 /**
- * Shared `Retry` Context.Service consumed by `@distilled.cloud/core/client`'s
- * `makeAPI`. Every SDK that goes through the shared client (cloudflare,
- * turso, planetscale, neon, stripe, kubernetes, axiom, posthog, gcp, ...)
- * reads its retry policy from this single tag, so an `Effect.provide`
- * (or `Layer.succeed`) at any layer covers every API call below it.
+ * Create a typed Retry service class for an SDK.
+ * Each SDK creates its own Retry service using this factory; the SDK's
+ * client wraps `makeAPI` with `retry: <SDK>.Retry` so the policy applies
+ * to every API call below it.
  *
  * @example
  * ```ts
- * import * as Retry from "@distilled.cloud/core/retry";
- *
- * myEffect.pipe(Retry.transient);
- * Effect.provide(myEffect, Layer.succeed(Retry.Retry, customPolicy));
+ * // packages/<sdk>/src/retry.ts
+ * export class Retry extends makeRetryService("PlanetScaleRetry") {}
  * ```
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "@distilled.cloud/core/Retry",
-) {}
-
-/**
- * Provides a custom retry policy to every API call below it.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);
-
-// ============================================================================
-// Legacy Retry Service Factory (deprecated)
-// ============================================================================
-
-/**
- * @deprecated Use the shared `Retry` Context.Service exported from this
- * module. Per-SDK Retry tags are no longer wired into core's `makeAPI`;
- * keeping a separate tag per SDK means the policy isn't actually consumed.
- * SDK retry modules should re-export `{ Retry, policy, none, throttling,
- * transient }` from `@distilled.cloud/core/retry` directly.
  */
 export const makeRetryService = (name: string) =>
   Context.Service<any, Policy>()(name);
@@ -190,8 +149,3 @@ export const transientOptions: Options = {
   ),
 };
 
-/** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
-
-/** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -55,40 +55,54 @@ export type Factory = (lastError: Ref.Ref<unknown>) => Options;
 export type Policy = Options | Factory;
 
 // ============================================================================
-// Retry Service Factory
+// Shared Retry Service
 // ============================================================================
 
 /**
- * Create a typed Retry service class for an SDK.
- * Each SDK should create its own Retry service using this factory.
+ * Shared `Retry` Context.Service consumed by `@distilled.cloud/core/client`'s
+ * `makeAPI`. Every SDK that goes through the shared client (cloudflare,
+ * turso, planetscale, neon, stripe, kubernetes, axiom, posthog, gcp, ...)
+ * reads its retry policy from this single tag, so an `Effect.provide`
+ * (or `Layer.succeed`) at any layer covers every API call below it.
  *
  * @example
  * ```ts
- * // In planetscale-sdk/src/retry.ts
- * export class Retry extends makeRetryService("PlanetScaleRetry") {}
+ * import * as Retry from "@distilled.cloud/core/retry";
+ *
+ * myEffect.pipe(Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Retry.Retry, customPolicy));
  * ```
  */
-export const makeRetryService = (name: string) =>
-  Context.Service<any, Policy>()(name);
+export class Retry extends Context.Service<Retry, Policy>()(
+  "@distilled.cloud/core/Retry",
+) {}
 
 /**
- * Provides a custom retry policy for API calls.
+ * Provides a custom retry policy to every API call below it.
  */
-export const policy =
-  (Service: any, optionsOrFactory: Policy) =>
-  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    Effect.provide(effect, Layer.succeed(Service, optionsOrFactory) as any);
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
 
 /**
  * Disables all automatic retries.
  */
-export const none =
-  (Service: any) =>
-  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    Effect.provide(
-      effect,
-      Layer.succeed(Service, { while: () => false }) as any,
-    );
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+// ============================================================================
+// Legacy Retry Service Factory (deprecated)
+// ============================================================================
+
+/**
+ * @deprecated Use the shared `Retry` Context.Service exported from this
+ * module. Per-SDK Retry tags are no longer wired into core's `makeAPI`;
+ * keeping a separate tag per SDK means the policy isn't actually consumed.
+ * SDK retry modules should re-export `{ Retry, policy, none, throttling,
+ * transient }` from `@distilled.cloud/core/retry` directly.
+ */
+export const makeRetryService = (name: string) =>
+  Context.Service<any, Policy>()(name);
 
 // ============================================================================
 // Retry Schedule Utilities
@@ -175,3 +189,9 @@ export const transientOptions: Options = {
     jittered,
   ),
 };
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -86,6 +86,49 @@ export const capped = (max: Duration.Duration) =>
   );
 
 // ============================================================================
+// Server Hint Helpers
+// ============================================================================
+
+/**
+ * Hard cap on how long we'll honor a server-provided `Retry-After` /
+ * `RateLimit` hint. A misbehaving server can otherwise park us forever.
+ */
+const SERVER_HINT_CAP_MS = 60_000;
+
+/**
+ * Extract a server-provided retry hint (in milliseconds) from an error's
+ * optional `retryAfter` field, capped at {@link SERVER_HINT_CAP_MS}.
+ *
+ * Returns `undefined` when the error doesn't carry a hint.
+ */
+const serverHintMillis = (error: unknown): number | undefined => {
+  const hint = (error as { retryAfter?: unknown } | null | undefined)
+    ?.retryAfter;
+  if (!Duration.isDuration(hint)) return undefined;
+  return Math.min(Duration.toMillis(hint), SERVER_HINT_CAP_MS);
+};
+
+/**
+ * Schedule modifier that honors `error.retryAfter` (set by the SDK's
+ * `matchError` from `Retry-After` / `RateLimit` headers) with precedence
+ * over the input delay. Falls back to the original delay when no hint is
+ * present.
+ */
+const honorServerHint = (
+  lastError: Ref.Ref<unknown>,
+  baseline?: (duration: Duration.Duration, error: unknown) => Duration.Duration,
+) =>
+  Schedule.modifyDelay(
+    Effect.fnUntraced(function* (duration: Duration.Duration) {
+      const error = yield* Ref.get(lastError);
+      const hint = serverHintMillis(error);
+      if (hint !== undefined) return hint;
+      const adjusted = baseline ? baseline(duration, error) : duration;
+      return Duration.toMillis(adjusted);
+    }),
+  );
+
+// ============================================================================
 // Default Retry Policies
 // ============================================================================
 
@@ -94,7 +137,9 @@ export const capped = (max: Duration.Duration) =>
  *
  * This policy:
  * - Retries transient errors (throttling, server, network, locked errors)
- * - Uses exponential backoff starting at 100ms with a factor of 2
+ * - Honors `error.retryAfter` (server-provided hint) with precedence,
+ *   capped at 60 seconds
+ * - Otherwise uses exponential backoff starting at 100ms with a factor of 2
  * - Ensures at least 500ms delay for throttling errors
  * - Limits to 5 retry attempts
  * - Applies jitter to avoid thundering herd
@@ -103,24 +148,37 @@ export const makeDefault: Factory = (lastError) => ({
   while: (error) => isTransientError(error),
   schedule: pipe(
     Schedule.exponential(100, 2),
-    Schedule.modifyDelay(
-      Effect.fnUntraced(function* (duration) {
-        const error = yield* Ref.get(lastError);
-        if (isThrottling(error)) {
-          if (Duration.toMillis(duration) < 500) {
-            return Duration.toMillis(Duration.millis(500));
-          }
-        }
-        return Duration.toMillis(duration);
-      }),
-    ),
+    honorServerHint(lastError, (duration, error) => {
+      if (isThrottling(error) && Duration.toMillis(duration) < 500) {
+        return Duration.millis(500);
+      }
+      return duration;
+    }),
     Schedule.both(Schedule.recurs(5)),
     jittered,
   ),
 });
 
 /**
+ * Factory for the throttling-only retry policy. Honors server hints when
+ * present so callers using `<SDK>.Retry.throttling` get correct backoff.
+ */
+export const throttlingFactory: Factory = (lastError) => ({
+  while: (error) => isThrottling(error),
+  schedule: pipe(
+    Schedule.exponential(1000, 2),
+    honorServerHint(lastError),
+    capped(Duration.seconds(5)),
+    jittered,
+  ),
+});
+
+/**
  * Retry options that retries all throttling errors indefinitely.
+ *
+ * Note: prefer {@link throttlingFactory} when you want server-hint honoring.
+ * This static `Options` form does not have access to `lastError` and so
+ * cannot read `error.retryAfter`.
  */
 export const throttlingOptions: Options = {
   while: (error) => isThrottling(error),
@@ -132,6 +190,20 @@ export const throttlingOptions: Options = {
 };
 
 /**
+ * Factory for the transient retry policy. Honors server hints when present
+ * so callers using `<SDK>.Retry.transient` get correct backoff.
+ */
+export const transientFactory: Factory = (lastError) => ({
+  while: isTransientError,
+  schedule: pipe(
+    Schedule.exponential(1000, 2),
+    honorServerHint(lastError),
+    capped(Duration.seconds(5)),
+    jittered,
+  ),
+});
+
+/**
  * Retry options that retries all transient errors indefinitely.
  *
  * This includes:
@@ -139,6 +211,8 @@ export const throttlingOptions: Options = {
  * 2. Server errors
  * 3. Network errors
  * 4. Locked errors (423)
+ *
+ * Note: prefer {@link transientFactory} when you want server-hint honoring.
  */
 export const transientOptions: Options = {
   while: isTransientError,

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -148,4 +148,3 @@ export const transientOptions: Options = {
     jittered,
   ),
 };
-

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -10,6 +10,8 @@
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
 import * as Context from "effect/Context";
@@ -90,22 +92,82 @@ export const capped = (max: Duration.Duration) =>
 // ============================================================================
 
 /**
- * Hard cap on how long we'll honor a server-provided `Retry-After` /
- * `RateLimit` hint. A misbehaving server can otherwise park us forever.
+ * Default cap (milliseconds) on how long we'll honor a server-provided
+ * `Retry-After` / `RateLimit` hint. A misbehaving server can otherwise park
+ * us forever.
  */
-const SERVER_HINT_CAP_MS = 60_000;
+export const DEFAULT_SERVER_RETRY_HINT_CAP_MS = 60_000;
+
+const ENV_SERVER_RETRY_HINT_CAP_MS = "DISTILLED_SERVER_RETRY_HINT_CAP_MS";
+
+/**
+ * Optional override for the server-hint cap, in milliseconds. When provided
+ * via `Layer.succeed(ServerRetryHintCapMs, n)`, that value wins over the
+ * environment.
+ *
+ * @example
+ * ```ts
+ * Effect.retry(op, policy).pipe(
+ *   Effect.provide(serverRetryHintCapLayer(120_000)),
+ * )
+ * ```
+ */
+export const ServerRetryHintCapMs = Context.Service<number>(
+  "@distilled.cloud/core/ServerRetryHintCapMs",
+);
+
+/**
+ * Layer that pins the server `retryAfter` cap to a fixed value (milliseconds).
+ */
+export const serverRetryHintCapLayer = (capMs: number) =>
+  Layer.succeed(ServerRetryHintCapMs, capMs);
+
+/**
+ * Effective cap when neither {@link ServerRetryHintCapMs} nor
+ * `DISTILLED_SERVER_RETRY_HINT_CAP_MS` is set: {@link DEFAULT_SERVER_RETRY_HINT_CAP_MS}.
+ *
+ * Reads `process.env.DISTILLED_SERVER_RETRY_HINT_CAP_MS` when present (must be
+ * a non-negative finite integer; invalid values are ignored). Undefined
+ * `process` (some edge runtimes) falls back to the default.
+ */
+export const readServerRetryHintCapMsFromEnv = (): number => {
+  if (typeof process === "undefined" || process.env === undefined) {
+    return DEFAULT_SERVER_RETRY_HINT_CAP_MS;
+  }
+  const raw = process.env[ENV_SERVER_RETRY_HINT_CAP_MS];
+  if (raw === undefined || raw === "") return DEFAULT_SERVER_RETRY_HINT_CAP_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_SERVER_RETRY_HINT_CAP_MS;
+  return Math.trunc(n);
+};
+
+const resolveServerRetryHintCapMs = (): Effect.Effect<number, never, never> =>
+  Effect.gen(function* () {
+    const fromLayer = yield* Effect.serviceOption(ServerRetryHintCapMs);
+    return Option.match(fromLayer, {
+      onNone: () => readServerRetryHintCapMsFromEnv(),
+      onSome: (n) =>
+        Number.isFinite(n) && n >= 0
+          ? Math.trunc(n)
+          : readServerRetryHintCapMsFromEnv(),
+    });
+  });
 
 /**
  * Extract a server-provided retry hint (in milliseconds) from an error's
- * optional `retryAfter` field, capped at {@link SERVER_HINT_CAP_MS}.
+ * optional `retryAfter` field, capped by the effective server-hint cap
+ * (see {@link ServerRetryHintCapMs} and {@link readServerRetryHintCapMsFromEnv}).
  *
  * Returns `undefined` when the error doesn't carry a hint.
  */
-const serverHintMillis = (error: unknown): number | undefined => {
+const serverHintMillis = (
+  error: unknown,
+  capMs: number,
+): number | undefined => {
   const hint = (error as { retryAfter?: unknown } | null | undefined)
     ?.retryAfter;
   if (!Duration.isDuration(hint)) return undefined;
-  return Math.min(Duration.toMillis(hint), SERVER_HINT_CAP_MS);
+  return Math.min(Duration.toMillis(hint), capMs);
 };
 
 /**
@@ -120,8 +182,9 @@ const honorServerHint = (
 ) =>
   Schedule.modifyDelay(
     Effect.fnUntraced(function* (duration: Duration.Duration) {
+      const capMs = yield* resolveServerRetryHintCapMs();
       const error = yield* Ref.get(lastError);
-      const hint = serverHintMillis(error);
+      const hint = serverHintMillis(error, capMs);
       if (hint !== undefined) return hint;
       const adjusted = baseline ? baseline(duration, error) : duration;
       return Duration.toMillis(adjusted);
@@ -137,8 +200,9 @@ const honorServerHint = (
  *
  * This policy:
  * - Retries transient errors (throttling, server, network, locked errors)
- * - Honors `error.retryAfter` (server-provided hint) with precedence,
- *   capped at 60 seconds
+ * - Honors `error.retryAfter` (server-provided hint) with precedence, capped
+ *   by {@link DEFAULT_SERVER_RETRY_HINT_CAP_MS} by default; override with
+ *   `DISTILLED_SERVER_RETRY_HINT_CAP_MS` or {@link ServerRetryHintCapMs}
  * - Otherwise uses exponential backoff starting at 100ms with a factor of 2
  * - Ensures at least 500ms delay for throttling errors
  * - Limits to 5 retry attempts

--- a/packages/core/test/retry-after.test.ts
+++ b/packages/core/test/retry-after.test.ts
@@ -1,0 +1,105 @@
+import * as Duration from "effect/Duration";
+import { describe, expect, it } from "vitest";
+import {
+  parseRatelimit,
+  parseRetryAfter,
+  parseServerRetryHint,
+} from "../src/retry-after.ts";
+
+describe("parseRetryAfter (RFC 7231 §7.1.3)", () => {
+  it("parses delay-seconds (integer)", () => {
+    const d = parseRetryAfter({ "retry-after": "120" });
+    expect(d).toBeDefined();
+    expect(Duration.toSeconds(d!)).toBe(120);
+  });
+
+  it("treats 0 seconds as a zero duration", () => {
+    const d = parseRetryAfter({ "retry-after": "0" });
+    expect(d).toBeDefined();
+    expect(Duration.toMillis(d!)).toBe(0);
+  });
+
+  it("parses HTTP-date in the future as a positive duration", () => {
+    const future = new Date(Date.now() + 5_000).toUTCString();
+    const d = parseRetryAfter({ "retry-after": future });
+    expect(d).toBeDefined();
+    const ms = Duration.toMillis(d!);
+    // toUTCString only has second-precision, so the parsed value is rounded
+    // down by up to 999ms relative to the wall-clock target. Allow generous
+    // slop on both sides for clock drift.
+    expect(ms).toBeGreaterThanOrEqual(3_900);
+    expect(ms).toBeLessThanOrEqual(5_200);
+  });
+
+  it("parses HTTP-date in the past as a zero duration", () => {
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    const d = parseRetryAfter({ "retry-after": past });
+    expect(d).toBeDefined();
+    expect(Duration.toMillis(d!)).toBe(0);
+  });
+
+  it("returns undefined for missing header", () => {
+    expect(parseRetryAfter({})).toBeUndefined();
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for empty / whitespace value", () => {
+    expect(parseRetryAfter({ "retry-after": "" })).toBeUndefined();
+    expect(parseRetryAfter({ "retry-after": "   " })).toBeUndefined();
+  });
+
+  it("returns undefined for unparseable garbage", () => {
+    expect(parseRetryAfter({ "retry-after": "not-a-date" })).toBeUndefined();
+  });
+
+  it("rejects negative integers (not a delay-seconds per RFC)", () => {
+    // "-5" is not 1*DIGIT and Date.parse fails — must fall through to undefined.
+    expect(parseRetryAfter({ "retry-after": "-5" })).toBeUndefined();
+  });
+});
+
+describe("parseRatelimit (IETF httpapi-ratelimit-headers)", () => {
+  it("parses compact `r=0, t=30` form", () => {
+    const d = parseRatelimit({ ratelimit: "r=0, t=30" });
+    expect(d).toBeDefined();
+    expect(Duration.toSeconds(d!)).toBe(30);
+  });
+
+  it("parses verbose `remaining=0, reset=15` form", () => {
+    const d = parseRatelimit({ ratelimit: "limit=100, remaining=0, reset=15" });
+    expect(d).toBeDefined();
+    expect(Duration.toSeconds(d!)).toBe(15);
+  });
+
+  it("returns undefined when remaining > 0 (not actually rate-limited)", () => {
+    expect(parseRatelimit({ ratelimit: "r=10, t=30" })).toBeUndefined();
+  });
+
+  it("returns undefined when reset is missing", () => {
+    expect(parseRatelimit({ ratelimit: "r=0" })).toBeUndefined();
+  });
+
+  it("returns undefined for missing header", () => {
+    expect(parseRatelimit({})).toBeUndefined();
+    expect(parseRatelimit(undefined)).toBeUndefined();
+  });
+});
+
+describe("parseServerRetryHint", () => {
+  it("prefers Retry-After when both are present", () => {
+    const d = parseServerRetryHint({
+      "retry-after": "5",
+      ratelimit: "r=0, t=99",
+    });
+    expect(Duration.toSeconds(d!)).toBe(5);
+  });
+
+  it("falls back to Ratelimit when Retry-After is absent", () => {
+    const d = parseServerRetryHint({ ratelimit: "r=0, t=42" });
+    expect(Duration.toSeconds(d!)).toBe(42);
+  });
+
+  it("returns undefined when neither header is present", () => {
+    expect(parseServerRetryHint({})).toBeUndefined();
+  });
+});

--- a/packages/core/test/retry.test.ts
+++ b/packages/core/test/retry.test.ts
@@ -1,0 +1,72 @@
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+import { describe, expect, it } from "vitest";
+import * as Category from "../src/category.ts";
+import { TooManyRequests } from "../src/errors.ts";
+import { makeDefault } from "../src/retry.ts";
+
+describe("makeDefault — server hint precedence", () => {
+  it("retries while error is a transient/throttling error", () => {
+    const error = new TooManyRequests({ message: "rate-limited" });
+    expect(Category.isTransientError(error)).toBe(true);
+    expect(Category.isThrottling(error)).toBe(true);
+  });
+
+  it("constructs a policy without crashing when error has retryAfter", () =>
+    Effect.gen(function* () {
+      const error = new TooManyRequests({
+        message: "rate-limited",
+        retryAfter: Duration.seconds(5),
+      });
+      const lastError = yield* Ref.make<unknown>(error);
+      const policy = makeDefault(lastError);
+      expect(policy.while).toBeDefined();
+      expect(policy.while!(error)).toBe(true);
+      expect(policy.schedule).toBeDefined();
+    }).pipe(Effect.runPromise));
+
+  it("schedule terminates after a finite number of attempts even with retryAfter", async () => {
+    const error = new TooManyRequests({
+      message: "rate-limited",
+      // 1ms hint — fast enough to exhaust 5 retries quickly.
+      retryAfter: Duration.millis(1),
+    });
+
+    let attempts = 0;
+    const program = Effect.gen(function* () {
+      const lastError = yield* Ref.make<unknown>(error);
+      const policy = makeDefault(lastError);
+      return yield* Effect.retry(
+        Effect.suspend(() => {
+          attempts += 1;
+          return Effect.fail(error);
+        }),
+        {
+          schedule: policy.schedule,
+          while: policy.while,
+        },
+      );
+    });
+
+    const exit = await Effect.runPromiseExit(program);
+    expect(exit._tag).toBe("Failure");
+    // Default policy is exponential.both(recurs(5)) ⇒ 1 initial + up to 5 retries.
+    expect(attempts).toBeGreaterThanOrEqual(2);
+    expect(attempts).toBeLessThanOrEqual(6);
+  });
+
+  it("retryAfter on the error is a Duration value", () => {
+    const error = new TooManyRequests({
+      message: "rate-limited",
+      retryAfter: Duration.seconds(7),
+    });
+    expect(Duration.isDuration((error as any).retryAfter)).toBe(true);
+    expect(Duration.toSeconds((error as any).retryAfter)).toBe(7);
+  });
+
+  it("error without retryAfter is still well-formed", () => {
+    const error = new TooManyRequests({ message: "no hint" });
+    expect((error as any).retryAfter).toBeUndefined();
+  });
+});

--- a/packages/core/test/server-retry-hint-cap.test.ts
+++ b/packages/core/test/server-retry-hint-cap.test.ts
@@ -1,0 +1,62 @@
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_SERVER_RETRY_HINT_CAP_MS,
+  readServerRetryHintCapMsFromEnv,
+  ServerRetryHintCapMs,
+  serverRetryHintCapLayer,
+} from "../src/retry.ts";
+
+describe("readServerRetryHintCapMsFromEnv", () => {
+  const key = "DISTILLED_SERVER_RETRY_HINT_CAP_MS";
+  let prev: string | undefined;
+
+  beforeEach(() => {
+    prev = process.env[key];
+  });
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
+  });
+
+  it("returns the default when unset", () => {
+    delete process.env[key];
+    expect(readServerRetryHintCapMsFromEnv()).toBe(
+      DEFAULT_SERVER_RETRY_HINT_CAP_MS,
+    );
+  });
+
+  it("reads a valid positive integer from the environment", () => {
+    process.env[key] = "5000";
+    expect(readServerRetryHintCapMsFromEnv()).toBe(5000);
+  });
+
+  it("truncates fractional values", () => {
+    process.env[key] = "999.7";
+    expect(readServerRetryHintCapMsFromEnv()).toBe(999);
+  });
+
+  it("ignores invalid values and falls back to the default", () => {
+    process.env[key] = "not-a-number";
+    expect(readServerRetryHintCapMsFromEnv()).toBe(
+      DEFAULT_SERVER_RETRY_HINT_CAP_MS,
+    );
+  });
+
+  it("treats negative numbers as invalid", () => {
+    process.env[key] = "-1";
+    expect(readServerRetryHintCapMsFromEnv()).toBe(
+      DEFAULT_SERVER_RETRY_HINT_CAP_MS,
+    );
+  });
+});
+
+describe("ServerRetryHintCapMs layer", () => {
+  it("provides the cap into the context", () => {
+    const program = Effect.gen(function* () {
+      return yield* ServerRetryHintCapMs;
+    }).pipe(Effect.provide(serverRetryHintCapLayer(42_000)));
+    expect(Effect.runSync(program)).toBe(42_000);
+  });
+});

--- a/packages/expo-eas/src/client.ts
+++ b/packages/expo-eas/src/client.ts
@@ -23,6 +23,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownEasError,
@@ -138,4 +139,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: EasParseError as any,
+  retry: Retry as any,
 });

--- a/packages/expo-eas/src/client.ts
+++ b/packages/expo-eas/src/client.ts
@@ -23,6 +23,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -73,6 +74,8 @@ const decodeRest = Schema.decodeUnknownOption(RestErrorResponse);
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   // Try GraphQL envelope first — works for both HTTP 200 with errors[] and
   // HTTP 400 responses returned by the GraphQL gateway.
@@ -90,10 +93,18 @@ const matchError = (
     }
 
     const StatusClass = (HTTP_STATUS_MAP as Record<number, unknown>)[status] as
-      | (new (args: { message: string }) => unknown)
+      | (new (args: {
+          message: string;
+          retryAfter?: ReturnType<typeof parseServerRetryHint>;
+        }) => unknown)
       | undefined;
     if (StatusClass && status >= 400) {
-      return Effect.fail(new StatusClass({ message }) as never);
+      return Effect.fail(
+        new StatusClass({
+          message,
+          retryAfter: parseServerRetryHint(headers),
+        }) as never,
+      );
     }
 
     return Effect.fail(
@@ -109,11 +120,17 @@ const matchError = (
   const rest = decodeRest(errorBody);
   if (rest._tag === "Some") {
     const StatusClass = (HTTP_STATUS_MAP as Record<number, unknown>)[status] as
-      | (new (args: { message: string }) => unknown)
+      | (new (args: {
+          message: string;
+          retryAfter?: ReturnType<typeof parseServerRetryHint>;
+        }) => unknown)
       | undefined;
     if (StatusClass) {
       return Effect.fail(
-        new StatusClass({ message: rest.value.message ?? "" }) as never,
+        new StatusClass({
+          message: rest.value.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }) as never,
       );
     }
     return Effect.fail(

--- a/packages/expo-eas/src/client.ts
+++ b/packages/expo-eas/src/client.ts
@@ -23,7 +23,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -95,14 +95,14 @@ const matchError = (
     const StatusClass = (HTTP_STATUS_MAP as Record<number, unknown>)[status] as
       | (new (args: {
           message: string;
-          retryAfter?: ReturnType<typeof parseServerRetryHint>;
+          retryAfter?: ReturnType<typeof parseRetryAfterForStatus>;
         }) => unknown)
       | undefined;
     if (StatusClass && status >= 400) {
       return Effect.fail(
         new StatusClass({
           message,
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }) as never,
       );
     }
@@ -122,14 +122,14 @@ const matchError = (
     const StatusClass = (HTTP_STATUS_MAP as Record<number, unknown>)[status] as
       | (new (args: {
           message: string;
-          retryAfter?: ReturnType<typeof parseServerRetryHint>;
+          retryAfter?: ReturnType<typeof parseRetryAfterForStatus>;
         }) => unknown)
       | undefined;
     if (StatusClass) {
       return Effect.fail(
         new StatusClass({
           message: rest.value.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }) as never,
       );
     }

--- a/packages/expo-eas/src/retry.ts
+++ b/packages/expo-eas/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Eas retry configuration.
+ * expo-eas retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * expo-eas API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Eas API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("EasRetry") {}
-
-/**
- * Provides a custom retry policy to all Eas API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/expo-eas/src/retry.ts
+++ b/packages/expo-eas/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * expo-eas retry configuration.
+ * ExpoEas retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * expo-eas API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/expo-eas/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * ExpoEas API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as ExpoEas from "@distilled.cloud/expo-eas";
+ *
+ * myEffect.pipe(ExpoEas.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(ExpoEas.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of ExpoEas API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("ExpoEasRetry") {}
+
+/** Provides a custom retry policy to every ExpoEas API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/expo-eas/src/retry.ts
+++ b/packages/expo-eas/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of ExpoEas API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/fly-io/src/client.ts
+++ b/packages/fly-io/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -30,12 +31,19 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message: parsed.error }));
+      return Effect.fail(
+        new ErrorClass({
+          message: parsed.error,
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(
       new UnknownFlyIoError({

--- a/packages/fly-io/src/client.ts
+++ b/packages/fly-io/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -41,7 +41,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.error,
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/fly-io/src/client.ts
+++ b/packages/fly-io/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownFlyIoError,
@@ -58,4 +59,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: FlyIoParseError as any,
+  retry: Retry as any,
 });

--- a/packages/fly-io/src/retry.ts
+++ b/packages/fly-io/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * fly-io retry configuration.
+ * FlyIo retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * fly-io API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/fly-io/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * FlyIo API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as FlyIo from "@distilled.cloud/fly-io";
+ *
+ * myEffect.pipe(FlyIo.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(FlyIo.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of FlyIo API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("FlyIoRetry") {}
+
+/** Provides a custom retry policy to every FlyIo API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/fly-io/src/retry.ts
+++ b/packages/fly-io/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Fly-io retry configuration.
+ * fly-io retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * fly-io API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Fly-io API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("Fly-ioRetry") {}
-
-/**
- * Provides a custom retry policy to all Fly-io API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/fly-io/src/retry.ts
+++ b/packages/fly-io/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of FlyIo API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/gcp/scripts/generate.ts
+++ b/packages/gcp/scripts/generate.ts
@@ -322,6 +322,7 @@ function generateService(doc: DiscoveryDoc, patches: ServicePatch): string {
   lines.push('import * as API from "../client/api.ts";');
   lines.push('import * as T from "../traits.ts";');
   lines.push("__CATEGORY_IMPORT__");
+  lines.push("__DURATION_SCHEMA_IMPORT__");
   lines.push('import type { Credentials } from "../credentials.ts";');
   lines.push('import type { DefaultErrors } from "../errors.ts";');
   lines.push('import type * as HttpClient from "effect/unstable/http/HttpClient";');
@@ -459,6 +460,16 @@ function generateService(doc: DiscoveryDoc, patches: ServicePatch): string {
     code = code.replace("__CATEGORY_IMPORT__", 'import * as C from "../category.ts";');
   } else {
     code = code.replace("__CATEGORY_IMPORT__\n", "");
+  }
+  // Only include the DurationSchema import if any retryable error class
+  // declares a `retryAfter` field.
+  if (code.includes("DurationSchema")) {
+    code = code.replace(
+      "__DURATION_SCHEMA_IMPORT__",
+      'import { DurationSchema } from "@distilled.cloud/core/errors";',
+    );
+  } else {
+    code = code.replace("__DURATION_SCHEMA_IMPORT__\n", "");
   }
   return code;
 }
@@ -698,6 +709,19 @@ function schemaTypeToSchemaExpr(schema: SchemaObject): string {
 // Error Generation
 // =============================================================================
 
+/**
+ * Categories that imply the error carries a server-provided retry hint
+ * (parsed from `Retry-After` / `RateLimit` headers). Errors in any of these
+ * categories get an extra `retryAfter: Schema.optional(DurationSchema)` field
+ * in their generated schema so SDK code can populate it from headers or body.
+ */
+const RETRYABLE_CATEGORIES = new Set([
+  "Retryable",
+  "ThrottlingError",
+  "ServerError",
+  "LockedError",
+]);
+
 function generateErrorClass(
   tag: string,
   matchers: ErrorMatcher[],
@@ -705,6 +729,7 @@ function generateErrorClass(
 ): string[] {
   const lines: string[] = [];
   const safeTag = safeIdentifier(tag);
+  const isRetryable = !!categories?.some((c) => RETRYABLE_CATEGORIES.has(c));
 
   lines.push(
     `export class ${safeTag} extends Schema.TaggedErrorClass<${safeTag}>()(`,
@@ -716,6 +741,9 @@ function generateErrorClass(
   lines.push(`    status: Schema.optional(Schema.String),`);
   lines.push(`    reason: Schema.optional(Schema.String),`);
   lines.push(`    domain: Schema.optional(Schema.String),`);
+  if (isRetryable) {
+    lines.push(`    retryAfter: Schema.optional(DurationSchema),`);
+  }
   lines.push(`  },`);
   lines.push(`) {}`);
 

--- a/packages/gcp/src/client/api.ts
+++ b/packages/gcp/src/client/api.ts
@@ -12,7 +12,7 @@ import {
   type OperationMethod,
   type PaginatedOperationMethod,
 } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { HTTP_STATUS_MAP, UnknownGCPError, GCPParseError } from "../errors.ts";
 import { Credentials } from "../credentials.ts";
 import { Retry } from "../retry.ts";
@@ -36,7 +36,10 @@ const matchError = (
 
   if (ErrorClass) {
     return Effect.fail(
-      new ErrorClass({ message, retryAfter: parseServerRetryHint(headers) }),
+      new ErrorClass({
+        message,
+        retryAfter: parseRetryAfterForStatus(status, headers),
+      }),
     );
   }
   return Effect.fail(

--- a/packages/gcp/src/client/api.ts
+++ b/packages/gcp/src/client/api.ts
@@ -14,6 +14,7 @@ import {
 } from "@distilled.cloud/core/client";
 import { HTTP_STATUS_MAP, UnknownGCPError, GCPParseError } from "../errors.ts";
 import { Credentials } from "../credentials.ts";
+import { Retry } from "../retry.ts";
 
 export type { OperationMethod, PaginatedOperationMethod };
 
@@ -51,6 +52,7 @@ const _API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: GCPParseError as any,
+  retry: Retry as any,
 });
 
 export const make = _API.make;

--- a/packages/gcp/src/client/api.ts
+++ b/packages/gcp/src/client/api.ts
@@ -12,6 +12,7 @@ import {
   type OperationMethod,
   type PaginatedOperationMethod,
 } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { HTTP_STATUS_MAP, UnknownGCPError, GCPParseError } from "../errors.ts";
 import { Credentials } from "../credentials.ts";
 import { Retry } from "../retry.ts";
@@ -24,6 +25,8 @@ export type { OperationMethod, PaginatedOperationMethod };
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   const ErrorClass = (HTTP_STATUS_MAP as any)[status];
   const message =
@@ -32,7 +35,9 @@ const matchError = (
       : String(status);
 
   if (ErrorClass) {
-    return Effect.fail(new ErrorClass({ message }));
+    return Effect.fail(
+      new ErrorClass({ message, retryAfter: parseServerRetryHint(headers) }),
+    );
   }
   return Effect.fail(
     new UnknownGCPError({ code: status, message, body: errorBody }),

--- a/packages/gcp/src/retry.ts
+++ b/packages/gcp/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * gcp retry configuration.
+ * GCP retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * gcp API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/gcp/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * GCP API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as GCP from "@distilled.cloud/gcp";
+ *
+ * myEffect.pipe(GCP.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(GCP.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of GCP API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("GCPRetry") {}
+
+/** Provides a custom retry policy to every GCP API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/gcp/src/retry.ts
+++ b/packages/gcp/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of GCP API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/gcp/src/retry.ts
+++ b/packages/gcp/src/retry.ts
@@ -1,23 +1,22 @@
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
+/**
+ * gcp retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * gcp API call below it.
+ */
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-export class Retry extends Context.Service<Retry, Policy>()("GCPRetry") {}
-
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/kubernetes/src/client/api.ts
+++ b/packages/kubernetes/src/client/api.ts
@@ -19,6 +19,7 @@ import {
   KubernetesParseError,
 } from "../errors.ts";
 import { Credentials } from "../credentials.ts";
+import { Retry } from "../retry.ts";
 
 export type { OperationMethod, PaginatedOperationMethod };
 
@@ -93,6 +94,7 @@ const _API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: KubernetesParseError as any,
+  retry: Retry as any,
 });
 
 export const make = _API.make;

--- a/packages/kubernetes/src/client/api.ts
+++ b/packages/kubernetes/src/client/api.ts
@@ -13,6 +13,7 @@ import {
   type OperationMethod,
   type PaginatedOperationMethod,
 } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import {
   HTTP_STATUS_MAP,
   UnknownKubernetesError,
@@ -62,12 +63,19 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message: parsed.message ?? "" }));
+      return Effect.fail(
+        new ErrorClass({
+          message: parsed.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(
       new UnknownKubernetesError({

--- a/packages/kubernetes/src/client/api.ts
+++ b/packages/kubernetes/src/client/api.ts
@@ -13,7 +13,7 @@ import {
   type OperationMethod,
   type PaginatedOperationMethod,
 } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import {
   HTTP_STATUS_MAP,
   UnknownKubernetesError,
@@ -73,7 +73,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/kubernetes/src/retry.ts
+++ b/packages/kubernetes/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Kubernetes API calls. */
@@ -49,7 +51,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/kubernetes/src/retry.ts
+++ b/packages/kubernetes/src/retry.ts
@@ -1,37 +1,22 @@
 /**
- * Kubernetes retry configuration.
+ * kubernetes retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * kubernetes API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Kubernetes API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "KubernetesRetry",
-) {}
-
-/**
- * Provides a custom retry policy to all Kubernetes API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/kubernetes/src/retry.ts
+++ b/packages/kubernetes/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * kubernetes retry configuration.
+ * Kubernetes retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * kubernetes API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/kubernetes/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Kubernetes API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Kubernetes from "@distilled.cloud/kubernetes";
+ *
+ * myEffect.pipe(Kubernetes.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Kubernetes.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Kubernetes API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("KubernetesRetry") {}
+
+/** Provides a custom retry policy to every Kubernetes API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/kubernetes/src/retry.ts
+++ b/packages/kubernetes/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Kubernetes API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("KubernetesRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "KubernetesRetry",
+) {}
 
 /** Provides a custom retry policy to every Kubernetes API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/mongodb-atlas/src/client.ts
+++ b/packages/mongodb-atlas/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -41,13 +42,18 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = STATUS_MAP[status];
     if (ErrorClass) {
       return Effect.fail(
-        new ErrorClass({ message: parsed.detail ?? parsed.reason ?? "" }),
+        new ErrorClass({
+          message: parsed.detail ?? parsed.reason ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
       );
     }
     return Effect.fail(

--- a/packages/mongodb-atlas/src/client.ts
+++ b/packages/mongodb-atlas/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   PaymentRequired,
@@ -73,4 +74,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: MongodbAtlasParseError as any,
+  retry: Retry as any,
 });

--- a/packages/mongodb-atlas/src/client.ts
+++ b/packages/mongodb-atlas/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -52,7 +52,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.detail ?? parsed.reason ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/mongodb-atlas/src/retry.ts
+++ b/packages/mongodb-atlas/src/retry.ts
@@ -1,37 +1,22 @@
 /**
- * Mongodb-atlas retry configuration.
+ * mongodb-atlas retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * mongodb-atlas API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Mongodb-atlas API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "Mongodb-atlasRetry",
-) {}
-
-/**
- * Provides a custom retry policy to all Mongodb-atlas API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/mongodb-atlas/src/retry.ts
+++ b/packages/mongodb-atlas/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of MongoDBAtlas API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("MongoDBAtlasRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "MongoDBAtlasRetry",
+) {}
 
 /** Provides a custom retry policy to every MongoDBAtlas API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/mongodb-atlas/src/retry.ts
+++ b/packages/mongodb-atlas/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * mongodb-atlas retry configuration.
+ * MongoDBAtlas retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * mongodb-atlas API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/mongodb-atlas/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * MongoDBAtlas API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as MongoDBAtlas from "@distilled.cloud/mongodb-atlas";
+ *
+ * myEffect.pipe(MongoDBAtlas.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(MongoDBAtlas.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of MongoDBAtlas API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("MongoDBAtlasRetry") {}
+
+/** Provides a custom retry policy to every MongoDBAtlas API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/mongodb-atlas/src/retry.ts
+++ b/packages/mongodb-atlas/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of MongoDBAtlas API calls. */
@@ -49,7 +51,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/neon/src/client.ts
+++ b/packages/neon/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import { HTTP_STATUS_MAP, UnknownNeonError, NeonParseError } from "./errors.ts";
 
 // Re-export for backwards compatibility (tests import UnknownNeonError from client)
@@ -56,4 +57,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: NeonParseError as any,
+  retry: Retry as any,
 });

--- a/packages/neon/src/client.ts
+++ b/packages/neon/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import { HTTP_STATUS_MAP, UnknownNeonError, NeonParseError } from "./errors.ts";
 
@@ -38,7 +38,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/neon/src/client.ts
+++ b/packages/neon/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import { HTTP_STATUS_MAP, UnknownNeonError, NeonParseError } from "./errors.ts";
 
@@ -27,12 +28,19 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message: parsed.message ?? "" }));
+      return Effect.fail(
+        new ErrorClass({
+          message: parsed.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(
       new UnknownNeonError({

--- a/packages/neon/src/retry.ts
+++ b/packages/neon/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * neon retry configuration.
+ * Neon retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * neon API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/neon/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Neon API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Neon from "@distilled.cloud/neon";
+ *
+ * myEffect.pipe(Neon.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Neon.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Neon API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("NeonRetry") {}
+
+/** Provides a custom retry policy to every Neon API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/neon/src/retry.ts
+++ b/packages/neon/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Neon retry configuration.
+ * neon retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * neon API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Neon API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("NeonRetry") {}
-
-/**
- * Provides a custom retry policy to all Neon API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/neon/src/retry.ts
+++ b/packages/neon/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Neon API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/planetscale/src/client.ts
+++ b/packages/planetscale/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownPlanetScaleError,
@@ -60,4 +61,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: PlanetScaleParseError as any,
+  retry: Retry as any,
 });

--- a/packages/planetscale/src/client.ts
+++ b/packages/planetscale/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -31,12 +32,19 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message: parsed.message ?? "" }));
+      return Effect.fail(
+        new ErrorClass({
+          message: parsed.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(
       new UnknownPlanetScaleError({

--- a/packages/planetscale/src/client.ts
+++ b/packages/planetscale/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -42,7 +42,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/planetscale/src/retry.ts
+++ b/packages/planetscale/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * planetscale retry configuration.
+ * PlanetScale retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * planetscale API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/planetscale/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * PlanetScale API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as PlanetScale from "@distilled.cloud/planetscale";
+ *
+ * myEffect.pipe(PlanetScale.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(PlanetScale.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of PlanetScale API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("PlanetScaleRetry") {}
+
+/** Provides a custom retry policy to every PlanetScale API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/planetscale/src/retry.ts
+++ b/packages/planetscale/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of PlanetScale API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("PlanetScaleRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "PlanetScaleRetry",
+) {}
 
 /** Provides a custom retry policy to every PlanetScale API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/planetscale/src/retry.ts
+++ b/packages/planetscale/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of PlanetScale API calls. */
@@ -49,7 +51,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/planetscale/src/retry.ts
+++ b/packages/planetscale/src/retry.ts
@@ -1,39 +1,22 @@
 /**
- * PlanetScale retry configuration.
+ * planetscale retry configuration.
  *
- * Re-exports shared retry utilities and provides a PlanetScale-specific Retry service.
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * planetscale API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of PlanetScale API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "PlanetScaleRetry",
-) {}
-
-/**
- * Provides a custom retry policy to all PlanetScale API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/posthog/src/client.ts
+++ b/packages/posthog/src/client.ts
@@ -7,7 +7,7 @@
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -57,7 +57,10 @@ const matchError = (
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
       return Effect.fail(
-        new ErrorClass({ message, retryAfter: parseServerRetryHint(headers) }),
+        new ErrorClass({
+          message,
+          retryAfter: parseRetryAfterForStatus(status, headers),
+        }),
       );
     }
     return Effect.fail(

--- a/packages/posthog/src/client.ts
+++ b/packages/posthog/src/client.ts
@@ -7,6 +7,7 @@
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownPosthogError,
@@ -80,4 +81,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: PosthogParseError as any,
+  retry: Retry as any,
 });

--- a/packages/posthog/src/client.ts
+++ b/packages/posthog/src/client.ts
@@ -7,6 +7,7 @@
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -47,13 +48,17 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const message = parsed.detail ?? parsed.message ?? parsed.error ?? "";
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message }));
+      return Effect.fail(
+        new ErrorClass({ message, retryAfter: parseServerRetryHint(headers) }),
+      );
     }
     return Effect.fail(
       new UnknownPosthogError({

--- a/packages/posthog/src/retry.ts
+++ b/packages/posthog/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of PostHog API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/posthog/src/retry.ts
+++ b/packages/posthog/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Posthog retry configuration.
+ * posthog retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * posthog API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Posthog API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("PosthogRetry") {}
-
-/**
- * Provides a custom retry policy to all Posthog API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/posthog/src/retry.ts
+++ b/packages/posthog/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * posthog retry configuration.
+ * PostHog retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * posthog API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/posthog/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * PostHog API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as PostHog from "@distilled.cloud/posthog";
+ *
+ * myEffect.pipe(PostHog.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(PostHog.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of PostHog API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("PostHogRetry") {}
+
+/** Provides a custom retry policy to every PostHog API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/prisma-postgres/src/client.ts
+++ b/packages/prisma-postgres/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -45,7 +45,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.error.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }
@@ -66,7 +66,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message,
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/prisma-postgres/src/client.ts
+++ b/packages/prisma-postgres/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownPrismaPostgresError,
@@ -73,4 +74,5 @@ export const API = makeAPI({
   }),
   matchError,
   ParseError: PrismaPostgresParseError as any,
+  retry: Retry as any,
 });

--- a/packages/prisma-postgres/src/client.ts
+++ b/packages/prisma-postgres/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -34,13 +35,18 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
       return Effect.fail(
-        new ErrorClass({ message: parsed.error.message ?? "" }),
+        new ErrorClass({
+          message: parsed.error.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
       );
     }
     return Effect.fail(
@@ -57,7 +63,12 @@ const matchError = (
     if (ErrorClass) {
       const message =
         typeof errorBody === "string" ? errorBody : String(errorBody ?? "");
-      return Effect.fail(new ErrorClass({ message }));
+      return Effect.fail(
+        new ErrorClass({
+          message,
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(new UnknownPrismaPostgresError({ body: errorBody }));
   }

--- a/packages/prisma-postgres/src/retry.ts
+++ b/packages/prisma-postgres/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of PrismaPostgres API calls. */
@@ -49,7 +51,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/prisma-postgres/src/retry.ts
+++ b/packages/prisma-postgres/src/retry.ts
@@ -35,7 +35,9 @@ export {
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of PrismaPostgres API calls. */
-export class Retry extends Context.Service<Retry, Policy>()("PrismaPostgresRetry") {}
+export class Retry extends Context.Service<Retry, Policy>()(
+  "PrismaPostgresRetry",
+) {}
 
 /** Provides a custom retry policy to every PrismaPostgres API call below it. */
 export const policy = (optionsOrFactory: Policy) =>

--- a/packages/prisma-postgres/src/retry.ts
+++ b/packages/prisma-postgres/src/retry.ts
@@ -1,37 +1,22 @@
 /**
- * Prisma Postgres retry configuration.
+ * prisma-postgres retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * prisma-postgres API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Prisma Postgres API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()(
-  "PrismaPostgresRetry",
-) {}
-
-/**
- * Provides a custom retry policy to all Prisma Postgres API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/prisma-postgres/src/retry.ts
+++ b/packages/prisma-postgres/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * prisma-postgres retry configuration.
+ * PrismaPostgres retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * prisma-postgres API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/prisma-postgres/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * PrismaPostgres API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as PrismaPostgres from "@distilled.cloud/prisma-postgres";
+ *
+ * myEffect.pipe(PrismaPostgres.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(PrismaPostgres.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of PrismaPostgres API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("PrismaPostgresRetry") {}
+
+/** Provides a custom retry policy to every PrismaPostgres API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -55,6 +56,8 @@ const StripeErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(StripeErrorResponse)(errorBody);
@@ -132,7 +135,12 @@ const matchError = (
     // Fall back to standard HTTP status errors (400, 401, 403, 404, etc.)
     const CoreErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (CoreErrorClass) {
-      return Effect.fail(new CoreErrorClass({ message: err.message ?? "" }));
+      return Effect.fail(
+        new CoreErrorClass({
+          message: err.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
 
     return Effect.fail(

--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   STRIPE_HTTP_STATUS_MAP,
@@ -159,4 +160,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: StripeParseError as any,
+  retry: Retry as any,
 });

--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -138,7 +138,7 @@ const matchError = (
       return Effect.fail(
         new CoreErrorClass({
           message: err.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/stripe/src/retry.ts
+++ b/packages/stripe/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Stripe retry configuration.
+ * stripe retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * stripe API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Stripe API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("StripeRetry") {}
-
-/**
- * Provides a custom retry policy to all Stripe API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/stripe/src/retry.ts
+++ b/packages/stripe/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * stripe retry configuration.
+ * Stripe retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * stripe API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/stripe/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Stripe API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Stripe from "@distilled.cloud/stripe";
+ *
+ * myEffect.pipe(Stripe.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Stripe.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Stripe API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("StripeRetry") {}
+
+/** Provides a custom retry policy to every Stripe API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/stripe/src/retry.ts
+++ b/packages/stripe/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Stripe API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownSupabaseError,
@@ -60,4 +61,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: SupabaseParseError as any,
+  retry: Retry as any,
 });

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -43,7 +43,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(effectiveStatus, headers),
         }),
       );
     }

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -30,6 +31,8 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
@@ -37,7 +40,12 @@ const matchError = (
     const effectiveStatus = status === 406 ? 404 : status;
     const ErrorClass = (HTTP_STATUS_MAP as any)[effectiveStatus];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message: parsed.message ?? "" }));
+      return Effect.fail(
+        new ErrorClass({
+          message: parsed.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(
       new UnknownSupabaseError({

--- a/packages/supabase/src/retry.ts
+++ b/packages/supabase/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Supabase retry configuration.
+ * supabase retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * supabase API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Supabase API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("SupabaseRetry") {}
-
-/**
- * Provides a custom retry policy to all Supabase API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/supabase/src/retry.ts
+++ b/packages/supabase/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Supabase API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/supabase/src/retry.ts
+++ b/packages/supabase/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * supabase retry configuration.
+ * Supabase retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * supabase API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/supabase/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Supabase API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Supabase from "@distilled.cloud/supabase";
+ *
+ * myEffect.pipe(Supabase.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Supabase.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Supabase API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("SupabaseRetry") {}
+
+/** Provides a custom retry policy to every Supabase API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/turso/src/client.ts
+++ b/packages/turso/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownTursoError,
@@ -61,4 +62,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: TursoParseError as any,
+  retry: Retry as any,
 });

--- a/packages/turso/src/client.ts
+++ b/packages/turso/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -32,12 +33,19 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message: parsed.error }));
+      return Effect.fail(
+        new ErrorClass({
+          message: parsed.error,
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(
       new UnknownTursoError({

--- a/packages/turso/src/client.ts
+++ b/packages/turso/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -43,7 +43,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.error,
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/turso/src/retry.ts
+++ b/packages/turso/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Turso retry configuration.
+ * turso retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * turso API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Turso API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("TursoRetry") {}
-
-/**
- * Provides a custom retry policy to all Turso API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/turso/src/retry.ts
+++ b/packages/turso/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * turso retry configuration.
+ * Turso retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * turso API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/turso/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Turso API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Turso from "@distilled.cloud/turso";
+ *
+ * myEffect.pipe(Turso.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Turso.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Turso API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("TursoRetry") {}
+
+/** Provides a custom retry policy to every Turso API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/turso/src/retry.ts
+++ b/packages/turso/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Turso API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/typesense/src/client.ts
+++ b/packages/typesense/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -41,7 +41,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }

--- a/packages/typesense/src/client.ts
+++ b/packages/typesense/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -30,12 +31,19 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message: parsed.message ?? "" }));
+      return Effect.fail(
+        new ErrorClass({
+          message: parsed.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(
       new UnknownTypesenseError({

--- a/packages/typesense/src/client.ts
+++ b/packages/typesense/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownTypesenseError,
@@ -58,4 +59,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: TypesenseParseError as any,
+  retry: Retry as any,
 });

--- a/packages/typesense/src/retry.ts
+++ b/packages/typesense/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Typesense retry configuration.
+ * typesense retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * typesense API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Typesense API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("TypesenseRetry") {}
-
-/**
- * Provides a custom retry policy to all Typesense API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/typesense/src/retry.ts
+++ b/packages/typesense/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * typesense retry configuration.
+ * Typesense retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * typesense API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/typesense/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * Typesense API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as Typesense from "@distilled.cloud/typesense";
+ *
+ * myEffect.pipe(Typesense.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(Typesense.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of Typesense API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("TypesenseRetry") {}
+
+/** Provides a custom retry policy to every Typesense API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/packages/typesense/src/retry.ts
+++ b/packages/typesense/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of Typesense API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/workos/src/client.ts
+++ b/packages/workos/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
   UnknownWorkosError,
@@ -83,4 +84,5 @@ export const API = makeAPI<Credentials>({
   }),
   matchError,
   ParseError: WorkosParseError as any,
+  retry: Retry as any,
 });

--- a/packages/workos/src/client.ts
+++ b/packages/workos/src/client.ts
@@ -8,7 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -70,7 +70,10 @@ const matchError = (
   const ErrorClass = (HTTP_STATUS_MAP as any)[status];
   if (ErrorClass) {
     return Effect.fail(
-      new ErrorClass({ message, retryAfter: parseServerRetryHint(headers) }),
+      new ErrorClass({
+        message,
+        retryAfter: parseRetryAfterForStatus(status, headers),
+      }),
     );
   }
   return Effect.fail(

--- a/packages/workos/src/client.ts
+++ b/packages/workos/src/client.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
   HTTP_STATUS_MAP,
@@ -40,6 +41,8 @@ const ApiErrorResponse = Schema.Struct({
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   // Try to extract a message and code from the body, but fall through to
   // status-code mapping regardless of whether the body parses as the
@@ -66,7 +69,9 @@ const matchError = (
   }
   const ErrorClass = (HTTP_STATUS_MAP as any)[status];
   if (ErrorClass) {
-    return Effect.fail(new ErrorClass({ message }));
+    return Effect.fail(
+      new ErrorClass({ message, retryAfter: parseServerRetryHint(headers) }),
+    );
   }
   return Effect.fail(
     new UnknownWorkosError({ code, message, body: errorBody }),

--- a/packages/workos/src/retry.ts
+++ b/packages/workos/src/retry.ts
@@ -19,8 +19,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import {
   type Policy,
-  throttlingOptions,
-  transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 export {
@@ -32,6 +32,8 @@ export {
   capped,
   throttlingOptions,
   transientOptions,
+  throttlingFactory,
+  transientFactory,
 } from "@distilled.cloud/core/retry";
 
 /** Context tag for configuring retry behavior of WorkOS API calls. */
@@ -47,7 +49,7 @@ export const none = Effect.provide(
 );
 
 /** Apply the throttling retry policy (retries throttling errors indefinitely). */
-export const throttling = policy(throttlingOptions);
+export const throttling = policy(throttlingFactory);
 
 /** Apply the transient retry policy (retries all transient errors indefinitely). */
-export const transient = policy(transientOptions);
+export const transient = policy(transientFactory);

--- a/packages/workos/src/retry.ts
+++ b/packages/workos/src/retry.ts
@@ -1,35 +1,22 @@
 /**
- * Workos retry configuration.
+ * workos retry configuration.
+ *
+ * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
+ * so a blanket retry policy installed at the layer level covers every
+ * workos API call below it.
  */
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as Context from "effect/Context";
 export {
   type Options,
   type Factory,
   type Policy,
+  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
+  policy,
+  none,
+  throttling,
+  transient,
 } from "@distilled.cloud/core/retry";
-import type { Policy } from "@distilled.cloud/core/retry";
-
-/**
- * Context tag for configuring retry behavior of Workos API calls.
- */
-export class Retry extends Context.Service<Retry, Policy>()("WorkosRetry") {}
-
-/**
- * Provides a custom retry policy to all Workos API calls.
- */
-export const policy = (optionsOrFactory: Policy) =>
-  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
-
-/**
- * Disables all automatic retries.
- */
-export const none = Effect.provide(
-  Layer.succeed(Retry, { while: () => false }),
-);

--- a/packages/workos/src/retry.ts
+++ b/packages/workos/src/retry.ts
@@ -1,22 +1,53 @@
 /**
- * workos retry configuration.
+ * WorkOS retry configuration.
  *
- * Re-exports the shared `Retry` Context.Service from `@distilled.cloud/core`
- * so a blanket retry policy installed at the layer level covers every
- * workos API call below it.
+ * Defines the per-SDK `Retry` Context.Service tag that
+ * `packages/workos/src/client.ts` wires into `makeAPI`. Callers can
+ * install a blanket retry policy at the layer level and have every
+ * WorkOS API call below it pick it up:
+ *
+ * @example
+ * ```ts
+ * import * as WorkOS from "@distilled.cloud/workos";
+ *
+ * myEffect.pipe(WorkOS.Retry.transient);
+ * Effect.provide(myEffect, Layer.succeed(WorkOS.Retry.Retry, customPolicy));
+ * ```
  */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {
+  type Policy,
+  throttlingOptions,
+  transientOptions,
+} from "@distilled.cloud/core/retry";
+
 export {
   type Options,
   type Factory,
   type Policy,
-  Retry,
   makeDefault,
   jittered,
   capped,
   throttlingOptions,
   transientOptions,
-  policy,
-  none,
-  throttling,
-  transient,
 } from "@distilled.cloud/core/retry";
+
+/** Context tag for configuring retry behavior of WorkOS API calls. */
+export class Retry extends Context.Service<Retry, Policy>()("WorkOSRetry") {}
+
+/** Provides a custom retry policy to every WorkOS API call below it. */
+export const policy = (optionsOrFactory: Policy) =>
+  Effect.provide(Layer.succeed(Retry, optionsOrFactory));
+
+/** Disables all automatic retries. */
+export const none = Effect.provide(
+  Layer.succeed(Retry, { while: () => false }),
+);
+
+/** Apply the throttling retry policy (retries throttling errors indefinitely). */
+export const throttling = policy(throttlingOptions);
+
+/** Apply the transient retry policy (retries all transient errors indefinitely). */
+export const transient = policy(transientOptions);

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -185,10 +185,9 @@ function generateChangelogEntry(version: string): string {
   const range = prevTag ? `${prevTag}...HEAD` : "HEAD";
   let logOutput = "";
   try {
-    logOutput = execSync(
-      `git log ${range} --no-merges --format="%H %s" -- .`,
-      { encoding: "utf-8" },
-    ).trim();
+    logOutput = execSync(`git log ${range} --no-merges --format="%H %s" -- .`, {
+      encoding: "utf-8",
+    }).trim();
   } catch {
     // git log failed — empty changelog
   }
@@ -220,9 +219,7 @@ function generateChangelogEntry(version: string): string {
       continue;
 
     // Parse conventional commit: type(scope): description (#PR)
-    const match = subject.match(
-      /^(feat|fix|perf)(?:\(([^)]*)\))?\s*:\s*(.+)$/,
-    );
+    const match = subject.match(/^(feat|fix|perf)(?:\(([^)]*)\))?\s*:\s*(.+)$/);
     if (!match) continue;
 
     const [, type, scope, description] = match;
@@ -315,25 +312,16 @@ try {
     if (headerEnd !== -1) {
       const header = existing.slice(0, headerEnd);
       const rest = existing.slice(headerEnd + 2);
-      await writeFile(
-        changelogPath,
-        `${header}\n\n${changelogEntry}\n${rest}`,
-      );
+      await writeFile(changelogPath, `${header}\n\n${changelogEntry}\n${rest}`);
     } else {
       // No double newline found — just prepend after first line
       const firstNewline = existing.indexOf("\n");
       const header = existing.slice(0, firstNewline);
       const rest = existing.slice(firstNewline + 1);
-      await writeFile(
-        changelogPath,
-        `${header}\n\n${changelogEntry}\n${rest}`,
-      );
+      await writeFile(changelogPath, `${header}\n\n${changelogEntry}\n${rest}`);
     }
   } else {
-    await writeFile(
-      changelogPath,
-      `# Changelog\n\n${changelogEntry}`,
-    );
+    await writeFile(changelogPath, `# Changelog\n\n${changelogEntry}`);
   }
   console.log(`  Updated CHANGELOG.md`);
 } catch (err) {

--- a/scripts/create-sdk-full.ts
+++ b/scripts/create-sdk-full.ts
@@ -15,7 +15,7 @@
  *   - Per-SDK `Retry` Context.Service tag installed into `makeAPI`, so callers
  *     can install a blanket retry policy at the layer level.
  *   - The scaffolded `matchError` parses standard `Retry-After` / `RateLimit`
- *     headers via `parseServerRetryHint` and attaches the resulting `Duration`
+ *     headers via `parseRetryAfterForStatus` and attaches the resulting `Duration`
  *     to retryable errors. The retry policy honors that hint with precedence
  *     over the default exponential backoff. To override per-service (bespoke
  *     headers, body fields), edit `matchError` in the SDK's `client.ts`.
@@ -172,12 +172,7 @@ const createSdkFull = Command.make(
       // If the create-sdk stage is skipped but a note was supplied, write it
       // into the existing metadata file so downstream stages still see it.
       if (config.skipCreate && note) {
-        yield* initMetadata(
-          root,
-          config.name,
-          `packages/${config.name}`,
-          note,
-        );
+        yield* initMetadata(root, config.name, `packages/${config.name}`, note);
         yield* Console.log(
           `${DIM}ℹ Wrote userNote to .ai-workspace/${config.name}-metadata.json${RESET}`,
         );

--- a/scripts/create-sdk-full.ts
+++ b/scripts/create-sdk-full.ts
@@ -14,11 +14,11 @@
  * Notes on built-in behaviors that the scaffold wires automatically:
  *   - Per-SDK `Retry` Context.Service tag installed into `makeAPI`, so callers
  *     can install a blanket retry policy at the layer level.
- *   - The scaffolded `matchError` parses standard `Retry-After` / `RateLimit`
- *     headers via `parseRetryAfterForStatus` and attaches the resulting `Duration`
- *     to retryable errors. The retry policy honors that hint with precedence
- *     over the default exponential backoff. To override per-service (bespoke
- *     headers, body fields), edit `matchError` in the SDK's `client.ts`.
+ *   - The scaffolded `matchError` uses `parseRetryAfterForStatus` when standard
+ *     `Retry-After` / `RateLimit` headers are present, so retryable errors can
+ *     carry a `retryAfter` hint; when headers are absent, `retryAfter` is omitted
+ *     and the default policy still retries with exponential backoff. For bespoke
+ *     hints per service, edit `matchError` in the SDK's `client.ts`.
  *
  * Usage:
  *   bun scripts/create-sdk-full.ts <name> --specs <url-or-repo>... [flags]

--- a/scripts/create-sdk-full.ts
+++ b/scripts/create-sdk-full.ts
@@ -11,6 +11,15 @@
  * Each stage runs as its own subprocess so the Claude Agent SDK session is
  * isolated. Output streams to the terminal live.
  *
+ * Notes on built-in behaviors that the scaffold wires automatically:
+ *   - Per-SDK `Retry` Context.Service tag installed into `makeAPI`, so callers
+ *     can install a blanket retry policy at the layer level.
+ *   - The scaffolded `matchError` parses standard `Retry-After` / `RateLimit`
+ *     headers via `parseServerRetryHint` and attaches the resulting `Duration`
+ *     to retryable errors. The retry policy honors that hint with precedence
+ *     over the default exponential backoff. To override per-service (bespoke
+ *     headers, body fields), edit `matchError` in the SDK's `client.ts`.
+ *
  * Usage:
  *   bun scripts/create-sdk-full.ts <name> --specs <url-or-repo>... [flags]
  *

--- a/scripts/create-sdk.ts
+++ b/scripts/create-sdk.ts
@@ -1188,6 +1188,7 @@ export const CredentialsFromEnv = Layer.effect(
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
 import { HTTP_STATUS_MAP, Unknown${capitalName}Error, ${capitalName}ParseError } from "./errors.ts";
 
 // Re-export for backwards compatibility
@@ -1202,16 +1203,28 @@ const ApiErrorResponse = Schema.Struct({
 
 /**
  * Match a ${capitalName} API error response to the appropriate error class based on HTTP status.
+ *
+ * Retryable errors (429, 5xx) carry an optional \`retryAfter\` Duration parsed
+ * from the standard \`Retry-After\` / \`RateLimit\` headers; the retry policy
+ * honors it. If this service uses bespoke headers or body fields for rate-limit
+ * cooldowns, parse them here and pass the result as \`retryAfter\`.
  */
 const matchError = (
   status: number,
   errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   try {
     const parsed = Schema.decodeUnknownSync(ApiErrorResponse)(errorBody);
     const ErrorClass = (HTTP_STATUS_MAP as any)[status];
     if (ErrorClass) {
-      return Effect.fail(new ErrorClass({ message: parsed.message ?? "" }));
+      return Effect.fail(
+        new ErrorClass({
+          message: parsed.message ?? "",
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
     }
     return Effect.fail(
       new Unknown${capitalName}Error({

--- a/scripts/create-sdk.ts
+++ b/scripts/create-sdk.ts
@@ -63,7 +63,6 @@ const quoteForCmd = (arg: string): string => {
     .join("^%");
 };
 
-
 /**
  * Run a shell command, capturing stdout/stderr. Fails with CommandError on non-zero exit
  * unless ignoreError is set.
@@ -1188,7 +1187,7 @@ export const CredentialsFromEnv = Layer.effect(
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
-import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";
+import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { HTTP_STATUS_MAP, Unknown${capitalName}Error, ${capitalName}ParseError } from "./errors.ts";
 
 // Re-export for backwards compatibility
@@ -1222,7 +1221,7 @@ const matchError = (
       return Effect.fail(
         new ErrorClass({
           message: parsed.message ?? "",
-          retryAfter: parseServerRetryHint(headers),
+          retryAfter: parseRetryAfterForStatus(status, headers),
         }),
       );
     }
@@ -1385,7 +1384,8 @@ const updateTestYml = (
     // current format is `name: ${{ steps.force.outputs.all || steps.changes.outputs.name }}`
     // (with the force-ci escape hatch). The negative lookahead pins to the
     // tail of the block so we splice after the last entry regardless of name.
-    const outputLineRegex = /(      [a-z0-9-]+: \$\{\{ steps\.force\.outputs\.all \|\| steps\.changes\.outputs\.[a-z0-9-]+ \}\})(?![\s\S]*      [a-z0-9-]+: \$\{\{ steps\.force\.outputs\.all \|\| steps\.changes\.outputs)/;
+    const outputLineRegex =
+      /(      [a-z0-9-]+: \$\{\{ steps\.force\.outputs\.all \|\| steps\.changes\.outputs\.[a-z0-9-]+ \}\})(?![\s\S]*      [a-z0-9-]+: \$\{\{ steps\.force\.outputs\.all \|\| steps\.changes\.outputs)/;
     const outputsMatch = content.match(outputLineRegex);
     if (outputsMatch) {
       content = content.replace(
@@ -1395,7 +1395,8 @@ const updateTestYml = (
     }
 
     // Splice after the last paths-filter block.
-    const filtersRegex = /(            [a-z0-9-]+:\n              - 'packages\/[a-z0-9-]+\/\*\*'\n              - 'packages\/core\/\*\*')(?![\s\S]*            [a-z0-9-]+:\n              - 'packages\/[a-z0-9-]+\/\*\*'\n              - 'packages\/core\/\*\*')/;
+    const filtersRegex =
+      /(            [a-z0-9-]+:\n              - 'packages\/[a-z0-9-]+\/\*\*'\n              - 'packages\/core\/\*\*')(?![\s\S]*            [a-z0-9-]+:\n              - 'packages\/[a-z0-9-]+\/\*\*'\n              - 'packages\/core\/\*\*')/;
     const filtersMatch = content.match(filtersRegex);
     if (filtersMatch) {
       content = content.replace(
@@ -1517,9 +1518,9 @@ const wireTestEnvVars = (
 
     // Find the end of the ci-{name} block (next `  ci-` or EOF).
     const blockStart = headerIdx + 1;
-    const nextJobMatch = content.slice(blockStart + jobHeader.length).match(
-      /\n  ci-[a-z0-9-]+:\n/,
-    );
+    const nextJobMatch = content
+      .slice(blockStart + jobHeader.length)
+      .match(/\n  ci-[a-z0-9-]+:\n/);
     const blockEnd = nextJobMatch
       ? blockStart + jobHeader.length + nextJobMatch.index!
       : content.length;
@@ -1610,7 +1611,8 @@ const updatePkgPrYml = (
     // the last block ending with `'packages/core/**'` (negative lookahead pins
     // to the tail).
     const filterEntry = `\n            ${name}:\n              - 'packages/${name}/**'\n              - 'packages/core/**'`;
-    const lastFilterRegex = /(\n            [a-z0-9-]+:\n              - 'packages\/[a-z0-9-]+\/\*\*'\n              - 'packages\/core\/\*\*')(?![\s\S]*\n            [a-z0-9-]+:\n              - 'packages\/[a-z0-9-]+\/\*\*'\n              - 'packages\/core\/\*\*')/;
+    const lastFilterRegex =
+      /(\n            [a-z0-9-]+:\n              - 'packages\/[a-z0-9-]+\/\*\*'\n              - 'packages\/core\/\*\*')(?![\s\S]*\n            [a-z0-9-]+:\n              - 'packages\/[a-z0-9-]+\/\*\*'\n              - 'packages\/core\/\*\*')/;
     const lastFilterMatch = content.match(lastFilterRegex);
     if (lastFilterMatch) {
       content = content.replace(
@@ -1667,13 +1669,11 @@ const updateReleaseYml = (
     // Insert into the publish-sdk matrix list. Anchor on the `steps:` line
     // that follows the matrix block so we splice before it.
     if (!alreadyInMatrix) {
-      const matrixEndAnchor = /(    strategy:[\s\S]*?package:\n(?:          - [a-z0-9-]+\n)+)(    steps:)/;
+      const matrixEndAnchor =
+        /(    strategy:[\s\S]*?package:\n(?:          - [a-z0-9-]+\n)+)(    steps:)/;
       const m = content.match(matrixEndAnchor);
       if (m) {
-        content = content.replace(
-          matrixEndAnchor,
-          `$1${matrixLine}$2`,
-        );
+        content = content.replace(matrixEndAnchor, `$1${matrixLine}$2`);
       }
     }
 
@@ -1702,7 +1702,9 @@ const updateNukeYml = (
 
     const inputHeader = `      ${name}:`;
     if (content.includes(inputHeader)) {
-      yield* Console.log(`\n⚠️  nuke.yml already has input for ${name}, skipping`);
+      yield* Console.log(
+        `\n⚠️  nuke.yml already has input for ${name}, skipping`,
+      );
       return;
     }
 
@@ -1710,7 +1712,8 @@ const updateNukeYml = (
 
     // Splice a workflow_dispatch input after the last existing one. The block
     // ends with the `jobs:` key, so anchor on the last input + `default: false`.
-    const lastInputRegex = /(      [a-z0-9-]+:\n        description: "[^"]+"\n        type: boolean\n        default: false\n)(?![\s\S]*      [a-z0-9-]+:\n        description: "[^"]+"\n        type: boolean\n        default: false\n)/;
+    const lastInputRegex =
+      /(      [a-z0-9-]+:\n        description: "[^"]+"\n        type: boolean\n        default: false\n)(?![\s\S]*      [a-z0-9-]+:\n        description: "[^"]+"\n        type: boolean\n        default: false\n)/;
     const description = name
       .split("-")
       .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
@@ -1723,7 +1726,8 @@ const updateNukeYml = (
 
     // Also append to the validate-inputs check so the workflow doesn't reject
     // a run that selected only this SDK.
-    const validateRegex = /(\s+&& "\$\{\{ inputs\.[a-z0-9-]+ \}\}" != "true" \\)\n(             \]\];)/;
+    const validateRegex =
+      /(\s+&& "\$\{\{ inputs\.[a-z0-9-]+ \}\}" != "true" \\)\n(             \]\];)/;
     const vMatch = content.match(validateRegex);
     if (vMatch) {
       content = content.replace(

--- a/scripts/create-sdk.ts
+++ b/scripts/create-sdk.ts
@@ -1203,10 +1203,11 @@ const ApiErrorResponse = Schema.Struct({
 /**
  * Match a ${capitalName} API error response to the appropriate error class based on HTTP status.
  *
- * Retryable errors (429, 5xx) carry an optional \`retryAfter\` Duration parsed
- * from the standard \`Retry-After\` / \`RateLimit\` headers; the retry policy
- * honors it. If this service uses bespoke headers or body fields for rate-limit
- * cooldowns, parse them here and pass the result as \`retryAfter\`.
+ * For status codes whose error class declares \`retryAfter\`, pass
+ * \`retryAfter: parseRetryAfterForStatus(status, headers)\`. That is \`undefined\`
+ * when no standard \`Retry-After\` / \`RateLimit\` hint is present — omitting the
+ * field is fine; the default retry policy still uses exponential backoff.
+ * For bespoke rate-limit hints, parse them here and pass \`retryAfter\` when known.
  */
 const matchError = (
   status: number,

--- a/scripts/discord-notify.ts
+++ b/scripts/discord-notify.ts
@@ -43,7 +43,9 @@ const afterHeading = changelog.indexOf("\n", start);
 const after = changelog.slice(afterHeading + 1);
 // Stop at the next `## ` heading (the previous version's entry).
 const nextHeadingIdx = after.indexOf("\n## ");
-const rawBody = (nextHeadingIdx === -1 ? after : after.slice(0, nextHeadingIdx)).trim();
+const rawBody = (
+  nextHeadingIdx === -1 ? after : after.slice(0, nextHeadingIdx)
+).trim();
 
 // CHANGELOG.md is formatted for GitHub Releases. Discord renders neither HTML
 // entities nor the `<samp>` tag, so swap them for plain-text/markdown

--- a/scripts/error-discovery.ts
+++ b/scripts/error-discovery.ts
@@ -132,12 +132,16 @@ const matchError = (
 \`\`\`
 When you construct a retryable error (TooManyRequests/429, InternalServerError/500,
 BadGateway/502, ServiceUnavailable/503, GatewayTimeout/504, Locked/423, or any
-class categorized retryable), you MUST pass \`retryAfter: parseRetryAfterForStatus(status, headers)\`
-so the retry policy honors server-provided wait hints (Retry-After / RateLimit headers).
+class categorized retryable), \`retryAfter\` on that instance is **optional**.
+If the response has standard \`Retry-After\` or \`RateLimit\` headers worth honoring,
+pass \`retryAfter: parseRetryAfterForStatus(status, headers)\`. If there is no
+usable hint, omit \`retryAfter\` entirely — the default retry policy still retries
+using exponential backoff starting at 100ms (you do not need to invent a wait).
 Import: \`import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";\`
+
 If this service uses bespoke headers or body fields for cooldown, parse them in
-\`matchError\` and pass the resulting \`Duration\` as \`retryAfter\` instead of (or
-in addition to, with \`??\` fallback) \`parseRetryAfterForStatus(status, headers)\`.
+\`matchError\` and pass the resulting \`Duration\` as \`retryAfter\` when present, still
+with \`??\` fallback to \`parseRetryAfterForStatus(status, headers)\` when appropriate.
 
 ### Step 2: Identify operations with weak error typing
 Look for operations that only have generic errors (DefaultErrors) and no

--- a/scripts/error-discovery.ts
+++ b/scripts/error-discovery.ts
@@ -112,6 +112,25 @@ Different SDKs use different patch formats:
 5. Read a few test files in ${pkgDir}/tests/ to see how errors are tested
 6. Identify the patch format this SDK uses (OpenAPI JSON Patch, Cloudflare-style, or AWS-style)
 
+### \`matchError\` contract (do not regress)
+The \`matchError\` function in client.ts has this signature:
+\`\`\`ts
+const matchError = (
+  status: number,
+  errorBody: unknown,
+  _errors?: readonly unknown[],
+  headers?: Record<string, string | undefined>,
+): Effect.Effect<never, unknown> => { ... }
+\`\`\`
+When you construct a retryable error (TooManyRequests/429, InternalServerError/500,
+BadGateway/502, ServiceUnavailable/503, GatewayTimeout/504, Locked/423, or any
+class categorized retryable), you MUST pass \`retryAfter: parseServerRetryHint(headers)\`
+so the retry policy honors server-provided wait hints (Retry-After / RateLimit headers).
+Import: \`import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";\`
+If this service uses bespoke headers or body fields for cooldown, parse them in
+\`matchError\` and pass the resulting \`Duration\` as \`retryAfter\` instead of (or
+in addition to, with \`??\` fallback) \`parseServerRetryHint(headers)\`.
+
 ### Step 2: Identify operations with weak error typing
 Look for operations that only have generic errors (DefaultErrors) and no
 operation-specific error types. These are candidates for error discovery.

--- a/scripts/error-discovery.ts
+++ b/scripts/error-discovery.ts
@@ -23,7 +23,14 @@ import { Console, Effect } from "effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import { Argument, Command, Flag } from "effect/unstable/cli";
-import { AgentError, AgentStatsAccumulator, BOLD, GREEN, RESET, runAgent } from "./lib/agent.ts";
+import {
+  AgentError,
+  AgentStatsAccumulator,
+  BOLD,
+  GREEN,
+  RESET,
+  runAgent,
+} from "./lib/agent.ts";
 import { metadataPromptSection } from "./lib/metadata.ts";
 
 // ============================================================================
@@ -37,8 +44,9 @@ function buildPrompt(
 ): string {
   const pkgDir = `packages/${name}`;
 
-  const serviceScope = services.length > 0
-    ? `
+  const serviceScope =
+    services.length > 0
+      ? `
 
 ## SCOPE RESTRICTION
 
@@ -53,7 +61,7 @@ Concretely:
   (e.g. for cloudflare: ${pkgDir}/patches/{${services.join(",")}}/...).
 - Ignore all other services even if you notice gaps in them — they are out of scope.
 `
-    : "";
+      : "";
 
   return `
 You are an error discovery agent for the ${name} SDK in the Distilled monorepo.
@@ -124,12 +132,12 @@ const matchError = (
 \`\`\`
 When you construct a retryable error (TooManyRequests/429, InternalServerError/500,
 BadGateway/502, ServiceUnavailable/503, GatewayTimeout/504, Locked/423, or any
-class categorized retryable), you MUST pass \`retryAfter: parseServerRetryHint(headers)\`
+class categorized retryable), you MUST pass \`retryAfter: parseRetryAfterForStatus(status, headers)\`
 so the retry policy honors server-provided wait hints (Retry-After / RateLimit headers).
-Import: \`import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";\`
+Import: \`import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";\`
 If this service uses bespoke headers or body fields for cooldown, parse them in
 \`matchError\` and pass the resulting \`Duration\` as \`retryAfter\` instead of (or
-in addition to, with \`??\` fallback) \`parseServerRetryHint(headers)\`.
+in addition to, with \`??\` fallback) \`parseRetryAfterForStatus(status, headers)\`.
 
 ### Step 2: Identify operations with weak error typing
 Look for operations that only have generic errors (DefaultErrors) and no
@@ -275,15 +283,18 @@ const errorDiscovery = Command.make(
 
       const stats = new AgentStatsAccumulator();
 
-      yield* runAgent({
-        prompt: buildPrompt(config.name, root, services),
-        cwd: root,
-        systemPromptAppend:
-          "You are an error discovery agent. Your job is to find undocumented API errors " +
-          "and add typed error classes to the SDK. Be methodical and thorough. " +
-          "When looking for files, prefer direct file reads over broad searches. " +
-          "Always start by reading files at the repo root or package root directly.",
-      }, stats);
+      yield* runAgent(
+        {
+          prompt: buildPrompt(config.name, root, services),
+          cwd: root,
+          systemPromptAppend:
+            "You are an error discovery agent. Your job is to find undocumented API errors " +
+            "and add typed error classes to the SDK. Be methodical and thorough. " +
+            "When looking for files, prefer direct file reads over broad searches. " +
+            "Always start by reading files at the repo root or package root directly.",
+        },
+        stats,
+      );
 
       yield* Console.log(
         `\n${GREEN}${BOLD}Error discovery complete for ${config.name}.${RESET}`,
@@ -306,7 +317,8 @@ const errorDiscovery = Command.make(
     {
       command:
         "bun scripts/error-discovery.ts cloudflare --service r2 --service workers",
-      description: "Discover errors only in Cloudflare's R2 and Workers services",
+      description:
+        "Discover errors only in Cloudflare's R2 and Workers services",
     },
     {
       command: "bun scripts/error-discovery.ts stripe",

--- a/scripts/generate-nuke.ts
+++ b/scripts/generate-nuke.ts
@@ -29,7 +29,16 @@ import { Console, Effect } from "effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import { Argument, Command, Flag } from "effect/unstable/cli";
-import { AgentError, AgentStatsAccumulator, BOLD, DIM, GREEN, RESET, YELLOW, runAgent } from "./lib/agent.ts";
+import {
+  AgentError,
+  AgentStatsAccumulator,
+  BOLD,
+  DIM,
+  GREEN,
+  RESET,
+  YELLOW,
+  runAgent,
+} from "./lib/agent.ts";
 import { metadataPromptSection } from "./lib/metadata.ts";
 
 // ============================================================================
@@ -333,9 +342,7 @@ const generateNuke = Command.make(
     ),
     reset: Flag.boolean("reset").pipe(
       Flag.withDefault(false),
-      Flag.withDescription(
-        "Delete existing nuke script and regenerate it",
-      ),
+      Flag.withDescription("Delete existing nuke script and regenerate it"),
     ),
   },
   (config) =>
@@ -343,11 +350,15 @@ const generateNuke = Command.make(
       const path = yield* Path.Path;
       const fs = yield* FileSystem.FileSystem;
       const root = path.resolve(import.meta.dir, "..");
-      const nukeScript = path.join(root, "packages", config.provider, "scripts", "nuke.ts");
-
-      yield* Console.log(
-        `\n${BOLD}Generate Nuke: ${config.provider}${RESET}`,
+      const nukeScript = path.join(
+        root,
+        "packages",
+        config.provider,
+        "scripts",
+        "nuke.ts",
       );
+
+      yield* Console.log(`\n${BOLD}Generate Nuke: ${config.provider}${RESET}`);
 
       // Handle existing script
       const exists = yield* fs.exists(nukeScript);
@@ -363,9 +374,7 @@ const generateNuke = Command.make(
         yield* Console.log(
           `${DIM}Run it with: bun packages/${config.provider}/scripts/nuke.ts --dry-run${RESET}`,
         );
-        yield* Console.log(
-          `${DIM}Use --reset to regenerate${RESET}`,
-        );
+        yield* Console.log(`${DIM}Use --reset to regenerate${RESET}`);
         return;
       }
 
@@ -373,16 +382,19 @@ const generateNuke = Command.make(
 
       const stats = new AgentStatsAccumulator();
 
-      yield* runAgent({
-        prompt: buildPrompt(config.provider, root),
-        cwd: root,
-        systemPromptAppend:
-          "You are generating a nuke script for a cloud provider SDK. " +
-          "Study the SDK's operations, credentials, and test files thoroughly " +
-          "before writing the script. The script must be complete and runnable. " +
-          "When looking for files, prefer direct file reads over broad searches. " +
-          "Always start by reading files at the package root directly.",
-      }, stats);
+      yield* runAgent(
+        {
+          prompt: buildPrompt(config.provider, root),
+          cwd: root,
+          systemPromptAppend:
+            "You are generating a nuke script for a cloud provider SDK. " +
+            "Study the SDK's operations, credentials, and test files thoroughly " +
+            "before writing the script. The script must be complete and runnable. " +
+            "When looking for files, prefer direct file reads over broad searches. " +
+            "Always start by reading files at the package root directly.",
+        },
+        stats,
+      );
 
       // Verify it was created
       const created = yield* fs.exists(nukeScript);
@@ -390,9 +402,7 @@ const generateNuke = Command.make(
         yield* Console.log(
           `\n${GREEN}${BOLD}Nuke script generated at packages/${config.provider}/scripts/nuke.ts${RESET}`,
         );
-        yield* Console.log(
-          `\n${DIM}Usage:${RESET}`,
-        );
+        yield* Console.log(`\n${DIM}Usage:${RESET}`);
         yield* Console.log(
           `  bun packages/${config.provider}/scripts/nuke.ts --dry-run  ${DIM}# List all resources${RESET}`,
         );

--- a/scripts/generate-tests.ts
+++ b/scripts/generate-tests.ts
@@ -409,6 +409,12 @@ This is a BUG in the SDK, not expected behavior. Your job is to FIX it.
      if (status === 401) return new Unauthorized({ ... });
      if (status === 403) return new Forbidden({ ... });
      \`\`\`
+   - **Preserve the \`headers\` parameter** on \`matchError\` and pass
+     \`retryAfter: parseServerRetryHint(headers)\` into any retryable error
+     constructor (TooManyRequests/429, Locked/423, InternalServerError/500,
+     BadGateway/502, ServiceUnavailable/503, GatewayTimeout/504, or any class
+     categorized retryable). Import: \`import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";\`
+     This lets the retry policy honor server-provided wait hints.
 
 4. **OR create a patch** if the error is operation-specific:
    - For OpenAPI SDKs: add a JSON Patch entry to \`patches/*.patch.json\`

--- a/scripts/generate-tests.ts
+++ b/scripts/generate-tests.ts
@@ -24,7 +24,18 @@ import { Console, Effect, Option } from "effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import { Argument, Command, Flag } from "effect/unstable/cli";
-import { AgentError, AgentStatsAccumulator, BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW, runAgent } from "./lib/agent.ts";
+import {
+  AgentError,
+  AgentStatsAccumulator,
+  BOLD,
+  CYAN,
+  DIM,
+  GREEN,
+  RED,
+  RESET,
+  YELLOW,
+  runAgent,
+} from "./lib/agent.ts";
 import {
   ensureMetadataDir,
   metadataPromptSection,
@@ -35,7 +46,12 @@ import {
 // Prompt Construction
 // ============================================================================
 
-function buildPrompt(provider: string, root: string, operation?: string, reset?: boolean): string {
+function buildPrompt(
+  provider: string,
+  root: string,
+  operation?: string,
+  reset?: boolean,
+): string {
   const pkgDir = `packages/${provider}`;
 
   const scopeDescription = operation
@@ -48,9 +64,13 @@ endpoint. Prioritize operations that create, read, update, delete, and list reso
   const scopeWorkflow = operation
     ? `
 ### Step 3: Generate tests for \`${operation}\`
-${reset ? `**RESET MODE**: Find any existing test file that contains tests for \`${operation}\`,
+${
+  reset
+    ? `**RESET MODE**: Find any existing test file that contains tests for \`${operation}\`,
 remove the describe block for \`${operation}\` from it, then regenerate those tests fresh.
-If the file becomes empty (no other describe blocks), delete it entirely.` : ""}
+If the file becomes empty (no other describe blocks), delete it entirely.`
+    : ""
+}
 Find the operation source, read its input/output schemas and error types, then
 generate tests following the rules below.
 
@@ -61,8 +81,12 @@ bun run test -- --run ${operation}
 from ${pkgDir}/. If tests fail, fix and re-run.`
     : `
 ### Step 3: Generate tests for each resource type
-${reset ? `**RESET MODE**: All existing test files (*.test.ts) have been deleted. Regenerate
-tests from scratch for every operation. The setup/helper file has been preserved.` : ""}
+${
+  reset
+    ? `**RESET MODE**: All existing test files (*.test.ts) have been deleted. Regenerate
+tests from scratch for every operation. The setup/helper file has been preserved.`
+    : ""
+}
 
 **For small SDKs (<50 operations):** test every operation.
 **For large SDKs (50+ operations):** identify every distinct resource type
@@ -410,10 +434,10 @@ This is a BUG in the SDK, not expected behavior. Your job is to FIX it.
      if (status === 403) return new Forbidden({ ... });
      \`\`\`
    - **Preserve the \`headers\` parameter** on \`matchError\` and pass
-     \`retryAfter: parseServerRetryHint(headers)\` into any retryable error
+     \`retryAfter: parseRetryAfterForStatus(status, headers)\` into any retryable error
      constructor (TooManyRequests/429, Locked/423, InternalServerError/500,
      BadGateway/502, ServiceUnavailable/503, GatewayTimeout/504, or any class
-     categorized retryable). Import: \`import { parseServerRetryHint } from "@distilled.cloud/core/retry-after";\`
+     categorized retryable). Import: \`import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";\`
      This lets the retry policy honor server-provided wait hints.
 
 4. **OR create a patch** if the error is operation-specific:
@@ -649,13 +673,20 @@ Include EVERY operation. Do not skip any.
 function buildOperationPrompt(
   provider: string,
   root: string,
-  operation: { name: string; file: string; errors: string[]; httpMethod: string; testFile: string },
+  operation: {
+    name: string;
+    file: string;
+    errors: string[];
+    httpMethod: string;
+    testFile: string;
+  },
   reset?: boolean,
 ): string {
   const pkgDir = `packages/${provider}`;
-  const errorsDesc = operation.errors.length > 0
-    ? `Non-generic errors to test: ${operation.errors.join(", ")}`
-    : "No per-operation errors — test client-level errors (e.g. InvalidRequestError for bad IDs)";
+  const errorsDesc =
+    operation.errors.length > 0
+      ? `Non-generic errors to test: ${operation.errors.join(", ")}`
+      : "No per-operation errors — test client-level errors (e.g. InvalidRequestError for bad IDs)";
 
   return `
 Generate tests for the \`${operation.name}\` operation (${operation.httpMethod}) in the ${provider} SDK.
@@ -761,9 +792,7 @@ const generateTests = Command.make(
     ),
     reset: Flag.boolean("reset").pipe(
       Flag.withDefault(false),
-      Flag.withDescription(
-        "Delete existing tests and regenerate them",
-      ),
+      Flag.withDescription("Delete existing tests and regenerate them"),
     ),
   },
   (config) =>
@@ -843,15 +872,16 @@ const generateTests = Command.make(
 
       if (op) {
         // Single operation mode — one agent call
-        yield* Console.log(
-          `${DIM}Generating tests for ${op}...${RESET}\n`,
-        );
+        yield* Console.log(`${DIM}Generating tests for ${op}...${RESET}\n`);
 
-        yield* runAgent({
-          prompt: buildPrompt(config.provider, root, op, config.reset),
-          cwd: root,
-          systemPromptAppend,
-        }, stats);
+        yield* runAgent(
+          {
+            prompt: buildPrompt(config.provider, root, op, config.reset),
+            cwd: root,
+            systemPromptAppend,
+          },
+          stats,
+        );
       } else {
         // All operations mode — two phases:
         // Phase 1: research & populate shared metadata file
@@ -864,22 +894,21 @@ const generateTests = Command.make(
           `${DIM}Phase 1: Researching SDK and building operation manifest...${RESET}\n`,
         );
 
-        const researchResult = yield* runAgent({
-          prompt: buildResearchPrompt(config.provider),
-          cwd: root,
-          systemPromptAppend,
-        }, stats);
+        const researchResult = yield* runAgent(
+          {
+            prompt: buildResearchPrompt(config.provider),
+            cwd: root,
+            systemPromptAppend,
+          },
+          stats,
+        );
 
         const sessionId = researchResult.sessionId;
 
         // Read the metadata file
         const manifestRaw = yield* fs
           .readFileString(path.join(root, manifestPath))
-          .pipe(
-            Effect.catch(() =>
-              Effect.succeed("[]"),
-            ),
-          );
+          .pipe(Effect.catch(() => Effect.succeed("[]")));
 
         let operations: Array<{
           name: string;
@@ -890,16 +919,26 @@ const generateTests = Command.make(
         }>;
         try {
           const parsed = JSON.parse(manifestRaw);
-          operations = Array.isArray(parsed) ? parsed : parsed.operations ?? [];
+          operations = Array.isArray(parsed)
+            ? parsed
+            : (parsed.operations ?? []);
         } catch {
           yield* Console.log(
             `${RED}Failed to parse manifest — falling back to single agent call${RESET}\n`,
           );
-          yield* runAgent({
-            prompt: buildPrompt(config.provider, root, undefined, config.reset),
-            cwd: root,
-            systemPromptAppend,
-          }, stats);
+          yield* runAgent(
+            {
+              prompt: buildPrompt(
+                config.provider,
+                root,
+                undefined,
+                config.reset,
+              ),
+              cwd: root,
+              systemPromptAppend,
+            },
+            stats,
+          );
           yield* Console.log(
             `\n${GREEN}${BOLD}Test generation complete for ${config.provider} / ${scope}.${RESET}`,
           );
@@ -911,7 +950,12 @@ const generateTests = Command.make(
         let skipped = 0;
         const toGenerate: typeof operations = [];
         for (const operation of operations) {
-          const testFilePath = path.join(root, "packages", config.provider, operation.testFile);
+          const testFilePath = path.join(
+            root,
+            "packages",
+            config.provider,
+            operation.testFile,
+          );
           const testExists = yield* fs.exists(testFilePath);
           if (testExists && !config.reset) {
             skipped++;
@@ -923,7 +967,9 @@ const generateTests = Command.make(
         yield* Console.log(
           `\n${BOLD}Found ${operations.length} operations:${RESET} ` +
             `${toGenerate.length} to generate` +
-            (skipped > 0 ? `, ${DIM}${skipped} skipped (test file exists)${RESET}` : ""),
+            (skipped > 0
+              ? `, ${DIM}${skipped} skipped (test file exists)${RESET}`
+              : ""),
         );
 
         // Phase 2: generate tests per operation, resuming the same session
@@ -934,24 +980,35 @@ const generateTests = Command.make(
             `\n${CYAN}[${completed}/${toGenerate.length}]${RESET} ${BOLD}${operation.name}${RESET} ${DIM}→ ${operation.testFile}${RESET}`,
           );
 
-          yield* runAgent({
-            prompt: buildOperationPrompt(config.provider, root, operation, config.reset),
-            cwd: root,
-            resume: sessionId,
-            systemPromptAppend,
-          }, stats);
+          yield* runAgent(
+            {
+              prompt: buildOperationPrompt(
+                config.provider,
+                root,
+                operation,
+                config.reset,
+              ),
+              cwd: root,
+              resume: sessionId,
+              systemPromptAppend,
+            },
+            stats,
+          );
         }
 
         // Phase 3: run the full test suite
         yield* Console.log(
           `\n${DIM}Running full test suite to verify...${RESET}\n`,
         );
-        yield* runAgent({
-          prompt: `Run the full test suite for ${pkgDir}/ with \`bun run test\` from that directory. If any tests fail, fix them and re-run until they pass. Report a summary of total tests, passed, and failed.`,
-          cwd: root,
-          resume: sessionId,
-          systemPromptAppend,
-        }, stats);
+        yield* runAgent(
+          {
+            prompt: `Run the full test suite for ${pkgDir}/ with \`bun run test\` from that directory. If any tests fail, fix them and re-run until they pass. Report a summary of total tests, passed, and failed.`,
+            cwd: root,
+            resume: sessionId,
+            systemPromptAppend,
+          },
+          stats,
+        );
       }
 
       yield* Console.log(
@@ -973,7 +1030,8 @@ const generateTests = Command.make(
       description: "Generate tests for Neon's createProject only",
     },
     {
-      command: "bun scripts/generate-tests.ts cloudflare --operation createBucket",
+      command:
+        "bun scripts/generate-tests.ts cloudflare --operation createBucket",
       description: "Generate tests for Cloudflare's R2 createBucket",
     },
   ]),

--- a/scripts/generate-tests.ts
+++ b/scripts/generate-tests.ts
@@ -433,12 +433,11 @@ This is a BUG in the SDK, not expected behavior. Your job is to FIX it.
      if (status === 401) return new Unauthorized({ ... });
      if (status === 403) return new Forbidden({ ... });
      \`\`\`
-   - **Preserve the \`headers\` parameter** on \`matchError\` and pass
-     \`retryAfter: parseRetryAfterForStatus(status, headers)\` into any retryable error
-     constructor (TooManyRequests/429, Locked/423, InternalServerError/500,
-     BadGateway/502, ServiceUnavailable/503, GatewayTimeout/504, or any class
-     categorized retryable). Import: \`import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";\`
-     This lets the retry policy honor server-provided wait hints.
+   - **Preserve the \`headers\` parameter** on \`matchError\`. For retryable errors,
+     when the response includes a standard \`Retry-After\` / \`RateLimit\` hint, pass
+     \`retryAfter: parseRetryAfterForStatus(status, headers)\`. When there is no hint,
+     omit \`retryAfter\` — the default policy still retries with exponential backoff.
+     Import: \`import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";\`
 
 4. **OR create a patch** if the error is operation-specific:
    - For OpenAPI SDKs: add a JSON Patch entry to \`patches/*.patch.json\`


### PR DESCRIPTION
## Summary

Standardizes how SDKs surface server-provided retry hints. Stacks on top of #225.

- **Core** defines an opaque `retryAfter: Duration.Duration` field on every retryable error (`TooManyRequests`, `Locked`, `InternalServerError`, `BadGateway`, `ServiceUnavailable`, `GatewayTimeout`).
- **Core** ships parsing primitives: `parseRetryAfter` (RFC 7231 §7.1.3 — `delay-seconds` or HTTP-date), `parseRatelimit` (IETF httpapi-ratelimit-headers — `r=0, t=30`), and `parseServerRetryHint` (try one then the other).
- **Each SDK's `matchError`** now accepts an optional `headers` arg and is responsible for deriving a `Duration` from whatever the service actually returns. Cloudflare, GCP, Kubernetes, plus all 15 scaffolded SDKs (turso, planetscale, neon, stripe, axiom, posthog, supabase, coinbase, fly-io, mongodb-atlas, typesense, workos, prisma-postgres, azure, expo-eas) populate `retryAfter` via `parseServerRetryHint(headers)` for the standard cases. The `scripts/create-sdk.ts` template emits the same wiring so newly scaffolded SDKs honor server hints by default.
- **Default retry policy** (`makeDefault`) and the new `throttlingFactory` / `transientFactory` honor `error.retryAfter` with precedence over the exponential backoff, capped at 60s so a misbehaving server can't park us forever.
- **AWS untouched** — uses its own retry stack.
- **Pipeline awareness**: prompts in `scripts/error-discovery.ts` and `scripts/generate-tests.ts` teach sub-agents to preserve the `headers` parameter on `matchError` and pass `retryAfter` into retryable error constructors when patching, so the convention sticks across regeneration.

### Override seam

If a service uses bespoke headers or body fields for cooldown, edit the SDK's `matchError`:

```ts
const retryAfter =
  parseServerRetryHint(headers) ??
  parseFooBespokeHeader(headers["x-foo-cooldown"]) ??
  parseFooBodyField(errorBody);
return Effect.fail(new TooManyRequests({ message, retryAfter }));
```

## Test plan

- [x] `bun run test` in `packages/core` — 29 new unit tests pass (header parsing edge cases + policy honoring `retryAfter`)
- [x] `bunx tsgo --noEmit` clean for cloudflare, kubernetes, turso, planetscale, neon, stripe, axiom, posthog, supabase, coinbase, fly-io, mongodb-atlas, typesense, workos, prisma-postgres, azure, expo-eas
- [x] `bunx oxlint src` clean across all 18 SDKs
- [x] GCP shows pre-existing readonly-array errors only (also present on `main`, out of scope)

Made with [Cursor](https://cursor.com)