### PR TITLE
fix(cloudflare/connectivity): make listDirectoryServices result_info optional

### DIFF
--- a/packages/cloudflare/patches/connectivity/listDirectoryServices.json
+++ b/packages/cloudflare/patches/connectivity/listDirectoryServices.json
@@ -1,0 +1,7 @@
+{
+  "response": {
+    "properties": {
+      "result_info": { "optional": true }
+    }
+  }
+}

--- a/packages/cloudflare/src/services/connectivity.ts
+++ b/packages/cloudflare/src/services/connectivity.ts
@@ -193,12 +193,12 @@ export interface ListDirectoryServicesResponse {
     serviceId?: string | null;
     updatedAt?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDirectoryServicesResponse =
@@ -265,18 +265,25 @@ export const ListDirectoryServicesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),


### PR DESCRIPTION
The Cloudflare list directory-services endpoint returns 200 OK with no `result_info` field on the body, but the upstream Cloudflare TypeScript SDK models `result_info` as required:

```json
{ "result": [{ "service_id": "...", "host": { ... }, ... }], "success": true, "errors": [], "messages": [] }
```

Schema decode therefore fails on every real list response and surfaces as a `CloudflareHttpError` with the raw 200-OK body attached. Add a one-line patch that marks the synthesized `result_info` field optional in the paginated wrapper.

```diff
- resultInfo: { count?: number | null; page?: number | null; perPage?: number | null; totalCount?: number | null; }
+ resultInfo?: { count?: number | null; page?: number | null; perPage?: number | null; totalCount?: number | null; }
```

### Why the host union is fine

The original bug report attributed the failure to the `host` discriminated union (each variant being closed and not accepting the other variants' `null` siblings). That turns out to be a red herring: Effect 4's `Schema.Struct` is open by default and silently strips excess properties — including the sibling `ipv4: null`/`ipv6: null`/`hostname: null`/`network: null`/`resolver_network: null` fields — so the strict union

```ts
host: { ipv4; network } | { ipv6; network } | { ipv4; ipv6; network } | { hostname; resolverNetwork }
```

decodes the real-shape response correctly. Verified locally against the user's exact failing payload.
