### PR TITLE
fix(cloudflare): sort Schema.Union variants by specificity

### DIFF
--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -993,8 +993,21 @@ function typeInfoToSchema(
         }
         return `Schema.Literals([${[...literalSet].join(", ")}])`;
       }
-      // General union - de-duplicate and filter unknowns
-      const unionParts = type.values
+      // General union - de-duplicate and filter unknowns.
+      // Sort object variants by required-property count (descending) so that
+      // more-specific shapes precede less-specific ones. Schema.Union is
+      // first-match-wins on encode; if `{ipv4, network}` is listed before
+      // `{ipv4, ipv6, network}`, dual-stack inputs match the first variant
+      // and `ipv6` is silently stripped on encode. Non-object variants keep
+      // their relative position thanks to stable sort.
+      const requiredPropCount = (v: TypeInfo): number =>
+        v.kind === "object" && v.properties
+          ? v.properties.filter((p) => p.required).length
+          : 0;
+      const sortedValues = [...type.values].sort(
+        (a, b) => requiredPropCount(b) - requiredPropCount(a),
+      );
+      const unionParts = sortedValues
         .filter((v) => v.kind !== "unknown")
         .map((v) =>
           typeInfoToSchema(v, indent, depth + 1, optionalObjectPropsNullable),

--- a/packages/cloudflare/src/services/ai.ts
+++ b/packages/cloudflare/src/services/ai.ts
@@ -99,24 +99,6 @@ export type RunAiResponse =
   | { description?: string | null };
 
 export const RunAiResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
-  Schema.Array(
-    Schema.Struct({
-      label: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      score: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }),
-  ),
-  UploadableSchema.pipe(T.HttpFormDataFile()),
-  Schema.Struct({
-    audio: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }),
-  Schema.Struct({
-    data: Schema.optional(
-      Schema.Union([Schema.Array(Schema.Array(Schema.Number)), Schema.Null]),
-    ),
-    shape: Schema.optional(
-      Schema.Union([Schema.Array(Schema.Number), Schema.Null]),
-    ),
-  }),
   Schema.Struct({
     text: Schema.String,
     vtt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
@@ -139,23 +121,6 @@ export const RunAiResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       vtt: "vtt",
       wordCount: "word_count",
       words: "words",
-    }),
-  ),
-  Schema.Array(
-    Schema.Struct({
-      box: Schema.optional(
-        Schema.Union([
-          Schema.Struct({
-            xmax: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-            xmin: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-            ymax: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-            ymin: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-          }),
-          Schema.Null,
-        ]),
-      ),
-      label: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      score: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
     }),
   ),
   Schema.Struct({
@@ -200,6 +165,41 @@ export const RunAiResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       response: "response",
       toolCalls: "tool_calls",
       usage: "usage",
+    }),
+  ),
+  Schema.Array(
+    Schema.Struct({
+      label: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      score: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    }),
+  ),
+  UploadableSchema.pipe(T.HttpFormDataFile()),
+  Schema.Struct({
+    audio: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }),
+  Schema.Struct({
+    data: Schema.optional(
+      Schema.Union([Schema.Array(Schema.Array(Schema.Number)), Schema.Null]),
+    ),
+    shape: Schema.optional(
+      Schema.Union([Schema.Array(Schema.Number), Schema.Null]),
+    ),
+  }),
+  Schema.Array(
+    Schema.Struct({
+      box: Schema.optional(
+        Schema.Union([
+          Schema.Struct({
+            xmax: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+            xmin: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+            ymax: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+            ymin: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          }),
+          Schema.Null,
+        ]),
+      ),
+      label: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      score: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
     }),
   ),
   Schema.Struct({

--- a/packages/cloudflare/src/services/api-gateway.ts
+++ b/packages/cloudflare/src/services/api-gateway.ts
@@ -701,6 +701,29 @@ export const GetOperationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     Schema.Union([
       Schema.Union([
         Schema.Struct({
+          parameterSchemas: Schema.Struct({
+            lastUpdated: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            parameterSchemas: Schema.optional(
+              Schema.Union([
+                Schema.Struct({
+                  parameters: Schema.optional(
+                    Schema.Union([Schema.Array(Schema.Unknown), Schema.Null]),
+                  ),
+                  responses: Schema.optional(Schema.Null),
+                }),
+                Schema.Null,
+              ]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              lastUpdated: "last_updated",
+              parameterSchemas: "parameter_schemas",
+            }),
+          ),
+        }).pipe(Schema.encodeKeys({ parameterSchemas: "parameter_schemas" })),
+        Schema.Struct({
           thresholds: Schema.optional(
             Schema.Union([
               Schema.Struct({
@@ -748,29 +771,6 @@ export const GetOperationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             ]),
           ),
         }),
-        Schema.Struct({
-          parameterSchemas: Schema.Struct({
-            lastUpdated: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            parameterSchemas: Schema.optional(
-              Schema.Union([
-                Schema.Struct({
-                  parameters: Schema.optional(
-                    Schema.Union([Schema.Array(Schema.Unknown), Schema.Null]),
-                  ),
-                  responses: Schema.optional(Schema.Null),
-                }),
-                Schema.Null,
-              ]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              lastUpdated: "last_updated",
-              parameterSchemas: "parameter_schemas",
-            }),
-          ),
-        }).pipe(Schema.encodeKeys({ parameterSchemas: "parameter_schemas" })),
         Schema.Struct({
           apiRouting: Schema.optional(
             Schema.Union([
@@ -1104,6 +1104,34 @@ export const ListOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
           Schema.Union([
             Schema.Union([
               Schema.Struct({
+                parameterSchemas: Schema.Struct({
+                  lastUpdated: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  parameterSchemas: Schema.optional(
+                    Schema.Union([
+                      Schema.Struct({
+                        parameters: Schema.optional(
+                          Schema.Union([
+                            Schema.Array(Schema.Unknown),
+                            Schema.Null,
+                          ]),
+                        ),
+                        responses: Schema.optional(Schema.Null),
+                      }),
+                      Schema.Null,
+                    ]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    lastUpdated: "last_updated",
+                    parameterSchemas: "parameter_schemas",
+                  }),
+                ),
+              }).pipe(
+                Schema.encodeKeys({ parameterSchemas: "parameter_schemas" }),
+              ),
+              Schema.Struct({
                 thresholds: Schema.optional(
                   Schema.Union([
                     Schema.Struct({
@@ -1151,34 +1179,6 @@ export const ListOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
                   ]),
                 ),
               }),
-              Schema.Struct({
-                parameterSchemas: Schema.Struct({
-                  lastUpdated: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  parameterSchemas: Schema.optional(
-                    Schema.Union([
-                      Schema.Struct({
-                        parameters: Schema.optional(
-                          Schema.Union([
-                            Schema.Array(Schema.Unknown),
-                            Schema.Null,
-                          ]),
-                        ),
-                        responses: Schema.optional(Schema.Null),
-                      }),
-                      Schema.Null,
-                    ]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    lastUpdated: "last_updated",
-                    parameterSchemas: "parameter_schemas",
-                  }),
-                ),
-              }).pipe(
-                Schema.encodeKeys({ parameterSchemas: "parameter_schemas" }),
-              ),
               Schema.Struct({
                 apiRouting: Schema.optional(
                   Schema.Union([
@@ -1545,6 +1545,29 @@ export const CreateOperationResponse =
       Schema.Union([
         Schema.Union([
           Schema.Struct({
+            parameterSchemas: Schema.Struct({
+              lastUpdated: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              parameterSchemas: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    parameters: Schema.optional(
+                      Schema.Union([Schema.Array(Schema.Unknown), Schema.Null]),
+                    ),
+                    responses: Schema.optional(Schema.Null),
+                  }),
+                  Schema.Null,
+                ]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                lastUpdated: "last_updated",
+                parameterSchemas: "parameter_schemas",
+              }),
+            ),
+          }).pipe(Schema.encodeKeys({ parameterSchemas: "parameter_schemas" })),
+          Schema.Struct({
             thresholds: Schema.optional(
               Schema.Union([
                 Schema.Struct({
@@ -1592,29 +1615,6 @@ export const CreateOperationResponse =
               ]),
             ),
           }),
-          Schema.Struct({
-            parameterSchemas: Schema.Struct({
-              lastUpdated: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              parameterSchemas: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    parameters: Schema.optional(
-                      Schema.Union([Schema.Array(Schema.Unknown), Schema.Null]),
-                    ),
-                    responses: Schema.optional(Schema.Null),
-                  }),
-                  Schema.Null,
-                ]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                lastUpdated: "last_updated",
-                parameterSchemas: "parameter_schemas",
-              }),
-            ),
-          }).pipe(Schema.encodeKeys({ parameterSchemas: "parameter_schemas" })),
           Schema.Struct({
             apiRouting: Schema.optional(
               Schema.Union([
@@ -2066,6 +2066,34 @@ export const BulkCreateOperationsResponse =
           Schema.Union([
             Schema.Union([
               Schema.Struct({
+                parameterSchemas: Schema.Struct({
+                  lastUpdated: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  parameterSchemas: Schema.optional(
+                    Schema.Union([
+                      Schema.Struct({
+                        parameters: Schema.optional(
+                          Schema.Union([
+                            Schema.Array(Schema.Unknown),
+                            Schema.Null,
+                          ]),
+                        ),
+                        responses: Schema.optional(Schema.Null),
+                      }),
+                      Schema.Null,
+                    ]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    lastUpdated: "last_updated",
+                    parameterSchemas: "parameter_schemas",
+                  }),
+                ),
+              }).pipe(
+                Schema.encodeKeys({ parameterSchemas: "parameter_schemas" }),
+              ),
+              Schema.Struct({
                 thresholds: Schema.optional(
                   Schema.Union([
                     Schema.Struct({
@@ -2113,34 +2141,6 @@ export const BulkCreateOperationsResponse =
                   ]),
                 ),
               }),
-              Schema.Struct({
-                parameterSchemas: Schema.Struct({
-                  lastUpdated: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  parameterSchemas: Schema.optional(
-                    Schema.Union([
-                      Schema.Struct({
-                        parameters: Schema.optional(
-                          Schema.Union([
-                            Schema.Array(Schema.Unknown),
-                            Schema.Null,
-                          ]),
-                        ),
-                        responses: Schema.optional(Schema.Null),
-                      }),
-                      Schema.Null,
-                    ]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    lastUpdated: "last_updated",
-                    parameterSchemas: "parameter_schemas",
-                  }),
-                ),
-              }).pipe(
-                Schema.encodeKeys({ parameterSchemas: "parameter_schemas" }),
-              ),
               Schema.Struct({
                 apiRouting: Schema.optional(
                   Schema.Union([
@@ -3632,6 +3632,34 @@ export const ListUserSchemaOperationsResponse =
             Schema.Union([
               Schema.Union([
                 Schema.Struct({
+                  parameterSchemas: Schema.Struct({
+                    lastUpdated: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    parameterSchemas: Schema.optional(
+                      Schema.Union([
+                        Schema.Struct({
+                          parameters: Schema.optional(
+                            Schema.Union([
+                              Schema.Array(Schema.Unknown),
+                              Schema.Null,
+                            ]),
+                          ),
+                          responses: Schema.optional(Schema.Null),
+                        }),
+                        Schema.Null,
+                      ]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      lastUpdated: "last_updated",
+                      parameterSchemas: "parameter_schemas",
+                    }),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({ parameterSchemas: "parameter_schemas" }),
+                ),
+                Schema.Struct({
                   thresholds: Schema.optional(
                     Schema.Union([
                       Schema.Struct({
@@ -3679,34 +3707,6 @@ export const ListUserSchemaOperationsResponse =
                     ]),
                   ),
                 }),
-                Schema.Struct({
-                  parameterSchemas: Schema.Struct({
-                    lastUpdated: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    parameterSchemas: Schema.optional(
-                      Schema.Union([
-                        Schema.Struct({
-                          parameters: Schema.optional(
-                            Schema.Union([
-                              Schema.Array(Schema.Unknown),
-                              Schema.Null,
-                            ]),
-                          ),
-                          responses: Schema.optional(Schema.Null),
-                        }),
-                        Schema.Null,
-                      ]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      lastUpdated: "last_updated",
-                      parameterSchemas: "parameter_schemas",
-                    }),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({ parameterSchemas: "parameter_schemas" }),
-                ),
                 Schema.Struct({
                   apiRouting: Schema.optional(
                     Schema.Union([

--- a/packages/cloudflare/src/services/connectivity.ts
+++ b/packages/cloudflare/src/services/connectivity.ts
@@ -81,11 +81,6 @@ export const GetDirectoryServiceResponse =
     host: Schema.Union([
       Schema.Struct({
         ipv4: Schema.String,
-        network: Schema.Struct({
-          tunnelId: Schema.String,
-        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
-      }),
-      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -93,6 +88,11 @@ export const GetDirectoryServiceResponse =
       }),
       Schema.Struct({
         ipv4: Schema.String,
+        network: Schema.Struct({
+          tunnelId: Schema.String,
+        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
+      }),
+      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -212,11 +212,6 @@ export const ListDirectoryServicesResponse =
         host: Schema.Union([
           Schema.Struct({
             ipv4: Schema.String,
-            network: Schema.Struct({
-              tunnelId: Schema.String,
-            }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
-          }),
-          Schema.Struct({
             ipv6: Schema.String,
             network: Schema.Struct({
               tunnelId: Schema.String,
@@ -224,6 +219,11 @@ export const ListDirectoryServicesResponse =
           }),
           Schema.Struct({
             ipv4: Schema.String,
+            network: Schema.Struct({
+              tunnelId: Schema.String,
+            }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
+          }),
+          Schema.Struct({
             ipv6: Schema.String,
             network: Schema.Struct({
               tunnelId: Schema.String,
@@ -341,11 +341,6 @@ export const CreateDirectoryServiceRequest =
     host: Schema.Union([
       Schema.Struct({
         ipv4: Schema.String,
-        network: Schema.Struct({
-          tunnelId: Schema.String,
-        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
-      }),
-      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -353,6 +348,11 @@ export const CreateDirectoryServiceRequest =
       }),
       Schema.Struct({
         ipv4: Schema.String,
+        network: Schema.Struct({
+          tunnelId: Schema.String,
+        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
+      }),
+      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -419,11 +419,6 @@ export const CreateDirectoryServiceResponse =
     host: Schema.Union([
       Schema.Struct({
         ipv4: Schema.String,
-        network: Schema.Struct({
-          tunnelId: Schema.String,
-        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
-      }),
-      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -431,6 +426,11 @@ export const CreateDirectoryServiceResponse =
       }),
       Schema.Struct({
         ipv4: Schema.String,
+        network: Schema.Struct({
+          tunnelId: Schema.String,
+        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
+      }),
+      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -526,11 +526,6 @@ export const UpdateDirectoryServiceRequest =
     host: Schema.Union([
       Schema.Struct({
         ipv4: Schema.String,
-        network: Schema.Struct({
-          tunnelId: Schema.String,
-        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
-      }),
-      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -538,6 +533,11 @@ export const UpdateDirectoryServiceRequest =
       }),
       Schema.Struct({
         ipv4: Schema.String,
+        network: Schema.Struct({
+          tunnelId: Schema.String,
+        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
+      }),
+      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -604,11 +604,6 @@ export const UpdateDirectoryServiceResponse =
     host: Schema.Union([
       Schema.Struct({
         ipv4: Schema.String,
-        network: Schema.Struct({
-          tunnelId: Schema.String,
-        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
-      }),
-      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,
@@ -616,6 +611,11 @@ export const UpdateDirectoryServiceResponse =
       }),
       Schema.Struct({
         ipv4: Schema.String,
+        network: Schema.Struct({
+          tunnelId: Schema.String,
+        }).pipe(Schema.encodeKeys({ tunnelId: "tunnel_id" })),
+      }),
+      Schema.Struct({
         ipv6: Schema.String,
         network: Schema.Struct({
           tunnelId: Schema.String,

--- a/packages/cloudflare/src/services/dns.ts
+++ b/packages/cloudflare/src/services/dns.ts
@@ -1109,6 +1109,54 @@ export const ScanListRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     result: Schema.Array(
       Schema.Union([
         Schema.Struct({
+          id: Schema.String,
+          comment: Schema.String,
+          content: Schema.String,
+          createdOn: Schema.String,
+          meta: Schema.Unknown,
+          modifiedOn: Schema.String,
+          name: Schema.String,
+          proxiable: Schema.Boolean,
+          proxied: Schema.Boolean,
+          settings: Schema.Struct({
+            ipv4Only: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            ipv6Only: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
+          ),
+          tags: Schema.Array(Schema.String),
+          ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+          type: Schema.Literal("OPENPGPKEY"),
+          commentModifiedOn: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          tagsModifiedOn: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            comment: "comment",
+            content: "content",
+            createdOn: "created_on",
+            meta: "meta",
+            modifiedOn: "modified_on",
+            name: "name",
+            proxiable: "proxiable",
+            proxied: "proxied",
+            settings: "settings",
+            tags: "tags",
+            ttl: "ttl",
+            type: "type",
+            commentModifiedOn: "comment_modified_on",
+            tagsModifiedOn: "tags_modified_on",
+          }),
+        ),
+        Schema.Struct({
           name: Schema.String,
           ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
           type: Schema.Literal("A"),
@@ -1400,54 +1448,6 @@ export const ScanListRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
             meta: "meta",
             modifiedOn: "modified_on",
             proxiable: "proxiable",
-            commentModifiedOn: "comment_modified_on",
-            tagsModifiedOn: "tags_modified_on",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          comment: Schema.String,
-          content: Schema.String,
-          createdOn: Schema.String,
-          meta: Schema.Unknown,
-          modifiedOn: Schema.String,
-          name: Schema.String,
-          proxiable: Schema.Boolean,
-          proxied: Schema.Boolean,
-          settings: Schema.Struct({
-            ipv4Only: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            ipv6Only: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
-          ),
-          tags: Schema.Array(Schema.String),
-          ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-          type: Schema.Literal("OPENPGPKEY"),
-          commentModifiedOn: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          tagsModifiedOn: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            comment: "comment",
-            content: "content",
-            createdOn: "created_on",
-            meta: "meta",
-            modifiedOn: "modified_on",
-            name: "name",
-            proxiable: "proxiable",
-            proxied: "proxied",
-            settings: "settings",
-            tags: "tags",
-            ttl: "ttl",
-            type: "type",
             commentModifiedOn: "comment_modified_on",
             tagsModifiedOn: "tags_modified_on",
           }),
@@ -3230,6 +3230,48 @@ export type GetRecordResponse =
 
 export const GetRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
   Schema.Struct({
+    id: Schema.String,
+    comment: Schema.String,
+    content: Schema.String,
+    createdOn: Schema.String,
+    meta: Schema.Unknown,
+    modifiedOn: Schema.String,
+    name: Schema.String,
+    proxiable: Schema.Boolean,
+    proxied: Schema.Boolean,
+    settings: Schema.Struct({
+      ipv4Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+      ipv6Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    }).pipe(
+      Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
+    ),
+    tags: Schema.Array(Schema.String),
+    ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+    type: Schema.Literal("OPENPGPKEY"),
+    commentModifiedOn: Schema.optional(
+      Schema.Union([Schema.String, Schema.Null]),
+    ),
+    tagsModifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      comment: "comment",
+      content: "content",
+      createdOn: "created_on",
+      meta: "meta",
+      modifiedOn: "modified_on",
+      name: "name",
+      proxiable: "proxiable",
+      proxied: "proxied",
+      settings: "settings",
+      tags: "tags",
+      ttl: "ttl",
+      type: "type",
+      commentModifiedOn: "comment_modified_on",
+      tagsModifiedOn: "tags_modified_on",
+    }),
+  ),
+  Schema.Struct({
     name: Schema.String,
     ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
     type: Schema.Literal("A"),
@@ -3499,48 +3541,6 @@ export const GetRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       meta: "meta",
       modifiedOn: "modified_on",
       proxiable: "proxiable",
-      commentModifiedOn: "comment_modified_on",
-      tagsModifiedOn: "tags_modified_on",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    comment: Schema.String,
-    content: Schema.String,
-    createdOn: Schema.String,
-    meta: Schema.Unknown,
-    modifiedOn: Schema.String,
-    name: Schema.String,
-    proxiable: Schema.Boolean,
-    proxied: Schema.Boolean,
-    settings: Schema.Struct({
-      ipv4Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-      ipv6Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
-    ),
-    tags: Schema.Array(Schema.String),
-    ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-    type: Schema.Literal("OPENPGPKEY"),
-    commentModifiedOn: Schema.optional(
-      Schema.Union([Schema.String, Schema.Null]),
-    ),
-    tagsModifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      comment: "comment",
-      content: "content",
-      createdOn: "created_on",
-      meta: "meta",
-      modifiedOn: "modified_on",
-      name: "name",
-      proxiable: "proxiable",
-      proxied: "proxied",
-      settings: "settings",
-      tags: "tags",
-      ttl: "ttl",
-      type: "type",
       commentModifiedOn: "comment_modified_on",
       tagsModifiedOn: "tags_modified_on",
     }),
@@ -5288,6 +5288,54 @@ export const ListRecordsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   result: Schema.Array(
     Schema.Union([
       Schema.Struct({
+        id: Schema.String,
+        comment: Schema.String,
+        content: Schema.String,
+        createdOn: Schema.String,
+        meta: Schema.Unknown,
+        modifiedOn: Schema.String,
+        name: Schema.String,
+        proxiable: Schema.Boolean,
+        proxied: Schema.Boolean,
+        settings: Schema.Struct({
+          ipv4Only: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
+          ipv6Only: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
+        ),
+        tags: Schema.Array(Schema.String),
+        ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+        type: Schema.Literal("OPENPGPKEY"),
+        commentModifiedOn: Schema.optional(
+          Schema.Union([Schema.String, Schema.Null]),
+        ),
+        tagsModifiedOn: Schema.optional(
+          Schema.Union([Schema.String, Schema.Null]),
+        ),
+      }).pipe(
+        Schema.encodeKeys({
+          id: "id",
+          comment: "comment",
+          content: "content",
+          createdOn: "created_on",
+          meta: "meta",
+          modifiedOn: "modified_on",
+          name: "name",
+          proxiable: "proxiable",
+          proxied: "proxied",
+          settings: "settings",
+          tags: "tags",
+          ttl: "ttl",
+          type: "type",
+          commentModifiedOn: "comment_modified_on",
+          tagsModifiedOn: "tags_modified_on",
+        }),
+      ),
+      Schema.Struct({
         name: Schema.String,
         ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
         type: Schema.Literal("A"),
@@ -5579,54 +5627,6 @@ export const ListRecordsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           meta: "meta",
           modifiedOn: "modified_on",
           proxiable: "proxiable",
-          commentModifiedOn: "comment_modified_on",
-          tagsModifiedOn: "tags_modified_on",
-        }),
-      ),
-      Schema.Struct({
-        id: Schema.String,
-        comment: Schema.String,
-        content: Schema.String,
-        createdOn: Schema.String,
-        meta: Schema.Unknown,
-        modifiedOn: Schema.String,
-        name: Schema.String,
-        proxiable: Schema.Boolean,
-        proxied: Schema.Boolean,
-        settings: Schema.Struct({
-          ipv4Only: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
-          ipv6Only: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
-        ),
-        tags: Schema.Array(Schema.String),
-        ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-        type: Schema.Literal("OPENPGPKEY"),
-        commentModifiedOn: Schema.optional(
-          Schema.Union([Schema.String, Schema.Null]),
-        ),
-        tagsModifiedOn: Schema.optional(
-          Schema.Union([Schema.String, Schema.Null]),
-        ),
-      }).pipe(
-        Schema.encodeKeys({
-          id: "id",
-          comment: "comment",
-          content: "content",
-          createdOn: "created_on",
-          meta: "meta",
-          modifiedOn: "modified_on",
-          name: "name",
-          proxiable: "proxiable",
-          proxied: "proxied",
-          settings: "settings",
-          tags: "tags",
-          ttl: "ttl",
-          type: "type",
           commentModifiedOn: "comment_modified_on",
           tagsModifiedOn: "tags_modified_on",
         }),
@@ -7399,6 +7399,48 @@ export type CreateRecordResponse =
 
 export const CreateRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
   Schema.Struct({
+    id: Schema.String,
+    comment: Schema.String,
+    content: Schema.String,
+    createdOn: Schema.String,
+    meta: Schema.Unknown,
+    modifiedOn: Schema.String,
+    name: Schema.String,
+    proxiable: Schema.Boolean,
+    proxied: Schema.Boolean,
+    settings: Schema.Struct({
+      ipv4Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+      ipv6Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    }).pipe(
+      Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
+    ),
+    tags: Schema.Array(Schema.String),
+    ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+    type: Schema.Literal("OPENPGPKEY"),
+    commentModifiedOn: Schema.optional(
+      Schema.Union([Schema.String, Schema.Null]),
+    ),
+    tagsModifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      comment: "comment",
+      content: "content",
+      createdOn: "created_on",
+      meta: "meta",
+      modifiedOn: "modified_on",
+      name: "name",
+      proxiable: "proxiable",
+      proxied: "proxied",
+      settings: "settings",
+      tags: "tags",
+      ttl: "ttl",
+      type: "type",
+      commentModifiedOn: "comment_modified_on",
+      tagsModifiedOn: "tags_modified_on",
+    }),
+  ),
+  Schema.Struct({
     name: Schema.String,
     ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
     type: Schema.Literal("A"),
@@ -7668,48 +7710,6 @@ export const CreateRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       meta: "meta",
       modifiedOn: "modified_on",
       proxiable: "proxiable",
-      commentModifiedOn: "comment_modified_on",
-      tagsModifiedOn: "tags_modified_on",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    comment: Schema.String,
-    content: Schema.String,
-    createdOn: Schema.String,
-    meta: Schema.Unknown,
-    modifiedOn: Schema.String,
-    name: Schema.String,
-    proxiable: Schema.Boolean,
-    proxied: Schema.Boolean,
-    settings: Schema.Struct({
-      ipv4Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-      ipv6Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
-    ),
-    tags: Schema.Array(Schema.String),
-    ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-    type: Schema.Literal("OPENPGPKEY"),
-    commentModifiedOn: Schema.optional(
-      Schema.Union([Schema.String, Schema.Null]),
-    ),
-    tagsModifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      comment: "comment",
-      content: "content",
-      createdOn: "created_on",
-      meta: "meta",
-      modifiedOn: "modified_on",
-      name: "name",
-      proxiable: "proxiable",
-      proxied: "proxied",
-      settings: "settings",
-      tags: "tags",
-      ttl: "ttl",
-      type: "type",
       commentModifiedOn: "comment_modified_on",
       tagsModifiedOn: "tags_modified_on",
     }),
@@ -9333,6 +9333,48 @@ export type UpdateRecordResponse =
 
 export const UpdateRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
   Schema.Struct({
+    id: Schema.String,
+    comment: Schema.String,
+    content: Schema.String,
+    createdOn: Schema.String,
+    meta: Schema.Unknown,
+    modifiedOn: Schema.String,
+    name: Schema.String,
+    proxiable: Schema.Boolean,
+    proxied: Schema.Boolean,
+    settings: Schema.Struct({
+      ipv4Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+      ipv6Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    }).pipe(
+      Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
+    ),
+    tags: Schema.Array(Schema.String),
+    ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+    type: Schema.Literal("OPENPGPKEY"),
+    commentModifiedOn: Schema.optional(
+      Schema.Union([Schema.String, Schema.Null]),
+    ),
+    tagsModifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      comment: "comment",
+      content: "content",
+      createdOn: "created_on",
+      meta: "meta",
+      modifiedOn: "modified_on",
+      name: "name",
+      proxiable: "proxiable",
+      proxied: "proxied",
+      settings: "settings",
+      tags: "tags",
+      ttl: "ttl",
+      type: "type",
+      commentModifiedOn: "comment_modified_on",
+      tagsModifiedOn: "tags_modified_on",
+    }),
+  ),
+  Schema.Struct({
     name: Schema.String,
     ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
     type: Schema.Literal("A"),
@@ -9602,48 +9644,6 @@ export const UpdateRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       meta: "meta",
       modifiedOn: "modified_on",
       proxiable: "proxiable",
-      commentModifiedOn: "comment_modified_on",
-      tagsModifiedOn: "tags_modified_on",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    comment: Schema.String,
-    content: Schema.String,
-    createdOn: Schema.String,
-    meta: Schema.Unknown,
-    modifiedOn: Schema.String,
-    name: Schema.String,
-    proxiable: Schema.Boolean,
-    proxied: Schema.Boolean,
-    settings: Schema.Struct({
-      ipv4Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-      ipv6Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
-    ),
-    tags: Schema.Array(Schema.String),
-    ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-    type: Schema.Literal("OPENPGPKEY"),
-    commentModifiedOn: Schema.optional(
-      Schema.Union([Schema.String, Schema.Null]),
-    ),
-    tagsModifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      comment: "comment",
-      content: "content",
-      createdOn: "created_on",
-      meta: "meta",
-      modifiedOn: "modified_on",
-      name: "name",
-      proxiable: "proxiable",
-      proxied: "proxied",
-      settings: "settings",
-      tags: "tags",
-      ttl: "ttl",
-      type: "type",
       commentModifiedOn: "comment_modified_on",
       tagsModifiedOn: "tags_modified_on",
     }),
@@ -11270,6 +11270,48 @@ export type PatchRecordResponse =
 
 export const PatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
   Schema.Struct({
+    id: Schema.String,
+    comment: Schema.String,
+    content: Schema.String,
+    createdOn: Schema.String,
+    meta: Schema.Unknown,
+    modifiedOn: Schema.String,
+    name: Schema.String,
+    proxiable: Schema.Boolean,
+    proxied: Schema.Boolean,
+    settings: Schema.Struct({
+      ipv4Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+      ipv6Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    }).pipe(
+      Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
+    ),
+    tags: Schema.Array(Schema.String),
+    ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+    type: Schema.Literal("OPENPGPKEY"),
+    commentModifiedOn: Schema.optional(
+      Schema.Union([Schema.String, Schema.Null]),
+    ),
+    tagsModifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      comment: "comment",
+      content: "content",
+      createdOn: "created_on",
+      meta: "meta",
+      modifiedOn: "modified_on",
+      name: "name",
+      proxiable: "proxiable",
+      proxied: "proxied",
+      settings: "settings",
+      tags: "tags",
+      ttl: "ttl",
+      type: "type",
+      commentModifiedOn: "comment_modified_on",
+      tagsModifiedOn: "tags_modified_on",
+    }),
+  ),
+  Schema.Struct({
     name: Schema.String,
     ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
     type: Schema.Literal("A"),
@@ -11539,48 +11581,6 @@ export const PatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       meta: "meta",
       modifiedOn: "modified_on",
       proxiable: "proxiable",
-      commentModifiedOn: "comment_modified_on",
-      tagsModifiedOn: "tags_modified_on",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    comment: Schema.String,
-    content: Schema.String,
-    createdOn: Schema.String,
-    meta: Schema.Unknown,
-    modifiedOn: Schema.String,
-    name: Schema.String,
-    proxiable: Schema.Boolean,
-    proxied: Schema.Boolean,
-    settings: Schema.Struct({
-      ipv4Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-      ipv6Only: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({ ipv4Only: "ipv4_only", ipv6Only: "ipv6_only" }),
-    ),
-    tags: Schema.Array(Schema.String),
-    ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-    type: Schema.Literal("OPENPGPKEY"),
-    commentModifiedOn: Schema.optional(
-      Schema.Union([Schema.String, Schema.Null]),
-    ),
-    tagsModifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      comment: "comment",
-      content: "content",
-      createdOn: "created_on",
-      meta: "meta",
-      modifiedOn: "modified_on",
-      name: "name",
-      proxiable: "proxiable",
-      proxied: "proxied",
-      settings: "settings",
-      tags: "tags",
-      ttl: "ttl",
-      type: "type",
       commentModifiedOn: "comment_modified_on",
       tagsModifiedOn: "tags_modified_on",
     }),
@@ -17354,6 +17354,57 @@ export const BatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       Schema.Array(
         Schema.Union([
           Schema.Struct({
+            id: Schema.String,
+            comment: Schema.String,
+            content: Schema.String,
+            createdOn: Schema.String,
+            meta: Schema.Unknown,
+            modifiedOn: Schema.String,
+            name: Schema.String,
+            proxiable: Schema.Boolean,
+            proxied: Schema.Boolean,
+            settings: Schema.Struct({
+              ipv4Only: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+              ipv6Only: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                ipv4Only: "ipv4_only",
+                ipv6Only: "ipv6_only",
+              }),
+            ),
+            tags: Schema.Array(Schema.String),
+            ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+            type: Schema.Literal("OPENPGPKEY"),
+            commentModifiedOn: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            tagsModifiedOn: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              comment: "comment",
+              content: "content",
+              createdOn: "created_on",
+              meta: "meta",
+              modifiedOn: "modified_on",
+              name: "name",
+              proxiable: "proxiable",
+              proxied: "proxied",
+              settings: "settings",
+              tags: "tags",
+              ttl: "ttl",
+              type: "type",
+              commentModifiedOn: "comment_modified_on",
+              tagsModifiedOn: "tags_modified_on",
+            }),
+          ),
+          Schema.Struct({
             name: Schema.String,
             ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
             type: Schema.Literal("A"),
@@ -17677,57 +17728,6 @@ export const BatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
               meta: "meta",
               modifiedOn: "modified_on",
               proxiable: "proxiable",
-              commentModifiedOn: "comment_modified_on",
-              tagsModifiedOn: "tags_modified_on",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            comment: Schema.String,
-            content: Schema.String,
-            createdOn: Schema.String,
-            meta: Schema.Unknown,
-            modifiedOn: Schema.String,
-            name: Schema.String,
-            proxiable: Schema.Boolean,
-            proxied: Schema.Boolean,
-            settings: Schema.Struct({
-              ipv4Only: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-              ipv6Only: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                ipv4Only: "ipv4_only",
-                ipv6Only: "ipv6_only",
-              }),
-            ),
-            tags: Schema.Array(Schema.String),
-            ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-            type: Schema.Literal("OPENPGPKEY"),
-            commentModifiedOn: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            tagsModifiedOn: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              comment: "comment",
-              content: "content",
-              createdOn: "created_on",
-              meta: "meta",
-              modifiedOn: "modified_on",
-              name: "name",
-              proxiable: "proxiable",
-              proxied: "proxied",
-              settings: "settings",
-              tags: "tags",
-              ttl: "ttl",
-              type: "type",
               commentModifiedOn: "comment_modified_on",
               tagsModifiedOn: "tags_modified_on",
             }),
@@ -19028,6 +19028,57 @@ export const BatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       Schema.Array(
         Schema.Union([
           Schema.Struct({
+            id: Schema.String,
+            comment: Schema.String,
+            content: Schema.String,
+            createdOn: Schema.String,
+            meta: Schema.Unknown,
+            modifiedOn: Schema.String,
+            name: Schema.String,
+            proxiable: Schema.Boolean,
+            proxied: Schema.Boolean,
+            settings: Schema.Struct({
+              ipv4Only: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+              ipv6Only: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                ipv4Only: "ipv4_only",
+                ipv6Only: "ipv6_only",
+              }),
+            ),
+            tags: Schema.Array(Schema.String),
+            ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+            type: Schema.Literal("OPENPGPKEY"),
+            commentModifiedOn: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            tagsModifiedOn: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              comment: "comment",
+              content: "content",
+              createdOn: "created_on",
+              meta: "meta",
+              modifiedOn: "modified_on",
+              name: "name",
+              proxiable: "proxiable",
+              proxied: "proxied",
+              settings: "settings",
+              tags: "tags",
+              ttl: "ttl",
+              type: "type",
+              commentModifiedOn: "comment_modified_on",
+              tagsModifiedOn: "tags_modified_on",
+            }),
+          ),
+          Schema.Struct({
             name: Schema.String,
             ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
             type: Schema.Literal("A"),
@@ -19351,57 +19402,6 @@ export const BatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
               meta: "meta",
               modifiedOn: "modified_on",
               proxiable: "proxiable",
-              commentModifiedOn: "comment_modified_on",
-              tagsModifiedOn: "tags_modified_on",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            comment: Schema.String,
-            content: Schema.String,
-            createdOn: Schema.String,
-            meta: Schema.Unknown,
-            modifiedOn: Schema.String,
-            name: Schema.String,
-            proxiable: Schema.Boolean,
-            proxied: Schema.Boolean,
-            settings: Schema.Struct({
-              ipv4Only: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-              ipv6Only: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                ipv4Only: "ipv4_only",
-                ipv6Only: "ipv6_only",
-              }),
-            ),
-            tags: Schema.Array(Schema.String),
-            ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-            type: Schema.Literal("OPENPGPKEY"),
-            commentModifiedOn: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            tagsModifiedOn: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              comment: "comment",
-              content: "content",
-              createdOn: "created_on",
-              meta: "meta",
-              modifiedOn: "modified_on",
-              name: "name",
-              proxiable: "proxiable",
-              proxied: "proxied",
-              settings: "settings",
-              tags: "tags",
-              ttl: "ttl",
-              type: "type",
               commentModifiedOn: "comment_modified_on",
               tagsModifiedOn: "tags_modified_on",
             }),
@@ -20702,6 +20702,57 @@ export const BatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       Schema.Array(
         Schema.Union([
           Schema.Struct({
+            id: Schema.String,
+            comment: Schema.String,
+            content: Schema.String,
+            createdOn: Schema.String,
+            meta: Schema.Unknown,
+            modifiedOn: Schema.String,
+            name: Schema.String,
+            proxiable: Schema.Boolean,
+            proxied: Schema.Boolean,
+            settings: Schema.Struct({
+              ipv4Only: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+              ipv6Only: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                ipv4Only: "ipv4_only",
+                ipv6Only: "ipv6_only",
+              }),
+            ),
+            tags: Schema.Array(Schema.String),
+            ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+            type: Schema.Literal("OPENPGPKEY"),
+            commentModifiedOn: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            tagsModifiedOn: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              comment: "comment",
+              content: "content",
+              createdOn: "created_on",
+              meta: "meta",
+              modifiedOn: "modified_on",
+              name: "name",
+              proxiable: "proxiable",
+              proxied: "proxied",
+              settings: "settings",
+              tags: "tags",
+              ttl: "ttl",
+              type: "type",
+              commentModifiedOn: "comment_modified_on",
+              tagsModifiedOn: "tags_modified_on",
+            }),
+          ),
+          Schema.Struct({
             name: Schema.String,
             ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
             type: Schema.Literal("A"),
@@ -21025,57 +21076,6 @@ export const BatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
               meta: "meta",
               modifiedOn: "modified_on",
               proxiable: "proxiable",
-              commentModifiedOn: "comment_modified_on",
-              tagsModifiedOn: "tags_modified_on",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            comment: Schema.String,
-            content: Schema.String,
-            createdOn: Schema.String,
-            meta: Schema.Unknown,
-            modifiedOn: Schema.String,
-            name: Schema.String,
-            proxiable: Schema.Boolean,
-            proxied: Schema.Boolean,
-            settings: Schema.Struct({
-              ipv4Only: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-              ipv6Only: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                ipv4Only: "ipv4_only",
-                ipv6Only: "ipv6_only",
-              }),
-            ),
-            tags: Schema.Array(Schema.String),
-            ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-            type: Schema.Literal("OPENPGPKEY"),
-            commentModifiedOn: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            tagsModifiedOn: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              comment: "comment",
-              content: "content",
-              createdOn: "created_on",
-              meta: "meta",
-              modifiedOn: "modified_on",
-              name: "name",
-              proxiable: "proxiable",
-              proxied: "proxied",
-              settings: "settings",
-              tags: "tags",
-              ttl: "ttl",
-              type: "type",
               commentModifiedOn: "comment_modified_on",
               tagsModifiedOn: "tags_modified_on",
             }),
@@ -22376,6 +22376,57 @@ export const BatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       Schema.Array(
         Schema.Union([
           Schema.Struct({
+            id: Schema.String,
+            comment: Schema.String,
+            content: Schema.String,
+            createdOn: Schema.String,
+            meta: Schema.Unknown,
+            modifiedOn: Schema.String,
+            name: Schema.String,
+            proxiable: Schema.Boolean,
+            proxied: Schema.Boolean,
+            settings: Schema.Struct({
+              ipv4Only: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+              ipv6Only: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                ipv4Only: "ipv4_only",
+                ipv6Only: "ipv6_only",
+              }),
+            ),
+            tags: Schema.Array(Schema.String),
+            ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+            type: Schema.Literal("OPENPGPKEY"),
+            commentModifiedOn: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            tagsModifiedOn: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              comment: "comment",
+              content: "content",
+              createdOn: "created_on",
+              meta: "meta",
+              modifiedOn: "modified_on",
+              name: "name",
+              proxiable: "proxiable",
+              proxied: "proxied",
+              settings: "settings",
+              tags: "tags",
+              ttl: "ttl",
+              type: "type",
+              commentModifiedOn: "comment_modified_on",
+              tagsModifiedOn: "tags_modified_on",
+            }),
+          ),
+          Schema.Struct({
             name: Schema.String,
             ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
             type: Schema.Literal("A"),
@@ -22699,57 +22750,6 @@ export const BatchRecordResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
               meta: "meta",
               modifiedOn: "modified_on",
               proxiable: "proxiable",
-              commentModifiedOn: "comment_modified_on",
-              tagsModifiedOn: "tags_modified_on",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            comment: Schema.String,
-            content: Schema.String,
-            createdOn: Schema.String,
-            meta: Schema.Unknown,
-            modifiedOn: Schema.String,
-            name: Schema.String,
-            proxiable: Schema.Boolean,
-            proxied: Schema.Boolean,
-            settings: Schema.Struct({
-              ipv4Only: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-              ipv6Only: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                ipv4Only: "ipv4_only",
-                ipv6Only: "ipv6_only",
-              }),
-            ),
-            tags: Schema.Array(Schema.String),
-            ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-            type: Schema.Literal("OPENPGPKEY"),
-            commentModifiedOn: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            tagsModifiedOn: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              comment: "comment",
-              content: "content",
-              createdOn: "created_on",
-              meta: "meta",
-              modifiedOn: "modified_on",
-              name: "name",
-              proxiable: "proxiable",
-              proxied: "proxied",
-              settings: "settings",
-              tags: "tags",
-              ttl: "ttl",
-              type: "type",
               commentModifiedOn: "comment_modified_on",
               tagsModifiedOn: "tags_modified_on",
             }),
@@ -25584,6 +25584,57 @@ export const ScanReviewRecordResponse =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              id: Schema.String,
+              comment: Schema.String,
+              content: Schema.String,
+              createdOn: Schema.String,
+              meta: Schema.Unknown,
+              modifiedOn: Schema.String,
+              name: Schema.String,
+              proxiable: Schema.Boolean,
+              proxied: Schema.Boolean,
+              settings: Schema.Struct({
+                ipv4Only: Schema.optional(
+                  Schema.Union([Schema.Boolean, Schema.Null]),
+                ),
+                ipv6Only: Schema.optional(
+                  Schema.Union([Schema.Boolean, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  ipv4Only: "ipv4_only",
+                  ipv6Only: "ipv6_only",
+                }),
+              ),
+              tags: Schema.Array(Schema.String),
+              ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
+              type: Schema.Literal("OPENPGPKEY"),
+              commentModifiedOn: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              tagsModifiedOn: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                id: "id",
+                comment: "comment",
+                content: "content",
+                createdOn: "created_on",
+                meta: "meta",
+                modifiedOn: "modified_on",
+                name: "name",
+                proxiable: "proxiable",
+                proxied: "proxied",
+                settings: "settings",
+                tags: "tags",
+                ttl: "ttl",
+                type: "type",
+                commentModifiedOn: "comment_modified_on",
+                tagsModifiedOn: "tags_modified_on",
+              }),
+            ),
+            Schema.Struct({
               name: Schema.String,
               ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
               type: Schema.Literal("A"),
@@ -25907,57 +25958,6 @@ export const ScanReviewRecordResponse =
                 meta: "meta",
                 modifiedOn: "modified_on",
                 proxiable: "proxiable",
-                commentModifiedOn: "comment_modified_on",
-                tagsModifiedOn: "tags_modified_on",
-              }),
-            ),
-            Schema.Struct({
-              id: Schema.String,
-              comment: Schema.String,
-              content: Schema.String,
-              createdOn: Schema.String,
-              meta: Schema.Unknown,
-              modifiedOn: Schema.String,
-              name: Schema.String,
-              proxiable: Schema.Boolean,
-              proxied: Schema.Boolean,
-              settings: Schema.Struct({
-                ipv4Only: Schema.optional(
-                  Schema.Union([Schema.Boolean, Schema.Null]),
-                ),
-                ipv6Only: Schema.optional(
-                  Schema.Union([Schema.Boolean, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  ipv4Only: "ipv4_only",
-                  ipv6Only: "ipv6_only",
-                }),
-              ),
-              tags: Schema.Array(Schema.String),
-              ttl: Schema.Union([Schema.Number, Schema.Literal("1")]),
-              type: Schema.Literal("OPENPGPKEY"),
-              commentModifiedOn: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              tagsModifiedOn: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                comment: "comment",
-                content: "content",
-                createdOn: "created_on",
-                meta: "meta",
-                modifiedOn: "modified_on",
-                name: "name",
-                proxiable: "proxiable",
-                proxied: "proxied",
-                settings: "settings",
-                tags: "tags",
-                ttl: "ttl",
-                type: "type",
                 commentModifiedOn: "comment_modified_on",
                 tagsModifiedOn: "tags_modified_on",
               }),

--- a/packages/cloudflare/src/services/firewall.ts
+++ b/packages/cloudflare/src/services/firewall.ts
@@ -1365,6 +1365,10 @@ export const BulkPutRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         Schema.Union([
           Schema.Union([
             Schema.Struct({
+              id: Schema.String,
+              deleted: Schema.Boolean,
+            }),
+            Schema.Struct({
               id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
               description: Schema.optional(
                 Schema.Union([Schema.String, Schema.Null]),
@@ -1376,10 +1380,6 @@ export const BulkPutRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                 Schema.Union([Schema.Boolean, Schema.Null]),
               ),
               ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            }),
-            Schema.Struct({
-              id: Schema.String,
-              deleted: Schema.Boolean,
             }),
           ]),
           Schema.Null,
@@ -1507,6 +1507,10 @@ export const GetRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     Schema.Union([
       Schema.Union([
         Schema.Struct({
+          id: Schema.String,
+          deleted: Schema.Boolean,
+        }),
+        Schema.Struct({
           id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
           description: Schema.optional(
             Schema.Union([Schema.String, Schema.Null]),
@@ -1516,10 +1520,6 @@ export const GetRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           ),
           paused: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
           ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Struct({
-          id: Schema.String,
-          deleted: Schema.Boolean,
         }),
       ]),
       Schema.Null,
@@ -1655,6 +1655,10 @@ export const ListRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         Schema.Union([
           Schema.Union([
             Schema.Struct({
+              id: Schema.String,
+              deleted: Schema.Boolean,
+            }),
+            Schema.Struct({
               id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
               description: Schema.optional(
                 Schema.Union([Schema.String, Schema.Null]),
@@ -1666,10 +1670,6 @@ export const ListRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                 Schema.Union([Schema.Boolean, Schema.Null]),
               ),
               ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            }),
-            Schema.Struct({
-              id: Schema.String,
-              deleted: Schema.Boolean,
             }),
           ]),
           Schema.Null,
@@ -1849,6 +1849,10 @@ export const CreateRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         Schema.Union([
           Schema.Union([
             Schema.Struct({
+              id: Schema.String,
+              deleted: Schema.Boolean,
+            }),
+            Schema.Struct({
               id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
               description: Schema.optional(
                 Schema.Union([Schema.String, Schema.Null]),
@@ -1860,10 +1864,6 @@ export const CreateRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                 Schema.Union([Schema.Boolean, Schema.Null]),
               ),
               ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            }),
-            Schema.Struct({
-              id: Schema.String,
-              deleted: Schema.Boolean,
             }),
           ]),
           Schema.Null,
@@ -2029,6 +2029,10 @@ export const UpdateRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     Schema.Union([
       Schema.Union([
         Schema.Struct({
+          id: Schema.String,
+          deleted: Schema.Boolean,
+        }),
+        Schema.Struct({
           id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
           description: Schema.optional(
             Schema.Union([Schema.String, Schema.Null]),
@@ -2038,10 +2042,6 @@ export const UpdateRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           ),
           paused: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
           ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Struct({
-          id: Schema.String,
-          deleted: Schema.Boolean,
         }),
       ]),
       Schema.Null,
@@ -2159,6 +2159,10 @@ export const PatchRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         Schema.Union([
           Schema.Union([
             Schema.Struct({
+              id: Schema.String,
+              deleted: Schema.Boolean,
+            }),
+            Schema.Struct({
               id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
               description: Schema.optional(
                 Schema.Union([Schema.String, Schema.Null]),
@@ -2170,10 +2174,6 @@ export const PatchRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                 Schema.Union([Schema.Boolean, Schema.Null]),
               ),
               ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            }),
-            Schema.Struct({
-              id: Schema.String,
-              deleted: Schema.Boolean,
             }),
           ]),
           Schema.Null,
@@ -2300,6 +2300,10 @@ export const DeleteRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     Schema.Union([
       Schema.Union([
         Schema.Struct({
+          id: Schema.String,
+          deleted: Schema.Boolean,
+        }),
+        Schema.Struct({
           id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
           description: Schema.optional(
             Schema.Union([Schema.String, Schema.Null]),
@@ -2309,10 +2313,6 @@ export const DeleteRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           ),
           paused: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
           ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Struct({
-          id: Schema.String,
-          deleted: Schema.Boolean,
         }),
       ]),
       Schema.Null,
@@ -2434,6 +2434,10 @@ export const BulkPatchRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
           Schema.Union([
             Schema.Union([
               Schema.Struct({
+                id: Schema.String,
+                deleted: Schema.Boolean,
+              }),
+              Schema.Struct({
                 id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
                 description: Schema.optional(
                   Schema.Union([Schema.String, Schema.Null]),
@@ -2447,10 +2451,6 @@ export const BulkPatchRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
                 ref: Schema.optional(
                   Schema.Union([Schema.String, Schema.Null]),
                 ),
-              }),
-              Schema.Struct({
-                id: Schema.String,
-                deleted: Schema.Boolean,
               }),
             ]),
             Schema.Null,
@@ -2576,6 +2576,10 @@ export const BulkDeleteRulesResponse =
           Schema.Union([
             Schema.Union([
               Schema.Struct({
+                id: Schema.String,
+                deleted: Schema.Boolean,
+              }),
+              Schema.Struct({
                 id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
                 description: Schema.optional(
                   Schema.Union([Schema.String, Schema.Null]),
@@ -2589,10 +2593,6 @@ export const BulkDeleteRulesResponse =
                 ref: Schema.optional(
                   Schema.Union([Schema.String, Schema.Null]),
                 ),
-              }),
-              Schema.Struct({
-                id: Schema.String,
-                deleted: Schema.Boolean,
               }),
             ]),
             Schema.Null,
@@ -4470,28 +4470,6 @@ export const ListWafPackageRulesResponse =
       Schema.Union([
         Schema.Struct({
           id: Schema.String,
-          allowedModes: Schema.Array(Schema.Literals(["on", "off"])),
-          description: Schema.String,
-          group: Schema.Struct({
-            id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          }),
-          mode: Schema.Literals(["on", "off"]),
-          packageId: Schema.String,
-          priority: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            allowedModes: "allowed_modes",
-            description: "description",
-            group: "group",
-            mode: "mode",
-            packageId: "package_id",
-            priority: "priority",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
           allowedModes: Schema.Array(
             Schema.Literals([
               "default",
@@ -4526,6 +4504,28 @@ export const ListWafPackageRulesResponse =
             id: "id",
             allowedModes: "allowed_modes",
             defaultMode: "default_mode",
+            description: "description",
+            group: "group",
+            mode: "mode",
+            packageId: "package_id",
+            priority: "priority",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          allowedModes: Schema.Array(Schema.Literals(["on", "off"])),
+          description: Schema.String,
+          group: Schema.Struct({
+            id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          }),
+          mode: Schema.Literals(["on", "off"]),
+          packageId: Schema.String,
+          priority: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            allowedModes: "allowed_modes",
             description: "description",
             group: "group",
             mode: "mode",
@@ -4642,28 +4642,6 @@ export const PatchWafPackageRuleResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
       id: Schema.String,
-      allowedModes: Schema.Array(Schema.Literals(["on", "off"])),
-      description: Schema.String,
-      group: Schema.Struct({
-        id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      }),
-      mode: Schema.Literals(["on", "off"]),
-      packageId: Schema.String,
-      priority: Schema.String,
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        allowedModes: "allowed_modes",
-        description: "description",
-        group: "group",
-        mode: "mode",
-        packageId: "package_id",
-        priority: "priority",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
       allowedModes: Schema.Array(
         Schema.Literals([
           "default",
@@ -4698,6 +4676,28 @@ export const PatchWafPackageRuleResponse =
         id: "id",
         allowedModes: "allowed_modes",
         defaultMode: "default_mode",
+        description: "description",
+        group: "group",
+        mode: "mode",
+        packageId: "package_id",
+        priority: "priority",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      allowedModes: Schema.Array(Schema.Literals(["on", "off"])),
+      description: Schema.String,
+      group: Schema.Struct({
+        id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      }),
+      mode: Schema.Literals(["on", "off"]),
+      packageId: Schema.String,
+      priority: Schema.String,
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        allowedModes: "allowed_modes",
         description: "description",
         group: "group",
         mode: "mode",

--- a/packages/cloudflare/src/services/hyperdrive.ts
+++ b/packages/cloudflare/src/services/hyperdrive.ts
@@ -440,14 +440,6 @@ export const CreateConfigRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String,
   origin: Schema.Union([
     Schema.Struct({
-      database: Schema.String,
-      host: Schema.String,
-      password: SensitiveString,
-      port: Schema.Number,
-      scheme: Schema.Literals(["postgres", "postgresql", "mysql"]),
-      user: Schema.String,
-    }),
-    Schema.Struct({
       accessClientId: Schema.String,
       accessClientSecret: SensitiveString,
       database: Schema.String,
@@ -466,6 +458,14 @@ export const CreateConfigRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         user: "user",
       }),
     ),
+    Schema.Struct({
+      database: Schema.String,
+      host: Schema.String,
+      password: SensitiveString,
+      port: Schema.Number,
+      scheme: Schema.Literals(["postgres", "postgresql", "mysql"]),
+      user: Schema.String,
+    }),
   ]),
   caching: Schema.optional(
     Schema.Union([
@@ -713,14 +713,6 @@ export const UpdateConfigRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String,
   origin: Schema.Union([
     Schema.Struct({
-      database: Schema.String,
-      host: Schema.String,
-      password: SensitiveString,
-      port: Schema.Number,
-      scheme: Schema.Literals(["postgres", "postgresql", "mysql"]),
-      user: Schema.String,
-    }),
-    Schema.Struct({
       accessClientId: Schema.String,
       accessClientSecret: SensitiveString,
       database: Schema.String,
@@ -739,6 +731,14 @@ export const UpdateConfigRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         user: "user",
       }),
     ),
+    Schema.Struct({
+      database: Schema.String,
+      host: Schema.String,
+      password: SensitiveString,
+      port: Schema.Number,
+      scheme: Schema.Literals(["postgres", "postgresql", "mysql"]),
+      user: Schema.String,
+    }),
   ]),
   caching: Schema.optional(
     Schema.Union([
@@ -1014,18 +1014,6 @@ export const PatchConfigRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   origin: Schema.optional(
     Schema.Union([
       Schema.Struct({
-        database: Schema.optional(Schema.String),
-        password: Schema.optional(SensitiveString),
-        scheme: Schema.optional(
-          Schema.Literals(["postgres", "postgresql", "mysql"]),
-        ),
-        user: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        host: Schema.String,
-        port: Schema.Number,
-      }),
-      Schema.Struct({
         accessClientId: Schema.String,
         accessClientSecret: SensitiveString,
         host: Schema.String,
@@ -1036,6 +1024,18 @@ export const PatchConfigRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           host: "host",
         }),
       ),
+      Schema.Struct({
+        host: Schema.String,
+        port: Schema.Number,
+      }),
+      Schema.Struct({
+        database: Schema.optional(Schema.String),
+        password: Schema.optional(SensitiveString),
+        scheme: Schema.optional(
+          Schema.Literals(["postgres", "postgresql", "mysql"]),
+        ),
+        user: Schema.optional(Schema.String),
+      }),
     ]),
   ),
   originConnectionLimit: Schema.optional(Schema.Number),

--- a/packages/cloudflare/src/services/magic-cloud-networking.ts
+++ b/packages/cloudflare/src/services/magic-cloud-networking.ts
@@ -10177,15 +10177,6 @@ export type InitialSetupCloudIntegrationResponse =
 export const InitialSetupCloudIntegrationResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
-      awsTrustPolicy: Schema.String,
-      itemType: Schema.String,
-    }).pipe(
-      Schema.encodeKeys({
-        awsTrustPolicy: "aws_trust_policy",
-        itemType: "item_type",
-      }),
-    ),
-    Schema.Struct({
       azureConsentUrl: Schema.String,
       integrationIdentityTag: Schema.String,
       itemType: Schema.String,
@@ -10207,6 +10198,15 @@ export const InitialSetupCloudIntegrationResponse =
         integrationIdentityTag: "integration_identity_tag",
         itemType: "item_type",
         tagCliCommand: "tag_cli_command",
+      }),
+    ),
+    Schema.Struct({
+      awsTrustPolicy: Schema.String,
+      itemType: Schema.String,
+    }).pipe(
+      Schema.encodeKeys({
+        awsTrustPolicy: "aws_trust_policy",
+        itemType: "item_type",
       }),
     ),
   ]).pipe(

--- a/packages/cloudflare/src/services/magic-transit.ts
+++ b/packages/cloudflare/src/services/magic-transit.ts
@@ -1653,6 +1653,10 @@ export const GetConnectorEventResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     e: Schema.Union([
       Schema.Struct({
+        k: Schema.Literal("StartUpgrade"),
+        url: Schema.String,
+      }),
+      Schema.Struct({
         k: Schema.Literal("Init"),
       }),
       Schema.Struct({
@@ -1684,10 +1688,6 @@ export const GetConnectorEventResponse =
       }),
       Schema.Struct({
         k: Schema.Literal("FinishRotatePkiFailure"),
-      }),
-      Schema.Struct({
-        k: Schema.Literal("StartUpgrade"),
-        url: Schema.String,
       }),
       Schema.Struct({
         k: Schema.Literal("FinishUpgradeSuccess"),
@@ -1841,6 +1841,10 @@ export const ListConnectorEventLatestsResponse =
       Schema.Struct({
         e: Schema.Union([
           Schema.Struct({
+            k: Schema.Literal("StartUpgrade"),
+            url: Schema.String,
+          }),
+          Schema.Struct({
             k: Schema.Literal("Init"),
           }),
           Schema.Struct({
@@ -1872,10 +1876,6 @@ export const ListConnectorEventLatestsResponse =
           }),
           Schema.Struct({
             k: Schema.Literal("FinishRotatePkiFailure"),
-          }),
-          Schema.Struct({
-            k: Schema.Literal("StartUpgrade"),
-            url: Schema.String,
           }),
           Schema.Struct({
             k: Schema.Literal("FinishUpgradeSuccess"),

--- a/packages/cloudflare/src/services/pipelines.ts
+++ b/packages/cloudflare/src/services/pipelines.ts
@@ -1009,6 +1009,46 @@ export const GetSinkResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     Schema.Union([
       Schema.Union([
         Schema.Struct({
+          token: Schema.String,
+          accountId: Schema.String,
+          bucket: Schema.String,
+          tableName: Schema.String,
+          namespace: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          rollingPolicy: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                fileSizeBytes: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                inactivitySeconds: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                intervalSeconds: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  fileSizeBytes: "file_size_bytes",
+                  inactivitySeconds: "inactivity_seconds",
+                  intervalSeconds: "interval_seconds",
+                }),
+              ),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            token: "token",
+            accountId: "account_id",
+            bucket: "bucket",
+            tableName: "table_name",
+            namespace: "namespace",
+            rollingPolicy: "rolling_policy",
+          }),
+        ),
+        Schema.Struct({
           accountId: Schema.String,
           bucket: Schema.String,
           credentials: Schema.Struct({
@@ -1084,46 +1124,6 @@ export const GetSinkResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             jurisdiction: "jurisdiction",
             partitioning: "partitioning",
             path: "path",
-            rollingPolicy: "rolling_policy",
-          }),
-        ),
-        Schema.Struct({
-          token: Schema.String,
-          accountId: Schema.String,
-          bucket: Schema.String,
-          tableName: Schema.String,
-          namespace: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          rollingPolicy: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                fileSizeBytes: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                inactivitySeconds: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                intervalSeconds: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  fileSizeBytes: "file_size_bytes",
-                  inactivitySeconds: "inactivity_seconds",
-                  intervalSeconds: "interval_seconds",
-                }),
-              ),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            token: "token",
-            accountId: "account_id",
-            bucket: "bucket",
-            tableName: "table_name",
-            namespace: "namespace",
             rollingPolicy: "rolling_policy",
           }),
         ),
@@ -1700,6 +1700,46 @@ export const ListSinksResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         Schema.Union([
           Schema.Union([
             Schema.Struct({
+              token: Schema.String,
+              accountId: Schema.String,
+              bucket: Schema.String,
+              tableName: Schema.String,
+              namespace: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              rollingPolicy: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    fileSizeBytes: Schema.optional(
+                      Schema.Union([Schema.Number, Schema.Null]),
+                    ),
+                    inactivitySeconds: Schema.optional(
+                      Schema.Union([Schema.Number, Schema.Null]),
+                    ),
+                    intervalSeconds: Schema.optional(
+                      Schema.Union([Schema.Number, Schema.Null]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      fileSizeBytes: "file_size_bytes",
+                      inactivitySeconds: "inactivity_seconds",
+                      intervalSeconds: "interval_seconds",
+                    }),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                token: "token",
+                accountId: "account_id",
+                bucket: "bucket",
+                tableName: "table_name",
+                namespace: "namespace",
+                rollingPolicy: "rolling_policy",
+              }),
+            ),
+            Schema.Struct({
               accountId: Schema.String,
               bucket: Schema.String,
               credentials: Schema.Struct({
@@ -1775,46 +1815,6 @@ export const ListSinksResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                 jurisdiction: "jurisdiction",
                 partitioning: "partitioning",
                 path: "path",
-                rollingPolicy: "rolling_policy",
-              }),
-            ),
-            Schema.Struct({
-              token: Schema.String,
-              accountId: Schema.String,
-              bucket: Schema.String,
-              tableName: Schema.String,
-              namespace: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              rollingPolicy: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    fileSizeBytes: Schema.optional(
-                      Schema.Union([Schema.Number, Schema.Null]),
-                    ),
-                    inactivitySeconds: Schema.optional(
-                      Schema.Union([Schema.Number, Schema.Null]),
-                    ),
-                    intervalSeconds: Schema.optional(
-                      Schema.Union([Schema.Number, Schema.Null]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      fileSizeBytes: "file_size_bytes",
-                      inactivitySeconds: "inactivity_seconds",
-                      intervalSeconds: "interval_seconds",
-                    }),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                token: "token",
-                accountId: "account_id",
-                bucket: "bucket",
-                tableName: "table_name",
-                namespace: "namespace",
                 rollingPolicy: "rolling_policy",
               }),
             ),
@@ -2371,6 +2371,35 @@ export const CreateSinkRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   config: Schema.optional(
     Schema.Union([
       Schema.Struct({
+        token: Schema.String,
+        accountId: Schema.String,
+        bucket: Schema.String,
+        tableName: Schema.String,
+        namespace: Schema.optional(Schema.String),
+        rollingPolicy: Schema.optional(
+          Schema.Struct({
+            fileSizeBytes: Schema.optional(Schema.Number),
+            inactivitySeconds: Schema.optional(Schema.Number),
+            intervalSeconds: Schema.optional(Schema.Number),
+          }).pipe(
+            Schema.encodeKeys({
+              fileSizeBytes: "file_size_bytes",
+              inactivitySeconds: "inactivity_seconds",
+              intervalSeconds: "interval_seconds",
+            }),
+          ),
+        ),
+      }).pipe(
+        Schema.encodeKeys({
+          token: "token",
+          accountId: "account_id",
+          bucket: "bucket",
+          tableName: "table_name",
+          namespace: "namespace",
+          rollingPolicy: "rolling_policy",
+        }),
+      ),
+      Schema.Struct({
         accountId: Schema.String,
         bucket: Schema.String,
         credentials: Schema.Struct({
@@ -2420,35 +2449,6 @@ export const CreateSinkRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           jurisdiction: "jurisdiction",
           partitioning: "partitioning",
           path: "path",
-          rollingPolicy: "rolling_policy",
-        }),
-      ),
-      Schema.Struct({
-        token: Schema.String,
-        accountId: Schema.String,
-        bucket: Schema.String,
-        tableName: Schema.String,
-        namespace: Schema.optional(Schema.String),
-        rollingPolicy: Schema.optional(
-          Schema.Struct({
-            fileSizeBytes: Schema.optional(Schema.Number),
-            inactivitySeconds: Schema.optional(Schema.Number),
-            intervalSeconds: Schema.optional(Schema.Number),
-          }).pipe(
-            Schema.encodeKeys({
-              fileSizeBytes: "file_size_bytes",
-              inactivitySeconds: "inactivity_seconds",
-              intervalSeconds: "interval_seconds",
-            }),
-          ),
-        ),
-      }).pipe(
-        Schema.encodeKeys({
-          token: "token",
-          accountId: "account_id",
-          bucket: "bucket",
-          tableName: "table_name",
-          namespace: "namespace",
           rollingPolicy: "rolling_policy",
         }),
       ),
@@ -2880,6 +2880,46 @@ export const CreateSinkResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     Schema.Union([
       Schema.Union([
         Schema.Struct({
+          token: Schema.String,
+          accountId: Schema.String,
+          bucket: Schema.String,
+          tableName: Schema.String,
+          namespace: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          rollingPolicy: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                fileSizeBytes: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                inactivitySeconds: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                intervalSeconds: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  fileSizeBytes: "file_size_bytes",
+                  inactivitySeconds: "inactivity_seconds",
+                  intervalSeconds: "interval_seconds",
+                }),
+              ),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            token: "token",
+            accountId: "account_id",
+            bucket: "bucket",
+            tableName: "table_name",
+            namespace: "namespace",
+            rollingPolicy: "rolling_policy",
+          }),
+        ),
+        Schema.Struct({
           accountId: Schema.String,
           bucket: Schema.String,
           credentials: Schema.Struct({
@@ -2955,46 +2995,6 @@ export const CreateSinkResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             jurisdiction: "jurisdiction",
             partitioning: "partitioning",
             path: "path",
-            rollingPolicy: "rolling_policy",
-          }),
-        ),
-        Schema.Struct({
-          token: Schema.String,
-          accountId: Schema.String,
-          bucket: Schema.String,
-          tableName: Schema.String,
-          namespace: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          rollingPolicy: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                fileSizeBytes: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                inactivitySeconds: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                intervalSeconds: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  fileSizeBytes: "file_size_bytes",
-                  inactivitySeconds: "inactivity_seconds",
-                  intervalSeconds: "interval_seconds",
-                }),
-              ),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            token: "token",
-            accountId: "account_id",
-            bucket: "bucket",
-            tableName: "table_name",
-            namespace: "namespace",
             rollingPolicy: "rolling_policy",
           }),
         ),

--- a/packages/cloudflare/src/services/radar.ts
+++ b/packages/cloudflare/src/services/radar.ts
@@ -13581,11 +13581,6 @@ export const SummaryCtResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ),
   }),
   summary_0: Schema.Union([
-    Schema.Record(Schema.String, Schema.Unknown),
-    Schema.Struct({
-      rfc6962: Schema.String,
-      static: Schema.String,
-    }),
     Schema.Struct({
       gt_121d: Schema.String,
       gt_16dLte_31d: Schema.String,
@@ -13604,6 +13599,21 @@ export const SummaryCtResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
     Schema.Struct({
+      domain: Schema.String,
+      extended: Schema.String,
+      organization: Schema.String,
+      unknown: Schema.String,
+    }),
+    Schema.Struct({
+      dsa: Schema.String,
+      ecdsa: Schema.String,
+      rsa: Schema.String,
+    }).pipe(Schema.encodeKeys({ dsa: "DSA", ecdsa: "ECDSA", rsa: "RSA" })),
+    Schema.Struct({
+      rfc6962: Schema.String,
+      static: Schema.String,
+    }),
+    Schema.Struct({
       certificate: Schema.String,
       precertificate: Schema.String,
     }).pipe(
@@ -13620,17 +13630,7 @@ export const SummaryCtResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       negative: Schema.String,
       positive: Schema.String,
     }).pipe(Schema.encodeKeys({ negative: "NEGATIVE", positive: "POSITIVE" })),
-    Schema.Struct({
-      dsa: Schema.String,
-      ecdsa: Schema.String,
-      rsa: Schema.String,
-    }).pipe(Schema.encodeKeys({ dsa: "DSA", ecdsa: "ECDSA", rsa: "RSA" })),
-    Schema.Struct({
-      domain: Schema.String,
-      extended: Schema.String,
-      organization: Schema.String,
-      unknown: Schema.String,
-    }),
+    Schema.Record(Schema.String, Schema.Unknown),
   ]),
 }).pipe(
   T.ResponsePath("result"),
@@ -22839,13 +22839,6 @@ export const TimeseriesGroupsCtResponse =
     }),
     serie_0: Schema.Union([
       Schema.Struct({
-        timestamps: Schema.Array(Schema.String),
-      }),
-      Schema.Struct({
-        rfc6962: Schema.Array(Schema.String),
-        static: Schema.Array(Schema.String),
-      }),
-      Schema.Struct({
         gt_121d: Schema.Array(Schema.String),
         gt_16dLte_31d: Schema.Array(Schema.String),
         gt_31dLte_91d: Schema.Array(Schema.String),
@@ -22862,6 +22855,21 @@ export const TimeseriesGroupsCtResponse =
           lte_3d: "lte_3d",
         }),
       ),
+      Schema.Struct({
+        domain: Schema.Array(Schema.String),
+        extended: Schema.Array(Schema.String),
+        organization: Schema.Array(Schema.String),
+        unknown: Schema.Array(Schema.String),
+      }),
+      Schema.Struct({
+        dsa: Schema.Array(Schema.String),
+        ecdsa: Schema.Array(Schema.String),
+        rsa: Schema.Array(Schema.String),
+      }).pipe(Schema.encodeKeys({ dsa: "DSA", ecdsa: "ECDSA", rsa: "RSA" })),
+      Schema.Struct({
+        rfc6962: Schema.Array(Schema.String),
+        static: Schema.Array(Schema.String),
+      }),
       Schema.Struct({
         certificate: Schema.Array(Schema.String),
         precertificate: Schema.Array(Schema.String),
@@ -22882,15 +22890,7 @@ export const TimeseriesGroupsCtResponse =
         Schema.encodeKeys({ negative: "NEGATIVE", positive: "POSITIVE" }),
       ),
       Schema.Struct({
-        dsa: Schema.Array(Schema.String),
-        ecdsa: Schema.Array(Schema.String),
-        rsa: Schema.Array(Schema.String),
-      }).pipe(Schema.encodeKeys({ dsa: "DSA", ecdsa: "ECDSA", rsa: "RSA" })),
-      Schema.Struct({
-        domain: Schema.Array(Schema.String),
-        extended: Schema.Array(Schema.String),
-        organization: Schema.Array(Schema.String),
-        unknown: Schema.Array(Schema.String),
+        timestamps: Schema.Array(Schema.String),
       }),
     ]),
   }).pipe(

--- a/packages/cloudflare/src/services/realtime-kit.ts
+++ b/packages/cloudflare/src/services/realtime-kit.ts
@@ -7362,7 +7362,6 @@ export const CreatePresetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         canEditConfig: Schema.Boolean,
         canStart: Schema.Boolean,
         config: Schema.Union([
-          Schema.String,
           Schema.Struct({
             accessControl: Schema.Literals(["FULL_ACCESS", "VIEW_ONLY"]),
             handlesViewOnly: Schema.Boolean,
@@ -7372,6 +7371,7 @@ export const CreatePresetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
               handlesViewOnly: "handles_view_only",
             }),
           ),
+          Schema.String,
         ]),
       }).pipe(
         Schema.encodeKeys({
@@ -7728,7 +7728,6 @@ export const CreatePresetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             canEditConfig: Schema.Boolean,
             canStart: Schema.Boolean,
             config: Schema.Union([
-              Schema.String,
               Schema.Struct({
                 accessControl: Schema.Literals(["FULL_ACCESS", "VIEW_ONLY"]),
                 handlesViewOnly: Schema.Boolean,
@@ -7738,6 +7737,7 @@ export const CreatePresetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                   handlesViewOnly: "handles_view_only",
                 }),
               ),
+              Schema.String,
             ]),
           }).pipe(
             Schema.encodeKeys({
@@ -8502,7 +8502,6 @@ export const PatchPresetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             canEditConfig: Schema.Boolean,
             canStart: Schema.Boolean,
             config: Schema.Union([
-              Schema.String,
               Schema.Struct({
                 accessControl: Schema.Literals(["FULL_ACCESS", "VIEW_ONLY"]),
                 handlesViewOnly: Schema.Boolean,
@@ -8512,6 +8511,7 @@ export const PatchPresetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                   handlesViewOnly: "handles_view_only",
                 }),
               ),
+              Schema.String,
             ]),
           }).pipe(
             Schema.encodeKeys({
@@ -8902,7 +8902,6 @@ export const DeletePresetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             canEditConfig: Schema.Boolean,
             canStart: Schema.Boolean,
             config: Schema.Union([
-              Schema.String,
               Schema.Struct({
                 accessControl: Schema.Literals(["FULL_ACCESS", "VIEW_ONLY"]),
                 handlesViewOnly: Schema.Boolean,
@@ -8912,6 +8911,7 @@ export const DeletePresetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                   handlesViewOnly: "handles_view_only",
                 }),
               ),
+              Schema.String,
             ]),
           }).pipe(
             Schema.encodeKeys({
@@ -9310,7 +9310,6 @@ export const GetPresetByIdPresetResponse =
               canEditConfig: Schema.Boolean,
               canStart: Schema.Boolean,
               config: Schema.Union([
-                Schema.String,
                 Schema.Struct({
                   accessControl: Schema.Literals(["FULL_ACCESS", "VIEW_ONLY"]),
                   handlesViewOnly: Schema.Boolean,
@@ -9320,6 +9319,7 @@ export const GetPresetByIdPresetResponse =
                     handlesViewOnly: "handles_view_only",
                   }),
                 ),
+                Schema.String,
               ]),
             }).pipe(
               Schema.encodeKeys({

--- a/packages/cloudflare/src/services/rules.ts
+++ b/packages/cloudflare/src/services/rules.ts
@@ -380,7 +380,9 @@ export const GetListBulkOperationResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
       id: Schema.String,
-      status: Schema.Literals(["pending", "running"]),
+      completed: Schema.String,
+      error: Schema.String,
+      status: Schema.Literal("failed"),
     }),
     Schema.Struct({
       id: Schema.String,
@@ -389,9 +391,7 @@ export const GetListBulkOperationResponse =
     }),
     Schema.Struct({
       id: Schema.String,
-      completed: Schema.String,
-      error: Schema.String,
-      status: Schema.Literal("failed"),
+      status: Schema.Literals(["pending", "running"]),
     }),
   ]).pipe(
     T.ResponsePath("result"),

--- a/packages/cloudflare/src/services/token-validation.ts
+++ b/packages/cloudflare/src/services/token-validation.ts
@@ -79,20 +79,6 @@ export const GetConfigurationResponse =
       keys: Schema.Array(
         Schema.Union([
           Schema.Struct({
-            alg: Schema.Literals([
-              "RS256",
-              "RS384",
-              "RS512",
-              "PS256",
-              "PS384",
-              "PS512",
-            ]),
-            e: Schema.String,
-            kid: Schema.String,
-            kty: Schema.Literal("RSA"),
-            n: Schema.String,
-          }),
-          Schema.Struct({
             alg: Schema.Literal("ES256"),
             crv: Schema.Literal("P-256"),
             kid: Schema.String,
@@ -107,6 +93,20 @@ export const GetConfigurationResponse =
             kty: Schema.Literal("EC"),
             x: Schema.String,
             y: Schema.String,
+          }),
+          Schema.Struct({
+            alg: Schema.Literals([
+              "RS256",
+              "RS384",
+              "RS512",
+              "PS256",
+              "PS384",
+              "PS512",
+            ]),
+            e: Schema.String,
+            kid: Schema.String,
+            kty: Schema.Literal("RSA"),
+            n: Schema.String,
           }),
         ]),
       ),
@@ -217,20 +217,6 @@ export const ListConfigurationsResponse =
           keys: Schema.Array(
             Schema.Union([
               Schema.Struct({
-                alg: Schema.Literals([
-                  "RS256",
-                  "RS384",
-                  "RS512",
-                  "PS256",
-                  "PS384",
-                  "PS512",
-                ]),
-                e: Schema.String,
-                kid: Schema.String,
-                kty: Schema.Literal("RSA"),
-                n: Schema.String,
-              }),
-              Schema.Struct({
                 alg: Schema.Literal("ES256"),
                 crv: Schema.Literal("P-256"),
                 kid: Schema.String,
@@ -245,6 +231,20 @@ export const ListConfigurationsResponse =
                 kty: Schema.Literal("EC"),
                 x: Schema.String,
                 y: Schema.String,
+              }),
+              Schema.Struct({
+                alg: Schema.Literals([
+                  "RS256",
+                  "RS384",
+                  "RS512",
+                  "PS256",
+                  "PS384",
+                  "PS512",
+                ]),
+                e: Schema.String,
+                kid: Schema.String,
+                kty: Schema.Literal("RSA"),
+                n: Schema.String,
               }),
             ]),
           ),
@@ -352,20 +352,6 @@ export const CreateConfigurationRequest =
       keys: Schema.Array(
         Schema.Union([
           Schema.Struct({
-            alg: Schema.Literals([
-              "RS256",
-              "RS384",
-              "RS512",
-              "PS256",
-              "PS384",
-              "PS512",
-            ]),
-            e: Schema.String,
-            kid: Schema.String,
-            kty: Schema.Literal("RSA"),
-            n: Schema.String,
-          }),
-          Schema.Struct({
             alg: Schema.Literal("ES256"),
             crv: Schema.Literal("P-256"),
             kid: Schema.String,
@@ -380,6 +366,20 @@ export const CreateConfigurationRequest =
             kty: Schema.Literal("EC"),
             x: Schema.String,
             y: Schema.String,
+          }),
+          Schema.Struct({
+            alg: Schema.Literals([
+              "RS256",
+              "RS384",
+              "RS512",
+              "PS256",
+              "PS384",
+              "PS512",
+            ]),
+            e: Schema.String,
+            kid: Schema.String,
+            kty: Schema.Literal("RSA"),
+            n: Schema.String,
           }),
         ]),
       ),
@@ -448,20 +448,6 @@ export const CreateConfigurationResponse =
       keys: Schema.Array(
         Schema.Union([
           Schema.Struct({
-            alg: Schema.Literals([
-              "RS256",
-              "RS384",
-              "RS512",
-              "PS256",
-              "PS384",
-              "PS512",
-            ]),
-            e: Schema.String,
-            kid: Schema.String,
-            kty: Schema.Literal("RSA"),
-            n: Schema.String,
-          }),
-          Schema.Struct({
             alg: Schema.Literal("ES256"),
             crv: Schema.Literal("P-256"),
             kid: Schema.String,
@@ -476,6 +462,20 @@ export const CreateConfigurationResponse =
             kty: Schema.Literal("EC"),
             x: Schema.String,
             y: Schema.String,
+          }),
+          Schema.Struct({
+            alg: Schema.Literals([
+              "RS256",
+              "RS384",
+              "RS512",
+              "PS256",
+              "PS384",
+              "PS512",
+            ]),
+            e: Schema.String,
+            kid: Schema.String,
+            kty: Schema.Literal("RSA"),
+            n: Schema.String,
           }),
         ]),
       ),
@@ -669,20 +669,6 @@ export const PutConfigurationCredentialRequest =
     keys: Schema.Array(
       Schema.Union([
         Schema.Struct({
-          alg: Schema.Literals([
-            "RS256",
-            "RS384",
-            "RS512",
-            "PS256",
-            "PS384",
-            "PS512",
-          ]),
-          e: Schema.String,
-          kid: Schema.String,
-          kty: Schema.Literal("RSA"),
-          n: Schema.String,
-        }),
-        Schema.Struct({
           alg: Schema.Literal("ES256"),
           crv: Schema.Literal("P-256"),
           kid: Schema.String,
@@ -697,6 +683,20 @@ export const PutConfigurationCredentialRequest =
           kty: Schema.Literal("EC"),
           x: Schema.String,
           y: Schema.String,
+        }),
+        Schema.Struct({
+          alg: Schema.Literals([
+            "RS256",
+            "RS384",
+            "RS512",
+            "PS256",
+            "PS384",
+            "PS512",
+          ]),
+          e: Schema.String,
+          kid: Schema.String,
+          kty: Schema.Literal("RSA"),
+          n: Schema.String,
         }),
       ]),
     ),
@@ -780,20 +780,6 @@ export const PutConfigurationCredentialResponse =
     keys: Schema.Array(
       Schema.Union([
         Schema.Struct({
-          alg: Schema.Literals([
-            "RS256",
-            "RS384",
-            "RS512",
-            "PS256",
-            "PS384",
-            "PS512",
-          ]),
-          e: Schema.String,
-          kid: Schema.String,
-          kty: Schema.Literal("RSA"),
-          n: Schema.String,
-        }),
-        Schema.Struct({
           alg: Schema.Literal("ES256"),
           crv: Schema.Literal("P-256"),
           kid: Schema.String,
@@ -808,6 +794,20 @@ export const PutConfigurationCredentialResponse =
           kty: Schema.Literal("EC"),
           x: Schema.String,
           y: Schema.String,
+        }),
+        Schema.Struct({
+          alg: Schema.Literals([
+            "RS256",
+            "RS384",
+            "RS512",
+            "PS256",
+            "PS384",
+            "PS512",
+          ]),
+          e: Schema.String,
+          kid: Schema.String,
+          kty: Schema.Literal("RSA"),
+          n: Schema.String,
         }),
       ]),
     ),

--- a/packages/cloudflare/src/services/workers-for-platforms.ts
+++ b/packages/cloudflare/src/services/workers-for-platforms.ts
@@ -912,21 +912,52 @@ export const PutDispatchNamespaceScriptRequest =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              algorithm: Schema.Unknown,
+              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
               name: Schema.String,
-              type: Schema.Literal("ai"),
-            }),
+              type: Schema.Literal("secret_key"),
+              usages: Schema.Array(
+                Schema.Literals([
+                  "encrypt",
+                  "decrypt",
+                  "sign",
+                  "verify",
+                  "deriveKey",
+                  "deriveBits",
+                  "wrapKey",
+                  "unwrapKey",
+                ]),
+              ),
+              keyBase64: Schema.optional(Schema.String),
+              keyJwk: Schema.optional(Schema.Unknown),
+            }).pipe(
+              Schema.encodeKeys({
+                algorithm: "algorithm",
+                format: "format",
+                name: "name",
+                type: "type",
+                usages: "usages",
+                keyBase64: "key_base64",
+                keyJwk: "key_jwk",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              secretName: Schema.String,
+              storeId: Schema.String,
+              type: Schema.Literal("secrets_store_secret"),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                secretName: "secret_name",
+                storeId: "store_id",
+                type: "type",
+              }),
+            ),
             Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("assets"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("browser"),
             }),
             Schema.Struct({
               id: Schema.String,
@@ -955,43 +986,9 @@ export const PutDispatchNamespaceScriptRequest =
               ),
             }),
             Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(Schema.String),
-              environment: Schema.optional(Schema.String),
-              namespaceId: Schema.optional(Schema.String),
-              scriptName: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
               id: Schema.String,
               name: Schema.String,
               type: Schema.Literal("hyperdrive"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("inherit"),
-              oldName: Schema.optional(Schema.String),
-              versionId: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                oldName: "old_name",
-                versionId: "version_id",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("images"),
             }),
             Schema.Struct({
               json: Schema.String,
@@ -1061,25 +1058,6 @@ export const PutDispatchNamespaceScriptRequest =
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("send_email"),
-              allowedDestinationAddresses: Schema.optional(
-                Schema.Array(Schema.String),
-              ),
-              allowedSenderAddresses: Schema.optional(
-                Schema.Array(Schema.String),
-              ),
-              destinationAddress: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                allowedDestinationAddresses: "allowed_destination_addresses",
-                allowedSenderAddresses: "allowed_sender_addresses",
-                destinationAddress: "destination_address",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               service: Schema.String,
               type: Schema.Literal("service"),
               environment: Schema.optional(Schema.String),
@@ -1102,53 +1080,6 @@ export const PutDispatchNamespaceScriptRequest =
             ),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("version_metadata"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              secretName: Schema.String,
-              storeId: Schema.String,
-              type: Schema.Literal("secrets_store_secret"),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                secretName: "secret_name",
-                storeId: "store_id",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              algorithm: Schema.Unknown,
-              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-              name: Schema.String,
-              type: Schema.Literal("secret_key"),
-              usages: Schema.Array(
-                Schema.Literals([
-                  "encrypt",
-                  "decrypt",
-                  "sign",
-                  "verify",
-                  "deriveKey",
-                  "deriveBits",
-                  "wrapKey",
-                  "unwrapKey",
-                ]),
-              ),
-              keyBase64: Schema.optional(Schema.String),
-              keyJwk: Schema.optional(Schema.Unknown),
-            }).pipe(
-              Schema.encodeKeys({
-                algorithm: "algorithm",
-                format: "format",
-                name: "name",
-                type: "type",
-                usages: "usages",
-                keyBase64: "key_base64",
-                keyJwk: "key_jwk",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               type: Schema.Literal("workflow"),
               workflowName: Schema.String,
               className: Schema.optional(Schema.String),
@@ -1166,6 +1097,75 @@ export const PutDispatchNamespaceScriptRequest =
               name: Schema.String,
               part: Schema.String,
               type: Schema.Literal("wasm_module"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("ai"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("assets"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("browser"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.optional(Schema.String),
+              environment: Schema.optional(Schema.String),
+              namespaceId: Schema.optional(Schema.String),
+              scriptName: Schema.optional(Schema.String),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("inherit"),
+              oldName: Schema.optional(Schema.String),
+              versionId: Schema.optional(Schema.String),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                oldName: "old_name",
+                versionId: "version_id",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("images"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("send_email"),
+              allowedDestinationAddresses: Schema.optional(
+                Schema.Array(Schema.String),
+              ),
+              allowedSenderAddresses: Schema.optional(
+                Schema.Array(Schema.String),
+              ),
+              destinationAddress: Schema.optional(Schema.String),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                allowedDestinationAddresses: "allowed_destination_addresses",
+                allowedSenderAddresses: "allowed_sender_addresses",
+                destinationAddress: "destination_address",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("version_metadata"),
             }),
           ]),
         ),
@@ -1965,21 +1965,40 @@ export const GetDispatchNamespaceScriptBindingResponse =
     result: Schema.Array(
       Schema.Union([
         Schema.Struct({
+          algorithm: Schema.Unknown,
+          format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
           name: Schema.String,
-          type: Schema.Literal("ai"),
+          type: Schema.Literal("secret_key"),
+          usages: Schema.Array(
+            Schema.Literals([
+              "encrypt",
+              "decrypt",
+              "sign",
+              "verify",
+              "deriveKey",
+              "deriveBits",
+              "wrapKey",
+              "unwrapKey",
+            ]),
+          ),
         }),
+        Schema.Struct({
+          name: Schema.String,
+          secretName: Schema.String,
+          storeId: Schema.String,
+          type: Schema.Literal("secrets_store_secret"),
+        }).pipe(
+          Schema.encodeKeys({
+            name: "name",
+            secretName: "secret_name",
+            storeId: "store_id",
+            type: "type",
+          }),
+        ),
         Schema.Struct({
           dataset: Schema.String,
           name: Schema.String,
           type: Schema.Literal("analytics_engine"),
-        }),
-        Schema.Struct({
-          name: Schema.String,
-          type: Schema.Literal("assets"),
-        }),
-        Schema.Struct({
-          name: Schema.String,
-          type: Schema.Literal("browser"),
         }),
         Schema.Struct({
           id: Schema.String,
@@ -2020,53 +2039,9 @@ export const GetDispatchNamespaceScriptBindingResponse =
           ),
         }),
         Schema.Struct({
-          name: Schema.String,
-          type: Schema.Literal("durable_object_namespace"),
-          className: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          environment: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          namespaceId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          scriptName: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            name: "name",
-            type: "type",
-            className: "class_name",
-            environment: "environment",
-            namespaceId: "namespace_id",
-            scriptName: "script_name",
-          }),
-        ),
-        Schema.Struct({
           id: Schema.String,
           name: Schema.String,
           type: Schema.Literal("hyperdrive"),
-        }),
-        Schema.Struct({
-          name: Schema.String,
-          type: Schema.Literal("inherit"),
-          oldName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          versionId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            name: "name",
-            type: "type",
-            oldName: "old_name",
-            versionId: "version_id",
-          }),
-        ),
-        Schema.Struct({
-          name: Schema.String,
-          type: Schema.Literal("images"),
         }),
         Schema.Struct({
           json: Schema.String,
@@ -2133,6 +2108,110 @@ export const GetDispatchNamespaceScriptBindingResponse =
         ),
         Schema.Struct({
           name: Schema.String,
+          service: Schema.String,
+          type: Schema.Literal("service"),
+          environment: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }),
+        Schema.Struct({
+          name: Schema.String,
+          part: Schema.String,
+          type: Schema.Literal("text_blob"),
+        }),
+        Schema.Struct({
+          indexName: Schema.String,
+          name: Schema.String,
+          type: Schema.Literal("vectorize"),
+        }).pipe(
+          Schema.encodeKeys({
+            indexName: "index_name",
+            name: "name",
+            type: "type",
+          }),
+        ),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("workflow"),
+          workflowName: Schema.String,
+          className: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          scriptName: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            name: "name",
+            type: "type",
+            workflowName: "workflow_name",
+            className: "class_name",
+            scriptName: "script_name",
+          }),
+        ),
+        Schema.Struct({
+          name: Schema.String,
+          part: Schema.String,
+          type: Schema.Literal("wasm_module"),
+        }),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("ai"),
+        }),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("assets"),
+        }),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("browser"),
+        }),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("durable_object_namespace"),
+          className: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          environment: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          namespaceId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          scriptName: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            name: "name",
+            type: "type",
+            className: "class_name",
+            environment: "environment",
+            namespaceId: "namespace_id",
+            scriptName: "script_name",
+          }),
+        ),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("inherit"),
+          oldName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          versionId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            name: "name",
+            type: "type",
+            oldName: "old_name",
+            versionId: "version_id",
+          }),
+        ),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("images"),
+        }),
+        Schema.Struct({
+          name: Schema.String,
           type: Schema.Literal("secret_text"),
         }),
         Schema.Struct({
@@ -2158,86 +2237,7 @@ export const GetDispatchNamespaceScriptBindingResponse =
         ),
         Schema.Struct({
           name: Schema.String,
-          service: Schema.String,
-          type: Schema.Literal("service"),
-          environment: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }),
-        Schema.Struct({
-          name: Schema.String,
-          part: Schema.String,
-          type: Schema.Literal("text_blob"),
-        }),
-        Schema.Struct({
-          indexName: Schema.String,
-          name: Schema.String,
-          type: Schema.Literal("vectorize"),
-        }).pipe(
-          Schema.encodeKeys({
-            indexName: "index_name",
-            name: "name",
-            type: "type",
-          }),
-        ),
-        Schema.Struct({
-          name: Schema.String,
           type: Schema.Literal("version_metadata"),
-        }),
-        Schema.Struct({
-          name: Schema.String,
-          secretName: Schema.String,
-          storeId: Schema.String,
-          type: Schema.Literal("secrets_store_secret"),
-        }).pipe(
-          Schema.encodeKeys({
-            name: "name",
-            secretName: "secret_name",
-            storeId: "store_id",
-            type: "type",
-          }),
-        ),
-        Schema.Struct({
-          algorithm: Schema.Unknown,
-          format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-          name: Schema.String,
-          type: Schema.Literal("secret_key"),
-          usages: Schema.Array(
-            Schema.Literals([
-              "encrypt",
-              "decrypt",
-              "sign",
-              "verify",
-              "deriveKey",
-              "deriveBits",
-              "wrapKey",
-              "unwrapKey",
-            ]),
-          ),
-        }),
-        Schema.Struct({
-          name: Schema.String,
-          type: Schema.Literal("workflow"),
-          workflowName: Schema.String,
-          className: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          scriptName: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            name: "name",
-            type: "type",
-            workflowName: "workflow_name",
-            className: "class_name",
-            scriptName: "script_name",
-          }),
-        ),
-        Schema.Struct({
-          name: Schema.String,
-          part: Schema.String,
-          type: Schema.Literal("wasm_module"),
         }),
       ]),
     ),
@@ -2753,10 +2753,6 @@ export type GetDispatchNamespaceScriptSecretResponse =
 export const GetDispatchNamespaceScriptSecretResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
-      name: Schema.String,
-      type: Schema.Literal("secret_text"),
-    }),
-    Schema.Struct({
       algorithm: Schema.Unknown,
       format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
       name: Schema.String,
@@ -2773,6 +2769,10 @@ export const GetDispatchNamespaceScriptSecretResponse =
           "unwrapKey",
         ]),
       ),
+    }),
+    Schema.Struct({
+      name: Schema.String,
+      type: Schema.Literal("secret_text"),
     }),
   ]).pipe(
     T.ResponsePath("result"),
@@ -2837,10 +2837,6 @@ export const ListDispatchNamespaceScriptSecretsResponse =
     result: Schema.Array(
       Schema.Union([
         Schema.Struct({
-          name: Schema.String,
-          type: Schema.Literal("secret_text"),
-        }),
-        Schema.Struct({
           algorithm: Schema.Unknown,
           format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
           name: Schema.String,
@@ -2857,6 +2853,10 @@ export const ListDispatchNamespaceScriptSecretsResponse =
               "unwrapKey",
             ]),
           ),
+        }),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("secret_text"),
         }),
       ]),
     ),
@@ -2929,10 +2929,6 @@ export type PutDispatchNamespaceScriptSecretResponse =
 export const PutDispatchNamespaceScriptSecretResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
-      name: Schema.String,
-      type: Schema.Literal("secret_text"),
-    }),
-    Schema.Struct({
       algorithm: Schema.Unknown,
       format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
       name: Schema.String,
@@ -2949,6 +2945,10 @@ export const PutDispatchNamespaceScriptSecretResponse =
           "unwrapKey",
         ]),
       ),
+    }),
+    Schema.Struct({
+      name: Schema.String,
+      type: Schema.Literal("secret_text"),
     }),
   ]).pipe(
     T.ResponsePath("result"),
@@ -3183,21 +3183,40 @@ export const GetDispatchNamespaceScriptSettingResponse =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              algorithm: Schema.Unknown,
+              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
               name: Schema.String,
-              type: Schema.Literal("ai"),
+              type: Schema.Literal("secret_key"),
+              usages: Schema.Array(
+                Schema.Literals([
+                  "encrypt",
+                  "decrypt",
+                  "sign",
+                  "verify",
+                  "deriveKey",
+                  "deriveBits",
+                  "wrapKey",
+                  "unwrapKey",
+                ]),
+              ),
             }),
+            Schema.Struct({
+              name: Schema.String,
+              secretName: Schema.String,
+              storeId: Schema.String,
+              type: Schema.Literal("secrets_store_secret"),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                secretName: "secret_name",
+                storeId: "store_id",
+                type: "type",
+              }),
+            ),
             Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("assets"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("browser"),
             }),
             Schema.Struct({
               id: Schema.String,
@@ -3238,55 +3257,9 @@ export const GetDispatchNamespaceScriptSettingResponse =
               ),
             }),
             Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              environment: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              namespaceId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              scriptName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
               id: Schema.String,
               name: Schema.String,
               type: Schema.Literal("hyperdrive"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("inherit"),
-              oldName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              versionId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                oldName: "old_name",
-                versionId: "version_id",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("images"),
             }),
             Schema.Struct({
               json: Schema.String,
@@ -3353,6 +3326,112 @@ export const GetDispatchNamespaceScriptSettingResponse =
             ),
             Schema.Struct({
               name: Schema.String,
+              service: Schema.String,
+              type: Schema.Literal("service"),
+              environment: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              part: Schema.String,
+              type: Schema.Literal("text_blob"),
+            }),
+            Schema.Struct({
+              indexName: Schema.String,
+              name: Schema.String,
+              type: Schema.Literal("vectorize"),
+            }).pipe(
+              Schema.encodeKeys({
+                indexName: "index_name",
+                name: "name",
+                type: "type",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("workflow"),
+              workflowName: Schema.String,
+              className: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              scriptName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                workflowName: "workflow_name",
+                className: "class_name",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              part: Schema.String,
+              type: Schema.Literal("wasm_module"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("ai"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("assets"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("browser"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              environment: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              namespaceId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              scriptName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("inherit"),
+              oldName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              versionId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                oldName: "old_name",
+                versionId: "version_id",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("images"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
               type: Schema.Literal("secret_text"),
             }),
             Schema.Struct({
@@ -3378,86 +3457,7 @@ export const GetDispatchNamespaceScriptSettingResponse =
             ),
             Schema.Struct({
               name: Schema.String,
-              service: Schema.String,
-              type: Schema.Literal("service"),
-              environment: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              part: Schema.String,
-              type: Schema.Literal("text_blob"),
-            }),
-            Schema.Struct({
-              indexName: Schema.String,
-              name: Schema.String,
-              type: Schema.Literal("vectorize"),
-            }).pipe(
-              Schema.encodeKeys({
-                indexName: "index_name",
-                name: "name",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               type: Schema.Literal("version_metadata"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              secretName: Schema.String,
-              storeId: Schema.String,
-              type: Schema.Literal("secrets_store_secret"),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                secretName: "secret_name",
-                storeId: "store_id",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              algorithm: Schema.Unknown,
-              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-              name: Schema.String,
-              type: Schema.Literal("secret_key"),
-              usages: Schema.Array(
-                Schema.Literals([
-                  "encrypt",
-                  "decrypt",
-                  "sign",
-                  "verify",
-                  "deriveKey",
-                  "deriveBits",
-                  "wrapKey",
-                  "unwrapKey",
-                ]),
-              ),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("workflow"),
-              workflowName: Schema.String,
-              className: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              scriptName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                workflowName: "workflow_name",
-                className: "class_name",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              part: Schema.String,
-              type: Schema.Literal("wasm_module"),
             }),
           ]),
         ),
@@ -3757,21 +3757,52 @@ export const PatchDispatchNamespaceScriptSettingRequest =
           Schema.Array(
             Schema.Union([
               Schema.Struct({
+                algorithm: Schema.Unknown,
+                format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
                 name: Schema.String,
-                type: Schema.Literal("ai"),
-              }),
+                type: Schema.Literal("secret_key"),
+                usages: Schema.Array(
+                  Schema.Literals([
+                    "encrypt",
+                    "decrypt",
+                    "sign",
+                    "verify",
+                    "deriveKey",
+                    "deriveBits",
+                    "wrapKey",
+                    "unwrapKey",
+                  ]),
+                ),
+                keyBase64: Schema.optional(Schema.String),
+                keyJwk: Schema.optional(Schema.Unknown),
+              }).pipe(
+                Schema.encodeKeys({
+                  algorithm: "algorithm",
+                  format: "format",
+                  name: "name",
+                  type: "type",
+                  usages: "usages",
+                  keyBase64: "key_base64",
+                  keyJwk: "key_jwk",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                secretName: Schema.String,
+                storeId: Schema.String,
+                type: Schema.Literal("secrets_store_secret"),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  secretName: "secret_name",
+                  storeId: "store_id",
+                  type: "type",
+                }),
+              ),
               Schema.Struct({
                 dataset: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("analytics_engine"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("assets"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("browser"),
               }),
               Schema.Struct({
                 id: Schema.String,
@@ -3800,43 +3831,9 @@ export const PatchDispatchNamespaceScriptSettingRequest =
                 ),
               }),
               Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("durable_object_namespace"),
-                className: Schema.optional(Schema.String),
-                environment: Schema.optional(Schema.String),
-                namespaceId: Schema.optional(Schema.String),
-                scriptName: Schema.optional(Schema.String),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  className: "class_name",
-                  environment: "environment",
-                  namespaceId: "namespace_id",
-                  scriptName: "script_name",
-                }),
-              ),
-              Schema.Struct({
                 id: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("hyperdrive"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("inherit"),
-                oldName: Schema.optional(Schema.String),
-                versionId: Schema.optional(Schema.String),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  oldName: "old_name",
-                  versionId: "version_id",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("images"),
               }),
               Schema.Struct({
                 json: Schema.String,
@@ -3908,25 +3905,6 @@ export const PatchDispatchNamespaceScriptSettingRequest =
               }),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("send_email"),
-                allowedDestinationAddresses: Schema.optional(
-                  Schema.Array(Schema.String),
-                ),
-                allowedSenderAddresses: Schema.optional(
-                  Schema.Array(Schema.String),
-                ),
-                destinationAddress: Schema.optional(Schema.String),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  allowedDestinationAddresses: "allowed_destination_addresses",
-                  allowedSenderAddresses: "allowed_sender_addresses",
-                  destinationAddress: "destination_address",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
                 service: Schema.String,
                 type: Schema.Literal("service"),
                 environment: Schema.optional(Schema.String),
@@ -3949,53 +3927,6 @@ export const PatchDispatchNamespaceScriptSettingRequest =
               ),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("version_metadata"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                secretName: Schema.String,
-                storeId: Schema.String,
-                type: Schema.Literal("secrets_store_secret"),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  secretName: "secret_name",
-                  storeId: "store_id",
-                  type: "type",
-                }),
-              ),
-              Schema.Struct({
-                algorithm: Schema.Unknown,
-                format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-                name: Schema.String,
-                type: Schema.Literal("secret_key"),
-                usages: Schema.Array(
-                  Schema.Literals([
-                    "encrypt",
-                    "decrypt",
-                    "sign",
-                    "verify",
-                    "deriveKey",
-                    "deriveBits",
-                    "wrapKey",
-                    "unwrapKey",
-                  ]),
-                ),
-                keyBase64: Schema.optional(Schema.String),
-                keyJwk: Schema.optional(Schema.Unknown),
-              }).pipe(
-                Schema.encodeKeys({
-                  algorithm: "algorithm",
-                  format: "format",
-                  name: "name",
-                  type: "type",
-                  usages: "usages",
-                  keyBase64: "key_base64",
-                  keyJwk: "key_jwk",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
                 type: Schema.Literal("workflow"),
                 workflowName: Schema.String,
                 className: Schema.optional(Schema.String),
@@ -4013,6 +3944,75 @@ export const PatchDispatchNamespaceScriptSettingRequest =
                 name: Schema.String,
                 part: Schema.String,
                 type: Schema.Literal("wasm_module"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("ai"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("assets"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("browser"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("durable_object_namespace"),
+                className: Schema.optional(Schema.String),
+                environment: Schema.optional(Schema.String),
+                namespaceId: Schema.optional(Schema.String),
+                scriptName: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  className: "class_name",
+                  environment: "environment",
+                  namespaceId: "namespace_id",
+                  scriptName: "script_name",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("inherit"),
+                oldName: Schema.optional(Schema.String),
+                versionId: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  oldName: "old_name",
+                  versionId: "version_id",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("images"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("send_email"),
+                allowedDestinationAddresses: Schema.optional(
+                  Schema.Array(Schema.String),
+                ),
+                allowedSenderAddresses: Schema.optional(
+                  Schema.Array(Schema.String),
+                ),
+                destinationAddress: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  allowedDestinationAddresses: "allowed_destination_addresses",
+                  allowedSenderAddresses: "allowed_sender_addresses",
+                  destinationAddress: "destination_address",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("version_metadata"),
               }),
             ]),
           ),
@@ -4364,21 +4364,40 @@ export const PatchDispatchNamespaceScriptSettingResponse =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              algorithm: Schema.Unknown,
+              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
               name: Schema.String,
-              type: Schema.Literal("ai"),
+              type: Schema.Literal("secret_key"),
+              usages: Schema.Array(
+                Schema.Literals([
+                  "encrypt",
+                  "decrypt",
+                  "sign",
+                  "verify",
+                  "deriveKey",
+                  "deriveBits",
+                  "wrapKey",
+                  "unwrapKey",
+                ]),
+              ),
             }),
+            Schema.Struct({
+              name: Schema.String,
+              secretName: Schema.String,
+              storeId: Schema.String,
+              type: Schema.Literal("secrets_store_secret"),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                secretName: "secret_name",
+                storeId: "store_id",
+                type: "type",
+              }),
+            ),
             Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("assets"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("browser"),
             }),
             Schema.Struct({
               id: Schema.String,
@@ -4419,55 +4438,9 @@ export const PatchDispatchNamespaceScriptSettingResponse =
               ),
             }),
             Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              environment: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              namespaceId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              scriptName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
               id: Schema.String,
               name: Schema.String,
               type: Schema.Literal("hyperdrive"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("inherit"),
-              oldName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              versionId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                oldName: "old_name",
-                versionId: "version_id",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("images"),
             }),
             Schema.Struct({
               json: Schema.String,
@@ -4534,6 +4507,112 @@ export const PatchDispatchNamespaceScriptSettingResponse =
             ),
             Schema.Struct({
               name: Schema.String,
+              service: Schema.String,
+              type: Schema.Literal("service"),
+              environment: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              part: Schema.String,
+              type: Schema.Literal("text_blob"),
+            }),
+            Schema.Struct({
+              indexName: Schema.String,
+              name: Schema.String,
+              type: Schema.Literal("vectorize"),
+            }).pipe(
+              Schema.encodeKeys({
+                indexName: "index_name",
+                name: "name",
+                type: "type",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("workflow"),
+              workflowName: Schema.String,
+              className: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              scriptName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                workflowName: "workflow_name",
+                className: "class_name",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              part: Schema.String,
+              type: Schema.Literal("wasm_module"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("ai"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("assets"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("browser"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              environment: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              namespaceId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              scriptName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("inherit"),
+              oldName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              versionId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                oldName: "old_name",
+                versionId: "version_id",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("images"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
               type: Schema.Literal("secret_text"),
             }),
             Schema.Struct({
@@ -4559,86 +4638,7 @@ export const PatchDispatchNamespaceScriptSettingResponse =
             ),
             Schema.Struct({
               name: Schema.String,
-              service: Schema.String,
-              type: Schema.Literal("service"),
-              environment: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              part: Schema.String,
-              type: Schema.Literal("text_blob"),
-            }),
-            Schema.Struct({
-              indexName: Schema.String,
-              name: Schema.String,
-              type: Schema.Literal("vectorize"),
-            }).pipe(
-              Schema.encodeKeys({
-                indexName: "index_name",
-                name: "name",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               type: Schema.Literal("version_metadata"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              secretName: Schema.String,
-              storeId: Schema.String,
-              type: Schema.Literal("secrets_store_secret"),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                secretName: "secret_name",
-                storeId: "store_id",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              algorithm: Schema.Unknown,
-              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-              name: Schema.String,
-              type: Schema.Literal("secret_key"),
-              usages: Schema.Array(
-                Schema.Literals([
-                  "encrypt",
-                  "decrypt",
-                  "sign",
-                  "verify",
-                  "deriveKey",
-                  "deriveBits",
-                  "wrapKey",
-                  "unwrapKey",
-                ]),
-              ),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("workflow"),
-              workflowName: Schema.String,
-              className: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              scriptName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                workflowName: "workflow_name",
-                className: "class_name",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              part: Schema.String,
-              type: Schema.Literal("wasm_module"),
             }),
           ]),
         ),

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -1165,21 +1165,40 @@ export const GetBetaWorkerVersionResponse =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              algorithm: Schema.Unknown,
+              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
               name: Schema.String,
-              type: Schema.Literal("ai"),
+              type: Schema.Literal("secret_key"),
+              usages: Schema.Array(
+                Schema.Literals([
+                  "encrypt",
+                  "decrypt",
+                  "sign",
+                  "verify",
+                  "deriveKey",
+                  "deriveBits",
+                  "wrapKey",
+                  "unwrapKey",
+                ]),
+              ),
             }),
+            Schema.Struct({
+              name: Schema.String,
+              secretName: Schema.String,
+              storeId: Schema.String,
+              type: Schema.Literal("secrets_store_secret"),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                secretName: "secret_name",
+                storeId: "store_id",
+                type: "type",
+              }),
+            ),
             Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("assets"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("browser"),
             }),
             Schema.Struct({
               id: Schema.String,
@@ -1220,55 +1239,9 @@ export const GetBetaWorkerVersionResponse =
               ),
             }),
             Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              environment: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              namespaceId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              scriptName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
               id: Schema.String,
               name: Schema.String,
               type: Schema.Literal("hyperdrive"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("inherit"),
-              oldName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              versionId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                oldName: "old_name",
-                versionId: "version_id",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("images"),
             }),
             Schema.Struct({
               json: Schema.String,
@@ -1335,31 +1308,6 @@ export const GetBetaWorkerVersionResponse =
             ),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("secret_text"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("send_email"),
-              allowedDestinationAddresses: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              allowedSenderAddresses: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              destinationAddress: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                allowedDestinationAddresses: "allowed_destination_addresses",
-                allowedSenderAddresses: "allowed_sender_addresses",
-                destinationAddress: "destination_address",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               service: Schema.String,
               type: Schema.Literal("service"),
               environment: Schema.optional(
@@ -1382,41 +1330,6 @@ export const GetBetaWorkerVersionResponse =
                 type: "type",
               }),
             ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("version_metadata"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              secretName: Schema.String,
-              storeId: Schema.String,
-              type: Schema.Literal("secrets_store_secret"),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                secretName: "secret_name",
-                storeId: "store_id",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              algorithm: Schema.Unknown,
-              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-              name: Schema.String,
-              type: Schema.Literal("secret_key"),
-              usages: Schema.Array(
-                Schema.Literals([
-                  "encrypt",
-                  "decrypt",
-                  "sign",
-                  "verify",
-                  "deriveKey",
-                  "deriveBits",
-                  "wrapKey",
-                  "unwrapKey",
-                ]),
-              ),
-            }),
             Schema.Struct({
               name: Schema.String,
               type: Schema.Literal("workflow"),
@@ -1443,12 +1356,99 @@ export const GetBetaWorkerVersionResponse =
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("worker_loader"),
+              type: Schema.Literal("artifacts"),
+              namespace: Schema.String,
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("artifacts"),
-              namespace: Schema.String,
+              type: Schema.Literal("ai"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("assets"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("browser"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              environment: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              namespaceId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              scriptName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("inherit"),
+              oldName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              versionId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                oldName: "old_name",
+                versionId: "version_id",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("images"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("secret_text"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("send_email"),
+              allowedDestinationAddresses: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              allowedSenderAddresses: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              destinationAddress: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                allowedDestinationAddresses: "allowed_destination_addresses",
+                allowedSenderAddresses: "allowed_sender_addresses",
+                destinationAddress: "destination_address",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("version_metadata"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("worker_loader"),
             }),
           ]),
         ),
@@ -1906,21 +1906,40 @@ export const ListBetaWorkerVersionsResponse =
             Schema.Array(
               Schema.Union([
                 Schema.Struct({
+                  algorithm: Schema.Unknown,
+                  format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
                   name: Schema.String,
-                  type: Schema.Literal("ai"),
+                  type: Schema.Literal("secret_key"),
+                  usages: Schema.Array(
+                    Schema.Literals([
+                      "encrypt",
+                      "decrypt",
+                      "sign",
+                      "verify",
+                      "deriveKey",
+                      "deriveBits",
+                      "wrapKey",
+                      "unwrapKey",
+                    ]),
+                  ),
                 }),
+                Schema.Struct({
+                  name: Schema.String,
+                  secretName: Schema.String,
+                  storeId: Schema.String,
+                  type: Schema.Literal("secrets_store_secret"),
+                }).pipe(
+                  Schema.encodeKeys({
+                    name: "name",
+                    secretName: "secret_name",
+                    storeId: "store_id",
+                    type: "type",
+                  }),
+                ),
                 Schema.Struct({
                   dataset: Schema.String,
                   name: Schema.String,
                   type: Schema.Literal("analytics_engine"),
-                }),
-                Schema.Struct({
-                  name: Schema.String,
-                  type: Schema.Literal("assets"),
-                }),
-                Schema.Struct({
-                  name: Schema.String,
-                  type: Schema.Literal("browser"),
                 }),
                 Schema.Struct({
                   id: Schema.String,
@@ -1964,55 +1983,9 @@ export const ListBetaWorkerVersionsResponse =
                   ),
                 }),
                 Schema.Struct({
-                  name: Schema.String,
-                  type: Schema.Literal("durable_object_namespace"),
-                  className: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  environment: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  namespaceId: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  scriptName: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    name: "name",
-                    type: "type",
-                    className: "class_name",
-                    environment: "environment",
-                    namespaceId: "namespace_id",
-                    scriptName: "script_name",
-                  }),
-                ),
-                Schema.Struct({
                   id: Schema.String,
                   name: Schema.String,
                   type: Schema.Literal("hyperdrive"),
-                }),
-                Schema.Struct({
-                  name: Schema.String,
-                  type: Schema.Literal("inherit"),
-                  oldName: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  versionId: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    name: "name",
-                    type: "type",
-                    oldName: "old_name",
-                    versionId: "version_id",
-                  }),
-                ),
-                Schema.Struct({
-                  name: Schema.String,
-                  type: Schema.Literal("images"),
                 }),
                 Schema.Struct({
                   json: Schema.String,
@@ -2082,32 +2055,6 @@ export const ListBetaWorkerVersionsResponse =
                 ),
                 Schema.Struct({
                   name: Schema.String,
-                  type: Schema.Literal("secret_text"),
-                }),
-                Schema.Struct({
-                  name: Schema.String,
-                  type: Schema.Literal("send_email"),
-                  allowedDestinationAddresses: Schema.optional(
-                    Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                  ),
-                  allowedSenderAddresses: Schema.optional(
-                    Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                  ),
-                  destinationAddress: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    name: "name",
-                    type: "type",
-                    allowedDestinationAddresses:
-                      "allowed_destination_addresses",
-                    allowedSenderAddresses: "allowed_sender_addresses",
-                    destinationAddress: "destination_address",
-                  }),
-                ),
-                Schema.Struct({
-                  name: Schema.String,
                   service: Schema.String,
                   type: Schema.Literal("service"),
                   environment: Schema.optional(
@@ -2130,41 +2077,6 @@ export const ListBetaWorkerVersionsResponse =
                     type: "type",
                   }),
                 ),
-                Schema.Struct({
-                  name: Schema.String,
-                  type: Schema.Literal("version_metadata"),
-                }),
-                Schema.Struct({
-                  name: Schema.String,
-                  secretName: Schema.String,
-                  storeId: Schema.String,
-                  type: Schema.Literal("secrets_store_secret"),
-                }).pipe(
-                  Schema.encodeKeys({
-                    name: "name",
-                    secretName: "secret_name",
-                    storeId: "store_id",
-                    type: "type",
-                  }),
-                ),
-                Schema.Struct({
-                  algorithm: Schema.Unknown,
-                  format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-                  name: Schema.String,
-                  type: Schema.Literal("secret_key"),
-                  usages: Schema.Array(
-                    Schema.Literals([
-                      "encrypt",
-                      "decrypt",
-                      "sign",
-                      "verify",
-                      "deriveKey",
-                      "deriveBits",
-                      "wrapKey",
-                      "unwrapKey",
-                    ]),
-                  ),
-                }),
                 Schema.Struct({
                   name: Schema.String,
                   type: Schema.Literal("workflow"),
@@ -2191,12 +2103,100 @@ export const ListBetaWorkerVersionsResponse =
                 }),
                 Schema.Struct({
                   name: Schema.String,
-                  type: Schema.Literal("worker_loader"),
+                  type: Schema.Literal("artifacts"),
+                  namespace: Schema.String,
                 }),
                 Schema.Struct({
                   name: Schema.String,
-                  type: Schema.Literal("artifacts"),
-                  namespace: Schema.String,
+                  type: Schema.Literal("ai"),
+                }),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("assets"),
+                }),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("browser"),
+                }),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("durable_object_namespace"),
+                  className: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  environment: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  namespaceId: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  scriptName: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    name: "name",
+                    type: "type",
+                    className: "class_name",
+                    environment: "environment",
+                    namespaceId: "namespace_id",
+                    scriptName: "script_name",
+                  }),
+                ),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("inherit"),
+                  oldName: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  versionId: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    name: "name",
+                    type: "type",
+                    oldName: "old_name",
+                    versionId: "version_id",
+                  }),
+                ),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("images"),
+                }),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("secret_text"),
+                }),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("send_email"),
+                  allowedDestinationAddresses: Schema.optional(
+                    Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                  ),
+                  allowedSenderAddresses: Schema.optional(
+                    Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                  ),
+                  destinationAddress: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    name: "name",
+                    type: "type",
+                    allowedDestinationAddresses:
+                      "allowed_destination_addresses",
+                    allowedSenderAddresses: "allowed_sender_addresses",
+                    destinationAddress: "destination_address",
+                  }),
+                ),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("version_metadata"),
+                }),
+                Schema.Struct({
+                  name: Schema.String,
+                  type: Schema.Literal("worker_loader"),
                 }),
               ]),
             ),
@@ -2613,21 +2613,52 @@ export const CreateBetaWorkerVersionRequest =
       Schema.Array(
         Schema.Union([
           Schema.Struct({
+            algorithm: Schema.Unknown,
+            format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
             name: Schema.String,
-            type: Schema.Literal("ai"),
-          }),
+            type: Schema.Literal("secret_key"),
+            usages: Schema.Array(
+              Schema.Literals([
+                "encrypt",
+                "decrypt",
+                "sign",
+                "verify",
+                "deriveKey",
+                "deriveBits",
+                "wrapKey",
+                "unwrapKey",
+              ]),
+            ),
+            keyBase64: Schema.optional(Schema.String),
+            keyJwk: Schema.optional(Schema.Unknown),
+          }).pipe(
+            Schema.encodeKeys({
+              algorithm: "algorithm",
+              format: "format",
+              name: "name",
+              type: "type",
+              usages: "usages",
+              keyBase64: "key_base64",
+              keyJwk: "key_jwk",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            secretName: Schema.String,
+            storeId: Schema.String,
+            type: Schema.Literal("secrets_store_secret"),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              secretName: "secret_name",
+              storeId: "store_id",
+              type: "type",
+            }),
+          ),
           Schema.Struct({
             dataset: Schema.String,
             name: Schema.String,
             type: Schema.Literal("analytics_engine"),
-          }),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("assets"),
-          }),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("browser"),
           }),
           Schema.Struct({
             id: Schema.String,
@@ -2656,43 +2687,9 @@ export const CreateBetaWorkerVersionRequest =
             ),
           }),
           Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("durable_object_namespace"),
-            className: Schema.optional(Schema.String),
-            environment: Schema.optional(Schema.String),
-            namespaceId: Schema.optional(Schema.String),
-            scriptName: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              className: "class_name",
-              environment: "environment",
-              namespaceId: "namespace_id",
-              scriptName: "script_name",
-            }),
-          ),
-          Schema.Struct({
             id: Schema.String,
             name: Schema.String,
             type: Schema.Literal("hyperdrive"),
-          }),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("inherit"),
-            oldName: Schema.optional(Schema.String),
-            versionId: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              oldName: "old_name",
-              versionId: "version_id",
-            }),
-          ),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("images"),
           }),
           Schema.Struct({
             json: Schema.String,
@@ -2762,25 +2759,6 @@ export const CreateBetaWorkerVersionRequest =
           }),
           Schema.Struct({
             name: Schema.String,
-            type: Schema.Literal("send_email"),
-            allowedDestinationAddresses: Schema.optional(
-              Schema.Array(Schema.String),
-            ),
-            allowedSenderAddresses: Schema.optional(
-              Schema.Array(Schema.String),
-            ),
-            destinationAddress: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              allowedDestinationAddresses: "allowed_destination_addresses",
-              allowedSenderAddresses: "allowed_sender_addresses",
-              destinationAddress: "destination_address",
-            }),
-          ),
-          Schema.Struct({
-            name: Schema.String,
             service: Schema.String,
             type: Schema.Literal("service"),
             environment: Schema.optional(Schema.String),
@@ -2799,53 +2777,6 @@ export const CreateBetaWorkerVersionRequest =
               indexName: "index_name",
               name: "name",
               type: "type",
-            }),
-          ),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("version_metadata"),
-          }),
-          Schema.Struct({
-            name: Schema.String,
-            secretName: Schema.String,
-            storeId: Schema.String,
-            type: Schema.Literal("secrets_store_secret"),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              secretName: "secret_name",
-              storeId: "store_id",
-              type: "type",
-            }),
-          ),
-          Schema.Struct({
-            algorithm: Schema.Unknown,
-            format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-            name: Schema.String,
-            type: Schema.Literal("secret_key"),
-            usages: Schema.Array(
-              Schema.Literals([
-                "encrypt",
-                "decrypt",
-                "sign",
-                "verify",
-                "deriveKey",
-                "deriveBits",
-                "wrapKey",
-                "unwrapKey",
-              ]),
-            ),
-            keyBase64: Schema.optional(Schema.String),
-            keyJwk: Schema.optional(Schema.Unknown),
-          }).pipe(
-            Schema.encodeKeys({
-              algorithm: "algorithm",
-              format: "format",
-              name: "name",
-              type: "type",
-              usages: "usages",
-              keyBase64: "key_base64",
-              keyJwk: "key_jwk",
             }),
           ),
           Schema.Struct({
@@ -2870,12 +2801,81 @@ export const CreateBetaWorkerVersionRequest =
           }),
           Schema.Struct({
             name: Schema.String,
-            type: Schema.Literal("worker_loader"),
+            type: Schema.Literal("artifacts"),
+            namespace: Schema.String,
           }),
           Schema.Struct({
             name: Schema.String,
-            type: Schema.Literal("artifacts"),
-            namespace: Schema.String,
+            type: Schema.Literal("ai"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("assets"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("browser"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("durable_object_namespace"),
+            className: Schema.optional(Schema.String),
+            environment: Schema.optional(Schema.String),
+            namespaceId: Schema.optional(Schema.String),
+            scriptName: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              className: "class_name",
+              environment: "environment",
+              namespaceId: "namespace_id",
+              scriptName: "script_name",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("inherit"),
+            oldName: Schema.optional(Schema.String),
+            versionId: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              oldName: "old_name",
+              versionId: "version_id",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("images"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("send_email"),
+            allowedDestinationAddresses: Schema.optional(
+              Schema.Array(Schema.String),
+            ),
+            allowedSenderAddresses: Schema.optional(
+              Schema.Array(Schema.String),
+            ),
+            destinationAddress: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              allowedDestinationAddresses: "allowed_destination_addresses",
+              allowedSenderAddresses: "allowed_sender_addresses",
+              destinationAddress: "destination_address",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("version_metadata"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("worker_loader"),
           }),
         ]),
       ),
@@ -3279,21 +3279,40 @@ export const CreateBetaWorkerVersionResponse =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              algorithm: Schema.Unknown,
+              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
               name: Schema.String,
-              type: Schema.Literal("ai"),
+              type: Schema.Literal("secret_key"),
+              usages: Schema.Array(
+                Schema.Literals([
+                  "encrypt",
+                  "decrypt",
+                  "sign",
+                  "verify",
+                  "deriveKey",
+                  "deriveBits",
+                  "wrapKey",
+                  "unwrapKey",
+                ]),
+              ),
             }),
+            Schema.Struct({
+              name: Schema.String,
+              secretName: Schema.String,
+              storeId: Schema.String,
+              type: Schema.Literal("secrets_store_secret"),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                secretName: "secret_name",
+                storeId: "store_id",
+                type: "type",
+              }),
+            ),
             Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("assets"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("browser"),
             }),
             Schema.Struct({
               id: Schema.String,
@@ -3334,55 +3353,9 @@ export const CreateBetaWorkerVersionResponse =
               ),
             }),
             Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              environment: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              namespaceId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              scriptName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
               id: Schema.String,
               name: Schema.String,
               type: Schema.Literal("hyperdrive"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("inherit"),
-              oldName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              versionId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                oldName: "old_name",
-                versionId: "version_id",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("images"),
             }),
             Schema.Struct({
               json: Schema.String,
@@ -3449,31 +3422,6 @@ export const CreateBetaWorkerVersionResponse =
             ),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("secret_text"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("send_email"),
-              allowedDestinationAddresses: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              allowedSenderAddresses: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              destinationAddress: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                allowedDestinationAddresses: "allowed_destination_addresses",
-                allowedSenderAddresses: "allowed_sender_addresses",
-                destinationAddress: "destination_address",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               service: Schema.String,
               type: Schema.Literal("service"),
               environment: Schema.optional(
@@ -3496,41 +3444,6 @@ export const CreateBetaWorkerVersionResponse =
                 type: "type",
               }),
             ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("version_metadata"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              secretName: Schema.String,
-              storeId: Schema.String,
-              type: Schema.Literal("secrets_store_secret"),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                secretName: "secret_name",
-                storeId: "store_id",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              algorithm: Schema.Unknown,
-              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-              name: Schema.String,
-              type: Schema.Literal("secret_key"),
-              usages: Schema.Array(
-                Schema.Literals([
-                  "encrypt",
-                  "decrypt",
-                  "sign",
-                  "verify",
-                  "deriveKey",
-                  "deriveBits",
-                  "wrapKey",
-                  "unwrapKey",
-                ]),
-              ),
-            }),
             Schema.Struct({
               name: Schema.String,
               type: Schema.Literal("workflow"),
@@ -3557,12 +3470,99 @@ export const CreateBetaWorkerVersionResponse =
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("worker_loader"),
+              type: Schema.Literal("artifacts"),
+              namespace: Schema.String,
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("artifacts"),
-              namespace: Schema.String,
+              type: Schema.Literal("ai"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("assets"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("browser"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              environment: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              namespaceId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              scriptName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("inherit"),
+              oldName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              versionId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                oldName: "old_name",
+                versionId: "version_id",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("images"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("secret_text"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("send_email"),
+              allowedDestinationAddresses: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              allowedSenderAddresses: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              destinationAddress: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                allowedDestinationAddresses: "allowed_destination_addresses",
+                allowedSenderAddresses: "allowed_sender_addresses",
+                destinationAddress: "destination_address",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("version_metadata"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("worker_loader"),
             }),
           ]),
         ),
@@ -5425,62 +5425,6 @@ export const QueryObservabilityTelemetryResponse =
                     Schema.Union([
                       Schema.Union([
                         Schema.Struct({
-                          eventType: Schema.Literals([
-                            "fetch",
-                            "scheduled",
-                            "alarm",
-                            "cron",
-                            "queue",
-                            "email",
-                            "tail",
-                            "rpc",
-                            "websocket",
-                            "unknown",
-                          ]),
-                          requestId: Schema.String,
-                          scriptName: Schema.String,
-                          durableObjectId: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                          entrypoint: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                          event: Schema.optional(
-                            Schema.Union([
-                              Schema.Record(Schema.String, Schema.Unknown),
-                              Schema.Null,
-                            ]),
-                          ),
-                          executionModel: Schema.optional(
-                            Schema.Union([
-                              Schema.Literals(["durableObject", "stateless"]),
-                              Schema.Null,
-                            ]),
-                          ),
-                          outcome: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                          scriptVersion: Schema.optional(
-                            Schema.Union([
-                              Schema.Struct({
-                                id: Schema.optional(
-                                  Schema.Union([Schema.String, Schema.Null]),
-                                ),
-                                message: Schema.optional(
-                                  Schema.Union([Schema.String, Schema.Null]),
-                                ),
-                                tag: Schema.optional(
-                                  Schema.Union([Schema.String, Schema.Null]),
-                                ),
-                              }),
-                              Schema.Null,
-                            ]),
-                          ),
-                          truncated: Schema.optional(
-                            Schema.Union([Schema.Boolean, Schema.Null]),
-                          ),
-                        }),
-                        Schema.Struct({
                           cpuTimeMs: Schema.Number,
                           eventType: Schema.Literals([
                             "fetch",
@@ -5530,6 +5474,62 @@ export const QueryObservabilityTelemetryResponse =
                               Schema.Literals(["durableObject", "stateless"]),
                               Schema.Null,
                             ]),
+                          ),
+                          scriptVersion: Schema.optional(
+                            Schema.Union([
+                              Schema.Struct({
+                                id: Schema.optional(
+                                  Schema.Union([Schema.String, Schema.Null]),
+                                ),
+                                message: Schema.optional(
+                                  Schema.Union([Schema.String, Schema.Null]),
+                                ),
+                                tag: Schema.optional(
+                                  Schema.Union([Schema.String, Schema.Null]),
+                                ),
+                              }),
+                              Schema.Null,
+                            ]),
+                          ),
+                          truncated: Schema.optional(
+                            Schema.Union([Schema.Boolean, Schema.Null]),
+                          ),
+                        }),
+                        Schema.Struct({
+                          eventType: Schema.Literals([
+                            "fetch",
+                            "scheduled",
+                            "alarm",
+                            "cron",
+                            "queue",
+                            "email",
+                            "tail",
+                            "rpc",
+                            "websocket",
+                            "unknown",
+                          ]),
+                          requestId: Schema.String,
+                          scriptName: Schema.String,
+                          durableObjectId: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                          entrypoint: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                          event: Schema.optional(
+                            Schema.Union([
+                              Schema.Record(Schema.String, Schema.Unknown),
+                              Schema.Null,
+                            ]),
+                          ),
+                          executionModel: Schema.optional(
+                            Schema.Union([
+                              Schema.Literals(["durableObject", "stateless"]),
+                              Schema.Null,
+                            ]),
+                          ),
+                          outcome: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
                           ),
                           scriptVersion: Schema.optional(
                             Schema.Union([
@@ -6719,21 +6719,52 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       Schema.Array(
         Schema.Union([
           Schema.Struct({
+            algorithm: Schema.Unknown,
+            format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
             name: Schema.String,
-            type: Schema.Literal("ai"),
-          }),
+            type: Schema.Literal("secret_key"),
+            usages: Schema.Array(
+              Schema.Literals([
+                "encrypt",
+                "decrypt",
+                "sign",
+                "verify",
+                "deriveKey",
+                "deriveBits",
+                "wrapKey",
+                "unwrapKey",
+              ]),
+            ),
+            keyBase64: Schema.optional(Schema.String),
+            keyJwk: Schema.optional(Schema.Unknown),
+          }).pipe(
+            Schema.encodeKeys({
+              algorithm: "algorithm",
+              format: "format",
+              name: "name",
+              type: "type",
+              usages: "usages",
+              keyBase64: "key_base64",
+              keyJwk: "key_jwk",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            secretName: Schema.String,
+            storeId: Schema.String,
+            type: Schema.Literal("secrets_store_secret"),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              secretName: "secret_name",
+              storeId: "store_id",
+              type: "type",
+            }),
+          ),
           Schema.Struct({
             dataset: Schema.String,
             name: Schema.String,
             type: Schema.Literal("analytics_engine"),
-          }),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("assets"),
-          }),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("browser"),
           }),
           Schema.Struct({
             id: Schema.String,
@@ -6762,43 +6793,9 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             ),
           }),
           Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("durable_object_namespace"),
-            className: Schema.optional(Schema.String),
-            environment: Schema.optional(Schema.String),
-            namespaceId: Schema.optional(Schema.String),
-            scriptName: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              className: "class_name",
-              environment: "environment",
-              namespaceId: "namespace_id",
-              scriptName: "script_name",
-            }),
-          ),
-          Schema.Struct({
             id: Schema.String,
             name: Schema.String,
             type: Schema.Literal("hyperdrive"),
-          }),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("inherit"),
-            oldName: Schema.optional(Schema.String),
-            versionId: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              oldName: "old_name",
-              versionId: "version_id",
-            }),
-          ),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("images"),
           }),
           Schema.Struct({
             json: Schema.String,
@@ -6868,25 +6865,6 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           }),
           Schema.Struct({
             name: Schema.String,
-            type: Schema.Literal("send_email"),
-            allowedDestinationAddresses: Schema.optional(
-              Schema.Array(Schema.String),
-            ),
-            allowedSenderAddresses: Schema.optional(
-              Schema.Array(Schema.String),
-            ),
-            destinationAddress: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              allowedDestinationAddresses: "allowed_destination_addresses",
-              allowedSenderAddresses: "allowed_sender_addresses",
-              destinationAddress: "destination_address",
-            }),
-          ),
-          Schema.Struct({
-            name: Schema.String,
             service: Schema.String,
             type: Schema.Literal("service"),
             environment: Schema.optional(Schema.String),
@@ -6905,53 +6883,6 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
               indexName: "index_name",
               name: "name",
               type: "type",
-            }),
-          ),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("version_metadata"),
-          }),
-          Schema.Struct({
-            name: Schema.String,
-            secretName: Schema.String,
-            storeId: Schema.String,
-            type: Schema.Literal("secrets_store_secret"),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              secretName: "secret_name",
-              storeId: "store_id",
-              type: "type",
-            }),
-          ),
-          Schema.Struct({
-            algorithm: Schema.Unknown,
-            format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-            name: Schema.String,
-            type: Schema.Literal("secret_key"),
-            usages: Schema.Array(
-              Schema.Literals([
-                "encrypt",
-                "decrypt",
-                "sign",
-                "verify",
-                "deriveKey",
-                "deriveBits",
-                "wrapKey",
-                "unwrapKey",
-              ]),
-            ),
-            keyBase64: Schema.optional(Schema.String),
-            keyJwk: Schema.optional(Schema.Unknown),
-          }).pipe(
-            Schema.encodeKeys({
-              algorithm: "algorithm",
-              format: "format",
-              name: "name",
-              type: "type",
-              usages: "usages",
-              keyBase64: "key_base64",
-              keyJwk: "key_jwk",
             }),
           ),
           Schema.Struct({
@@ -6976,12 +6907,81 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           }),
           Schema.Struct({
             name: Schema.String,
-            type: Schema.Literal("worker_loader"),
+            type: Schema.Literal("artifacts"),
+            namespace: Schema.String,
           }),
           Schema.Struct({
             name: Schema.String,
-            type: Schema.Literal("artifacts"),
-            namespace: Schema.String,
+            type: Schema.Literal("ai"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("assets"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("browser"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("durable_object_namespace"),
+            className: Schema.optional(Schema.String),
+            environment: Schema.optional(Schema.String),
+            namespaceId: Schema.optional(Schema.String),
+            scriptName: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              className: "class_name",
+              environment: "environment",
+              namespaceId: "namespace_id",
+              scriptName: "script_name",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("inherit"),
+            oldName: Schema.optional(Schema.String),
+            versionId: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              oldName: "old_name",
+              versionId: "version_id",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("images"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("send_email"),
+            allowedDestinationAddresses: Schema.optional(
+              Schema.Array(Schema.String),
+            ),
+            allowedSenderAddresses: Schema.optional(
+              Schema.Array(Schema.String),
+            ),
+            destinationAddress: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              allowedDestinationAddresses: "allowed_destination_addresses",
+              allowedSenderAddresses: "allowed_sender_addresses",
+              destinationAddress: "destination_address",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("version_metadata"),
+          }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("worker_loader"),
           }),
         ]),
       ),
@@ -8838,6 +8838,52 @@ export const CreateScriptEdgePreviewRequest =
           Schema.Array(
             Schema.Union([
               Schema.Struct({
+                type: Schema.Literal("workflow"),
+                name: Schema.String,
+                workflowName: Schema.String,
+                className: Schema.String,
+                scriptName: Schema.optional(Schema.String),
+                raw: Schema.optional(Schema.Boolean),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  workflowName: "workflow_name",
+                  className: "class_name",
+                  scriptName: "script_name",
+                  raw: "raw",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("secrets_store_secret"),
+                name: Schema.String,
+                storeId: Schema.String,
+                secretName: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  storeId: "store_id",
+                  secretName: "secret_name",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("ratelimit"),
+                name: Schema.String,
+                namespaceId: Schema.String,
+                simple: Schema.Struct({
+                  limit: Schema.Number,
+                  period: Schema.Literals(["10", "60"]),
+                }),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  namespaceId: "namespace_id",
+                  simple: "simple",
+                }),
+              ),
+              Schema.Struct({
                 type: Schema.Literal("plain_text"),
                 name: Schema.String,
                 text: Schema.String,
@@ -8926,22 +8972,6 @@ export const CreateScriptEdgePreviewRequest =
                 entrypoint: Schema.optional(Schema.String),
               }),
               Schema.Struct({
-                type: Schema.Literal("ai"),
-                name: Schema.String,
-                staging: Schema.optional(Schema.Boolean),
-                raw: Schema.optional(Schema.Boolean),
-              }),
-              Schema.Struct({
-                type: Schema.Literal("browser"),
-                name: Schema.String,
-                raw: Schema.optional(Schema.Boolean),
-              }),
-              Schema.Struct({
-                type: Schema.Literal("images"),
-                name: Schema.String,
-                raw: Schema.optional(Schema.Boolean),
-              }),
-              Schema.Struct({
                 type: Schema.Literal("vectorize"),
                 name: Schema.String,
                 indexName: Schema.String,
@@ -8955,31 +8985,9 @@ export const CreateScriptEdgePreviewRequest =
                 }),
               ),
               Schema.Struct({
-                type: Schema.Literal("workflow"),
-                name: Schema.String,
-                workflowName: Schema.String,
-                className: Schema.String,
-                scriptName: Schema.optional(Schema.String),
-                raw: Schema.optional(Schema.Boolean),
-              }).pipe(
-                Schema.encodeKeys({
-                  type: "type",
-                  name: "name",
-                  workflowName: "workflow_name",
-                  className: "class_name",
-                  scriptName: "script_name",
-                  raw: "raw",
-                }),
-              ),
-              Schema.Struct({
                 type: Schema.Literal("hyperdrive"),
                 name: Schema.String,
                 id: Schema.String,
-              }),
-              Schema.Struct({
-                type: Schema.Literal("analytics_engine"),
-                name: Schema.String,
-                dataset: Schema.optional(Schema.String),
               }),
               Schema.Struct({
                 type: Schema.Literal("dispatch_namespace"),
@@ -9003,25 +9011,6 @@ export const CreateScriptEdgePreviewRequest =
                   }),
                 ),
               }),
-              Schema.Struct({
-                type: Schema.Literal("send_email"),
-                name: Schema.String,
-                destinationAddress: Schema.optional(Schema.String),
-                allowedDestinationAddresses: Schema.optional(
-                  Schema.Array(Schema.String),
-                ),
-                allowedSenderAddresses: Schema.optional(
-                  Schema.Array(Schema.String),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  type: "type",
-                  name: "name",
-                  destinationAddress: "destination_address",
-                  allowedDestinationAddresses: "allowed_destination_addresses",
-                  allowedSenderAddresses: "allowed_sender_addresses",
-                }),
-              ),
               Schema.Struct({
                 type: Schema.Literal("mtls_certificate"),
                 name: Schema.String,
@@ -9054,16 +9043,64 @@ export const CreateScriptEdgePreviewRequest =
                 pipeline: Schema.String,
               }),
               Schema.Struct({
-                type: Schema.Literal("secrets_store_secret"),
+                type: Schema.Literal("logfwdr"),
                 name: Schema.String,
-                storeId: Schema.String,
-                secretName: Schema.String,
+                destination: Schema.String,
+              }),
+              Schema.Struct({
+                type: Schema.Literal("ai_search_namespace"),
+                name: Schema.String,
+                namespace: Schema.String,
+              }),
+              Schema.Struct({
+                type: Schema.Literal("ai_search"),
+                name: Schema.String,
+                instanceName: Schema.String,
               }).pipe(
                 Schema.encodeKeys({
                   type: "type",
                   name: "name",
-                  storeId: "store_id",
-                  secretName: "secret_name",
+                  instanceName: "instance_name",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("ai"),
+                name: Schema.String,
+                staging: Schema.optional(Schema.Boolean),
+                raw: Schema.optional(Schema.Boolean),
+              }),
+              Schema.Struct({
+                type: Schema.Literal("browser"),
+                name: Schema.String,
+                raw: Schema.optional(Schema.Boolean),
+              }),
+              Schema.Struct({
+                type: Schema.Literal("images"),
+                name: Schema.String,
+                raw: Schema.optional(Schema.Boolean),
+              }),
+              Schema.Struct({
+                type: Schema.Literal("analytics_engine"),
+                name: Schema.String,
+                dataset: Schema.optional(Schema.String),
+              }),
+              Schema.Struct({
+                type: Schema.Literal("send_email"),
+                name: Schema.String,
+                destinationAddress: Schema.optional(Schema.String),
+                allowedDestinationAddresses: Schema.optional(
+                  Schema.Array(Schema.String),
+                ),
+                allowedSenderAddresses: Schema.optional(
+                  Schema.Array(Schema.String),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  destinationAddress: "destination_address",
+                  allowedDestinationAddresses: "allowed_destination_addresses",
+                  allowedSenderAddresses: "allowed_sender_addresses",
                 }),
               ),
               Schema.Struct({
@@ -9086,43 +9123,6 @@ export const CreateScriptEdgePreviewRequest =
                 type: Schema.Literal("worker_loader"),
                 name: Schema.String,
               }),
-              Schema.Struct({
-                type: Schema.Literal("logfwdr"),
-                name: Schema.String,
-                destination: Schema.String,
-              }),
-              Schema.Struct({
-                type: Schema.Literal("ai_search_namespace"),
-                name: Schema.String,
-                namespace: Schema.String,
-              }),
-              Schema.Struct({
-                type: Schema.Literal("ai_search"),
-                name: Schema.String,
-                instanceName: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  type: "type",
-                  name: "name",
-                  instanceName: "instance_name",
-                }),
-              ),
-              Schema.Struct({
-                type: Schema.Literal("ratelimit"),
-                name: Schema.String,
-                namespaceId: Schema.String,
-                simple: Schema.Struct({
-                  limit: Schema.Number,
-                  period: Schema.Literals(["10", "60"]),
-                }),
-              }).pipe(
-                Schema.encodeKeys({
-                  type: "type",
-                  name: "name",
-                  namespaceId: "namespace_id",
-                  simple: "simple",
-                }),
-              ),
               Schema.Struct({
                 type: Schema.Literal("inherit"),
                 name: Schema.String,
@@ -9686,21 +9686,40 @@ export const GetScriptScriptAndVersionSettingResponse =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              algorithm: Schema.Unknown,
+              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
               name: Schema.String,
-              type: Schema.Literal("ai"),
+              type: Schema.Literal("secret_key"),
+              usages: Schema.Array(
+                Schema.Literals([
+                  "encrypt",
+                  "decrypt",
+                  "sign",
+                  "verify",
+                  "deriveKey",
+                  "deriveBits",
+                  "wrapKey",
+                  "unwrapKey",
+                ]),
+              ),
             }),
+            Schema.Struct({
+              name: Schema.String,
+              secretName: Schema.String,
+              storeId: Schema.String,
+              type: Schema.Literal("secrets_store_secret"),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                secretName: "secret_name",
+                storeId: "store_id",
+                type: "type",
+              }),
+            ),
             Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("assets"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("browser"),
             }),
             Schema.Struct({
               id: Schema.String,
@@ -9741,55 +9760,9 @@ export const GetScriptScriptAndVersionSettingResponse =
               ),
             }),
             Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              environment: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              namespaceId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              scriptName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
               id: Schema.String,
               name: Schema.String,
               type: Schema.Literal("hyperdrive"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("inherit"),
-              oldName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              versionId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                oldName: "old_name",
-                versionId: "version_id",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("images"),
             }),
             Schema.Struct({
               json: Schema.String,
@@ -9856,31 +9829,6 @@ export const GetScriptScriptAndVersionSettingResponse =
             ),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("secret_text"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("send_email"),
-              allowedDestinationAddresses: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              allowedSenderAddresses: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              destinationAddress: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                allowedDestinationAddresses: "allowed_destination_addresses",
-                allowedSenderAddresses: "allowed_sender_addresses",
-                destinationAddress: "destination_address",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               service: Schema.String,
               type: Schema.Literal("service"),
               environment: Schema.optional(
@@ -9903,41 +9851,6 @@ export const GetScriptScriptAndVersionSettingResponse =
                 type: "type",
               }),
             ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("version_metadata"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              secretName: Schema.String,
-              storeId: Schema.String,
-              type: Schema.Literal("secrets_store_secret"),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                secretName: "secret_name",
-                storeId: "store_id",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              algorithm: Schema.Unknown,
-              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-              name: Schema.String,
-              type: Schema.Literal("secret_key"),
-              usages: Schema.Array(
-                Schema.Literals([
-                  "encrypt",
-                  "decrypt",
-                  "sign",
-                  "verify",
-                  "deriveKey",
-                  "deriveBits",
-                  "wrapKey",
-                  "unwrapKey",
-                ]),
-              ),
-            }),
             Schema.Struct({
               name: Schema.String,
               type: Schema.Literal("workflow"),
@@ -9964,12 +9877,99 @@ export const GetScriptScriptAndVersionSettingResponse =
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("worker_loader"),
+              type: Schema.Literal("artifacts"),
+              namespace: Schema.String,
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("artifacts"),
-              namespace: Schema.String,
+              type: Schema.Literal("ai"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("assets"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("browser"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              environment: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              namespaceId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              scriptName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("inherit"),
+              oldName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              versionId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                oldName: "old_name",
+                versionId: "version_id",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("images"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("secret_text"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("send_email"),
+              allowedDestinationAddresses: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              allowedSenderAddresses: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              destinationAddress: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                allowedDestinationAddresses: "allowed_destination_addresses",
+                allowedSenderAddresses: "allowed_sender_addresses",
+                destinationAddress: "destination_address",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("version_metadata"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("worker_loader"),
             }),
           ]),
         ),
@@ -10253,21 +10253,52 @@ export const PatchScriptScriptAndVersionSettingRequest =
           Schema.Array(
             Schema.Union([
               Schema.Struct({
+                algorithm: Schema.Unknown,
+                format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
                 name: Schema.String,
-                type: Schema.Literal("ai"),
-              }),
+                type: Schema.Literal("secret_key"),
+                usages: Schema.Array(
+                  Schema.Literals([
+                    "encrypt",
+                    "decrypt",
+                    "sign",
+                    "verify",
+                    "deriveKey",
+                    "deriveBits",
+                    "wrapKey",
+                    "unwrapKey",
+                  ]),
+                ),
+                keyBase64: Schema.optional(Schema.String),
+                keyJwk: Schema.optional(Schema.Unknown),
+              }).pipe(
+                Schema.encodeKeys({
+                  algorithm: "algorithm",
+                  format: "format",
+                  name: "name",
+                  type: "type",
+                  usages: "usages",
+                  keyBase64: "key_base64",
+                  keyJwk: "key_jwk",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                secretName: Schema.String,
+                storeId: Schema.String,
+                type: Schema.Literal("secrets_store_secret"),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  secretName: "secret_name",
+                  storeId: "store_id",
+                  type: "type",
+                }),
+              ),
               Schema.Struct({
                 dataset: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("analytics_engine"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("assets"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("browser"),
               }),
               Schema.Struct({
                 id: Schema.String,
@@ -10296,43 +10327,9 @@ export const PatchScriptScriptAndVersionSettingRequest =
                 ),
               }),
               Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("durable_object_namespace"),
-                className: Schema.optional(Schema.String),
-                environment: Schema.optional(Schema.String),
-                namespaceId: Schema.optional(Schema.String),
-                scriptName: Schema.optional(Schema.String),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  className: "class_name",
-                  environment: "environment",
-                  namespaceId: "namespace_id",
-                  scriptName: "script_name",
-                }),
-              ),
-              Schema.Struct({
                 id: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("hyperdrive"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("inherit"),
-                oldName: Schema.optional(Schema.String),
-                versionId: Schema.optional(Schema.String),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  oldName: "old_name",
-                  versionId: "version_id",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("images"),
               }),
               Schema.Struct({
                 json: Schema.String,
@@ -10404,25 +10401,6 @@ export const PatchScriptScriptAndVersionSettingRequest =
               }),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("send_email"),
-                allowedDestinationAddresses: Schema.optional(
-                  Schema.Array(Schema.String),
-                ),
-                allowedSenderAddresses: Schema.optional(
-                  Schema.Array(Schema.String),
-                ),
-                destinationAddress: Schema.optional(Schema.String),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  allowedDestinationAddresses: "allowed_destination_addresses",
-                  allowedSenderAddresses: "allowed_sender_addresses",
-                  destinationAddress: "destination_address",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
                 service: Schema.String,
                 type: Schema.Literal("service"),
                 environment: Schema.optional(Schema.String),
@@ -10441,53 +10419,6 @@ export const PatchScriptScriptAndVersionSettingRequest =
                   indexName: "index_name",
                   name: "name",
                   type: "type",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("version_metadata"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                secretName: Schema.String,
-                storeId: Schema.String,
-                type: Schema.Literal("secrets_store_secret"),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  secretName: "secret_name",
-                  storeId: "store_id",
-                  type: "type",
-                }),
-              ),
-              Schema.Struct({
-                algorithm: Schema.Unknown,
-                format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-                name: Schema.String,
-                type: Schema.Literal("secret_key"),
-                usages: Schema.Array(
-                  Schema.Literals([
-                    "encrypt",
-                    "decrypt",
-                    "sign",
-                    "verify",
-                    "deriveKey",
-                    "deriveBits",
-                    "wrapKey",
-                    "unwrapKey",
-                  ]),
-                ),
-                keyBase64: Schema.optional(Schema.String),
-                keyJwk: Schema.optional(Schema.Unknown),
-              }).pipe(
-                Schema.encodeKeys({
-                  algorithm: "algorithm",
-                  format: "format",
-                  name: "name",
-                  type: "type",
-                  usages: "usages",
-                  keyBase64: "key_base64",
-                  keyJwk: "key_jwk",
                 }),
               ),
               Schema.Struct({
@@ -10512,12 +10443,81 @@ export const PatchScriptScriptAndVersionSettingRequest =
               }),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("worker_loader"),
+                type: Schema.Literal("artifacts"),
+                namespace: Schema.String,
               }),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("artifacts"),
-                namespace: Schema.String,
+                type: Schema.Literal("ai"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("assets"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("browser"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("durable_object_namespace"),
+                className: Schema.optional(Schema.String),
+                environment: Schema.optional(Schema.String),
+                namespaceId: Schema.optional(Schema.String),
+                scriptName: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  className: "class_name",
+                  environment: "environment",
+                  namespaceId: "namespace_id",
+                  scriptName: "script_name",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("inherit"),
+                oldName: Schema.optional(Schema.String),
+                versionId: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  oldName: "old_name",
+                  versionId: "version_id",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("images"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("send_email"),
+                allowedDestinationAddresses: Schema.optional(
+                  Schema.Array(Schema.String),
+                ),
+                allowedSenderAddresses: Schema.optional(
+                  Schema.Array(Schema.String),
+                ),
+                destinationAddress: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  allowedDestinationAddresses: "allowed_destination_addresses",
+                  allowedSenderAddresses: "allowed_sender_addresses",
+                  destinationAddress: "destination_address",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("version_metadata"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("worker_loader"),
               }),
             ]),
           ),
@@ -10866,21 +10866,40 @@ export const PatchScriptScriptAndVersionSettingResponse =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              algorithm: Schema.Unknown,
+              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
               name: Schema.String,
-              type: Schema.Literal("ai"),
+              type: Schema.Literal("secret_key"),
+              usages: Schema.Array(
+                Schema.Literals([
+                  "encrypt",
+                  "decrypt",
+                  "sign",
+                  "verify",
+                  "deriveKey",
+                  "deriveBits",
+                  "wrapKey",
+                  "unwrapKey",
+                ]),
+              ),
             }),
+            Schema.Struct({
+              name: Schema.String,
+              secretName: Schema.String,
+              storeId: Schema.String,
+              type: Schema.Literal("secrets_store_secret"),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                secretName: "secret_name",
+                storeId: "store_id",
+                type: "type",
+              }),
+            ),
             Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("assets"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("browser"),
             }),
             Schema.Struct({
               id: Schema.String,
@@ -10921,55 +10940,9 @@ export const PatchScriptScriptAndVersionSettingResponse =
               ),
             }),
             Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              environment: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              namespaceId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              scriptName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
               id: Schema.String,
               name: Schema.String,
               type: Schema.Literal("hyperdrive"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("inherit"),
-              oldName: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              versionId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                oldName: "old_name",
-                versionId: "version_id",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("images"),
             }),
             Schema.Struct({
               json: Schema.String,
@@ -11036,31 +11009,6 @@ export const PatchScriptScriptAndVersionSettingResponse =
             ),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("secret_text"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("send_email"),
-              allowedDestinationAddresses: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              allowedSenderAddresses: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              destinationAddress: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                allowedDestinationAddresses: "allowed_destination_addresses",
-                allowedSenderAddresses: "allowed_sender_addresses",
-                destinationAddress: "destination_address",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               service: Schema.String,
               type: Schema.Literal("service"),
               environment: Schema.optional(
@@ -11083,41 +11031,6 @@ export const PatchScriptScriptAndVersionSettingResponse =
                 type: "type",
               }),
             ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("version_metadata"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              secretName: Schema.String,
-              storeId: Schema.String,
-              type: Schema.Literal("secrets_store_secret"),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                secretName: "secret_name",
-                storeId: "store_id",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              algorithm: Schema.Unknown,
-              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-              name: Schema.String,
-              type: Schema.Literal("secret_key"),
-              usages: Schema.Array(
-                Schema.Literals([
-                  "encrypt",
-                  "decrypt",
-                  "sign",
-                  "verify",
-                  "deriveKey",
-                  "deriveBits",
-                  "wrapKey",
-                  "unwrapKey",
-                ]),
-              ),
-            }),
             Schema.Struct({
               name: Schema.String,
               type: Schema.Literal("workflow"),
@@ -11144,12 +11057,99 @@ export const PatchScriptScriptAndVersionSettingResponse =
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("worker_loader"),
+              type: Schema.Literal("artifacts"),
+              namespace: Schema.String,
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("artifacts"),
-              namespace: Schema.String,
+              type: Schema.Literal("ai"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("assets"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("browser"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              environment: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              namespaceId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              scriptName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("inherit"),
+              oldName: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              versionId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                oldName: "old_name",
+                versionId: "version_id",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("images"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("secret_text"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("send_email"),
+              allowedDestinationAddresses: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              allowedSenderAddresses: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              destinationAddress: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                allowedDestinationAddresses: "allowed_destination_addresses",
+                allowedSenderAddresses: "allowed_sender_addresses",
+                destinationAddress: "destination_address",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("version_metadata"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("worker_loader"),
             }),
           ]),
         ),
@@ -11326,10 +11326,6 @@ export type GetScriptSecretResponse =
 export const GetScriptSecretResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union(
   [
     Schema.Struct({
-      name: Schema.String,
-      type: Schema.Literal("secret_text"),
-    }),
-    Schema.Struct({
       algorithm: Schema.Unknown,
       format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
       name: Schema.String,
@@ -11346,6 +11342,10 @@ export const GetScriptSecretResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union(
           "unwrapKey",
         ]),
       ),
+    }),
+    Schema.Struct({
+      name: Schema.String,
+      type: Schema.Literal("secret_text"),
     }),
   ],
 ).pipe(
@@ -11412,10 +11412,6 @@ export const ListScriptSecretsResponse =
     result: Schema.Array(
       Schema.Union([
         Schema.Struct({
-          name: Schema.String,
-          type: Schema.Literal("secret_text"),
-        }),
-        Schema.Struct({
           algorithm: Schema.Unknown,
           format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
           name: Schema.String,
@@ -11432,6 +11428,10 @@ export const ListScriptSecretsResponse =
               "unwrapKey",
             ]),
           ),
+        }),
+        Schema.Struct({
+          name: Schema.String,
+          type: Schema.Literal("secret_text"),
         }),
       ]),
     ),
@@ -11503,10 +11503,6 @@ export type PutScriptSecretResponse =
 export const PutScriptSecretResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union(
   [
     Schema.Struct({
-      name: Schema.String,
-      type: Schema.Literal("secret_text"),
-    }),
-    Schema.Struct({
       algorithm: Schema.Unknown,
       format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
       name: Schema.String,
@@ -11523,6 +11519,10 @@ export const PutScriptSecretResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union(
           "unwrapKey",
         ]),
       ),
+    }),
+    Schema.Struct({
+      name: Schema.String,
+      type: Schema.Literal("secret_text"),
     }),
   ],
 ).pipe(
@@ -12494,21 +12494,40 @@ export const GetScriptVersionResponse =
           Schema.Array(
             Schema.Union([
               Schema.Struct({
+                algorithm: Schema.Unknown,
+                format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
                 name: Schema.String,
-                type: Schema.Literal("ai"),
+                type: Schema.Literal("secret_key"),
+                usages: Schema.Array(
+                  Schema.Literals([
+                    "encrypt",
+                    "decrypt",
+                    "sign",
+                    "verify",
+                    "deriveKey",
+                    "deriveBits",
+                    "wrapKey",
+                    "unwrapKey",
+                  ]),
+                ),
               }),
+              Schema.Struct({
+                name: Schema.String,
+                secretName: Schema.String,
+                storeId: Schema.String,
+                type: Schema.Literal("secrets_store_secret"),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  secretName: "secret_name",
+                  storeId: "store_id",
+                  type: "type",
+                }),
+              ),
               Schema.Struct({
                 dataset: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("analytics_engine"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("assets"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("browser"),
               }),
               Schema.Struct({
                 id: Schema.String,
@@ -12552,55 +12571,9 @@ export const GetScriptVersionResponse =
                 ),
               }),
               Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("durable_object_namespace"),
-                className: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                environment: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                namespaceId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                scriptName: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  className: "class_name",
-                  environment: "environment",
-                  namespaceId: "namespace_id",
-                  scriptName: "script_name",
-                }),
-              ),
-              Schema.Struct({
                 id: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("hyperdrive"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("inherit"),
-                oldName: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                versionId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  oldName: "old_name",
-                  versionId: "version_id",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("images"),
               }),
               Schema.Struct({
                 json: Schema.String,
@@ -12670,31 +12643,6 @@ export const GetScriptVersionResponse =
               ),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("secret_text"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("send_email"),
-                allowedDestinationAddresses: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                allowedSenderAddresses: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                destinationAddress: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  allowedDestinationAddresses: "allowed_destination_addresses",
-                  allowedSenderAddresses: "allowed_sender_addresses",
-                  destinationAddress: "destination_address",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
                 service: Schema.String,
                 type: Schema.Literal("service"),
                 environment: Schema.optional(
@@ -12717,41 +12665,6 @@ export const GetScriptVersionResponse =
                   type: "type",
                 }),
               ),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("version_metadata"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                secretName: Schema.String,
-                storeId: Schema.String,
-                type: Schema.Literal("secrets_store_secret"),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  secretName: "secret_name",
-                  storeId: "store_id",
-                  type: "type",
-                }),
-              ),
-              Schema.Struct({
-                algorithm: Schema.Unknown,
-                format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-                name: Schema.String,
-                type: Schema.Literal("secret_key"),
-                usages: Schema.Array(
-                  Schema.Literals([
-                    "encrypt",
-                    "decrypt",
-                    "sign",
-                    "verify",
-                    "deriveKey",
-                    "deriveBits",
-                    "wrapKey",
-                    "unwrapKey",
-                  ]),
-                ),
-              }),
               Schema.Struct({
                 name: Schema.String,
                 type: Schema.Literal("workflow"),
@@ -12778,12 +12691,99 @@ export const GetScriptVersionResponse =
               }),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("worker_loader"),
+                type: Schema.Literal("artifacts"),
+                namespace: Schema.String,
               }),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("artifacts"),
-                namespace: Schema.String,
+                type: Schema.Literal("ai"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("assets"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("browser"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("durable_object_namespace"),
+                className: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                environment: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                namespaceId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                scriptName: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  className: "class_name",
+                  environment: "environment",
+                  namespaceId: "namespace_id",
+                  scriptName: "script_name",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("inherit"),
+                oldName: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                versionId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  oldName: "old_name",
+                  versionId: "version_id",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("images"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("secret_text"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("send_email"),
+                allowedDestinationAddresses: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                allowedSenderAddresses: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                destinationAddress: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  allowedDestinationAddresses: "allowed_destination_addresses",
+                  allowedSenderAddresses: "allowed_sender_addresses",
+                  destinationAddress: "destination_address",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("version_metadata"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("worker_loader"),
               }),
             ]),
           ),
@@ -13233,21 +13233,52 @@ export const CreateScriptVersionRequest =
         Schema.Array(
           Schema.Union([
             Schema.Struct({
+              algorithm: Schema.Unknown,
+              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
               name: Schema.String,
-              type: Schema.Literal("ai"),
-            }),
+              type: Schema.Literal("secret_key"),
+              usages: Schema.Array(
+                Schema.Literals([
+                  "encrypt",
+                  "decrypt",
+                  "sign",
+                  "verify",
+                  "deriveKey",
+                  "deriveBits",
+                  "wrapKey",
+                  "unwrapKey",
+                ]),
+              ),
+              keyBase64: Schema.optional(Schema.String),
+              keyJwk: Schema.optional(Schema.Unknown),
+            }).pipe(
+              Schema.encodeKeys({
+                algorithm: "algorithm",
+                format: "format",
+                name: "name",
+                type: "type",
+                usages: "usages",
+                keyBase64: "key_base64",
+                keyJwk: "key_jwk",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              secretName: Schema.String,
+              storeId: Schema.String,
+              type: Schema.Literal("secrets_store_secret"),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                secretName: "secret_name",
+                storeId: "store_id",
+                type: "type",
+              }),
+            ),
             Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("assets"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("browser"),
             }),
             Schema.Struct({
               id: Schema.String,
@@ -13276,43 +13307,9 @@ export const CreateScriptVersionRequest =
               ),
             }),
             Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(Schema.String),
-              environment: Schema.optional(Schema.String),
-              namespaceId: Schema.optional(Schema.String),
-              scriptName: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
               id: Schema.String,
               name: Schema.String,
               type: Schema.Literal("hyperdrive"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("inherit"),
-              oldName: Schema.optional(Schema.String),
-              versionId: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                oldName: "old_name",
-                versionId: "version_id",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("images"),
             }),
             Schema.Struct({
               json: Schema.String,
@@ -13382,25 +13379,6 @@ export const CreateScriptVersionRequest =
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("send_email"),
-              allowedDestinationAddresses: Schema.optional(
-                Schema.Array(Schema.String),
-              ),
-              allowedSenderAddresses: Schema.optional(
-                Schema.Array(Schema.String),
-              ),
-              destinationAddress: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                allowedDestinationAddresses: "allowed_destination_addresses",
-                allowedSenderAddresses: "allowed_sender_addresses",
-                destinationAddress: "destination_address",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               service: Schema.String,
               type: Schema.Literal("service"),
               environment: Schema.optional(Schema.String),
@@ -13419,53 +13397,6 @@ export const CreateScriptVersionRequest =
                 indexName: "index_name",
                 name: "name",
                 type: "type",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("version_metadata"),
-            }),
-            Schema.Struct({
-              name: Schema.String,
-              secretName: Schema.String,
-              storeId: Schema.String,
-              type: Schema.Literal("secrets_store_secret"),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                secretName: "secret_name",
-                storeId: "store_id",
-                type: "type",
-              }),
-            ),
-            Schema.Struct({
-              algorithm: Schema.Unknown,
-              format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-              name: Schema.String,
-              type: Schema.Literal("secret_key"),
-              usages: Schema.Array(
-                Schema.Literals([
-                  "encrypt",
-                  "decrypt",
-                  "sign",
-                  "verify",
-                  "deriveKey",
-                  "deriveBits",
-                  "wrapKey",
-                  "unwrapKey",
-                ]),
-              ),
-              keyBase64: Schema.optional(Schema.String),
-              keyJwk: Schema.optional(Schema.Unknown),
-            }).pipe(
-              Schema.encodeKeys({
-                algorithm: "algorithm",
-                format: "format",
-                name: "name",
-                type: "type",
-                usages: "usages",
-                keyBase64: "key_base64",
-                keyJwk: "key_jwk",
               }),
             ),
             Schema.Struct({
@@ -13490,12 +13421,81 @@ export const CreateScriptVersionRequest =
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("worker_loader"),
+              type: Schema.Literal("artifacts"),
+              namespace: Schema.String,
             }),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("artifacts"),
-              namespace: Schema.String,
+              type: Schema.Literal("ai"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("assets"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("browser"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.optional(Schema.String),
+              environment: Schema.optional(Schema.String),
+              namespaceId: Schema.optional(Schema.String),
+              scriptName: Schema.optional(Schema.String),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("inherit"),
+              oldName: Schema.optional(Schema.String),
+              versionId: Schema.optional(Schema.String),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                oldName: "old_name",
+                versionId: "version_id",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("images"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("send_email"),
+              allowedDestinationAddresses: Schema.optional(
+                Schema.Array(Schema.String),
+              ),
+              allowedSenderAddresses: Schema.optional(
+                Schema.Array(Schema.String),
+              ),
+              destinationAddress: Schema.optional(Schema.String),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                allowedDestinationAddresses: "allowed_destination_addresses",
+                allowedSenderAddresses: "allowed_sender_addresses",
+                destinationAddress: "destination_address",
+              }),
+            ),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("version_metadata"),
+            }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("worker_loader"),
             }),
           ]),
         ),
@@ -13680,21 +13680,40 @@ export const CreateScriptVersionResponse =
           Schema.Array(
             Schema.Union([
               Schema.Struct({
+                algorithm: Schema.Unknown,
+                format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
                 name: Schema.String,
-                type: Schema.Literal("ai"),
+                type: Schema.Literal("secret_key"),
+                usages: Schema.Array(
+                  Schema.Literals([
+                    "encrypt",
+                    "decrypt",
+                    "sign",
+                    "verify",
+                    "deriveKey",
+                    "deriveBits",
+                    "wrapKey",
+                    "unwrapKey",
+                  ]),
+                ),
               }),
+              Schema.Struct({
+                name: Schema.String,
+                secretName: Schema.String,
+                storeId: Schema.String,
+                type: Schema.Literal("secrets_store_secret"),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  secretName: "secret_name",
+                  storeId: "store_id",
+                  type: "type",
+                }),
+              ),
               Schema.Struct({
                 dataset: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("analytics_engine"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("assets"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("browser"),
               }),
               Schema.Struct({
                 id: Schema.String,
@@ -13738,55 +13757,9 @@ export const CreateScriptVersionResponse =
                 ),
               }),
               Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("durable_object_namespace"),
-                className: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                environment: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                namespaceId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                scriptName: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  className: "class_name",
-                  environment: "environment",
-                  namespaceId: "namespace_id",
-                  scriptName: "script_name",
-                }),
-              ),
-              Schema.Struct({
                 id: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("hyperdrive"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("inherit"),
-                oldName: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                versionId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  oldName: "old_name",
-                  versionId: "version_id",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("images"),
               }),
               Schema.Struct({
                 json: Schema.String,
@@ -13856,31 +13829,6 @@ export const CreateScriptVersionResponse =
               ),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("secret_text"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("send_email"),
-                allowedDestinationAddresses: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                allowedSenderAddresses: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                destinationAddress: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  allowedDestinationAddresses: "allowed_destination_addresses",
-                  allowedSenderAddresses: "allowed_sender_addresses",
-                  destinationAddress: "destination_address",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
                 service: Schema.String,
                 type: Schema.Literal("service"),
                 environment: Schema.optional(
@@ -13903,41 +13851,6 @@ export const CreateScriptVersionResponse =
                   type: "type",
                 }),
               ),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("version_metadata"),
-              }),
-              Schema.Struct({
-                name: Schema.String,
-                secretName: Schema.String,
-                storeId: Schema.String,
-                type: Schema.Literal("secrets_store_secret"),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  secretName: "secret_name",
-                  storeId: "store_id",
-                  type: "type",
-                }),
-              ),
-              Schema.Struct({
-                algorithm: Schema.Unknown,
-                format: Schema.Literals(["raw", "pkcs8", "spki", "jwk"]),
-                name: Schema.String,
-                type: Schema.Literal("secret_key"),
-                usages: Schema.Array(
-                  Schema.Literals([
-                    "encrypt",
-                    "decrypt",
-                    "sign",
-                    "verify",
-                    "deriveKey",
-                    "deriveBits",
-                    "wrapKey",
-                    "unwrapKey",
-                  ]),
-                ),
-              }),
               Schema.Struct({
                 name: Schema.String,
                 type: Schema.Literal("workflow"),
@@ -13964,12 +13877,99 @@ export const CreateScriptVersionResponse =
               }),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("worker_loader"),
+                type: Schema.Literal("artifacts"),
+                namespace: Schema.String,
               }),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("artifacts"),
-                namespace: Schema.String,
+                type: Schema.Literal("ai"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("assets"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("browser"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("durable_object_namespace"),
+                className: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                environment: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                namespaceId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                scriptName: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  className: "class_name",
+                  environment: "environment",
+                  namespaceId: "namespace_id",
+                  scriptName: "script_name",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("inherit"),
+                oldName: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                versionId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  oldName: "old_name",
+                  versionId: "version_id",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("images"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("secret_text"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("send_email"),
+                allowedDestinationAddresses: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                allowedSenderAddresses: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                destinationAddress: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  allowedDestinationAddresses: "allowed_destination_addresses",
+                  allowedSenderAddresses: "allowed_sender_addresses",
+                  destinationAddress: "destination_address",
+                }),
+              ),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("version_metadata"),
+              }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("worker_loader"),
               }),
             ]),
           ),
@@ -14333,6 +14333,52 @@ export const CreateServiceEdgePreviewRequest =
           Schema.Array(
             Schema.Union([
               Schema.Struct({
+                type: Schema.Literal("workflow"),
+                name: Schema.String,
+                workflowName: Schema.String,
+                className: Schema.String,
+                scriptName: Schema.optional(Schema.String),
+                raw: Schema.optional(Schema.Boolean),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  workflowName: "workflow_name",
+                  className: "class_name",
+                  scriptName: "script_name",
+                  raw: "raw",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("secrets_store_secret"),
+                name: Schema.String,
+                storeId: Schema.String,
+                secretName: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  storeId: "store_id",
+                  secretName: "secret_name",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("ratelimit"),
+                name: Schema.String,
+                namespaceId: Schema.String,
+                simple: Schema.Struct({
+                  limit: Schema.Number,
+                  period: Schema.Literals(["10", "60"]),
+                }),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  namespaceId: "namespace_id",
+                  simple: "simple",
+                }),
+              ),
+              Schema.Struct({
                 type: Schema.Literal("plain_text"),
                 name: Schema.String,
                 text: Schema.String,
@@ -14421,22 +14467,6 @@ export const CreateServiceEdgePreviewRequest =
                 entrypoint: Schema.optional(Schema.String),
               }),
               Schema.Struct({
-                type: Schema.Literal("ai"),
-                name: Schema.String,
-                staging: Schema.optional(Schema.Boolean),
-                raw: Schema.optional(Schema.Boolean),
-              }),
-              Schema.Struct({
-                type: Schema.Literal("browser"),
-                name: Schema.String,
-                raw: Schema.optional(Schema.Boolean),
-              }),
-              Schema.Struct({
-                type: Schema.Literal("images"),
-                name: Schema.String,
-                raw: Schema.optional(Schema.Boolean),
-              }),
-              Schema.Struct({
                 type: Schema.Literal("vectorize"),
                 name: Schema.String,
                 indexName: Schema.String,
@@ -14450,31 +14480,9 @@ export const CreateServiceEdgePreviewRequest =
                 }),
               ),
               Schema.Struct({
-                type: Schema.Literal("workflow"),
-                name: Schema.String,
-                workflowName: Schema.String,
-                className: Schema.String,
-                scriptName: Schema.optional(Schema.String),
-                raw: Schema.optional(Schema.Boolean),
-              }).pipe(
-                Schema.encodeKeys({
-                  type: "type",
-                  name: "name",
-                  workflowName: "workflow_name",
-                  className: "class_name",
-                  scriptName: "script_name",
-                  raw: "raw",
-                }),
-              ),
-              Schema.Struct({
                 type: Schema.Literal("hyperdrive"),
                 name: Schema.String,
                 id: Schema.String,
-              }),
-              Schema.Struct({
-                type: Schema.Literal("analytics_engine"),
-                name: Schema.String,
-                dataset: Schema.optional(Schema.String),
               }),
               Schema.Struct({
                 type: Schema.Literal("dispatch_namespace"),
@@ -14498,25 +14506,6 @@ export const CreateServiceEdgePreviewRequest =
                   }),
                 ),
               }),
-              Schema.Struct({
-                type: Schema.Literal("send_email"),
-                name: Schema.String,
-                destinationAddress: Schema.optional(Schema.String),
-                allowedDestinationAddresses: Schema.optional(
-                  Schema.Array(Schema.String),
-                ),
-                allowedSenderAddresses: Schema.optional(
-                  Schema.Array(Schema.String),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  type: "type",
-                  name: "name",
-                  destinationAddress: "destination_address",
-                  allowedDestinationAddresses: "allowed_destination_addresses",
-                  allowedSenderAddresses: "allowed_sender_addresses",
-                }),
-              ),
               Schema.Struct({
                 type: Schema.Literal("mtls_certificate"),
                 name: Schema.String,
@@ -14549,16 +14538,64 @@ export const CreateServiceEdgePreviewRequest =
                 pipeline: Schema.String,
               }),
               Schema.Struct({
-                type: Schema.Literal("secrets_store_secret"),
+                type: Schema.Literal("logfwdr"),
                 name: Schema.String,
-                storeId: Schema.String,
-                secretName: Schema.String,
+                destination: Schema.String,
+              }),
+              Schema.Struct({
+                type: Schema.Literal("ai_search_namespace"),
+                name: Schema.String,
+                namespace: Schema.String,
+              }),
+              Schema.Struct({
+                type: Schema.Literal("ai_search"),
+                name: Schema.String,
+                instanceName: Schema.String,
               }).pipe(
                 Schema.encodeKeys({
                   type: "type",
                   name: "name",
-                  storeId: "store_id",
-                  secretName: "secret_name",
+                  instanceName: "instance_name",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("ai"),
+                name: Schema.String,
+                staging: Schema.optional(Schema.Boolean),
+                raw: Schema.optional(Schema.Boolean),
+              }),
+              Schema.Struct({
+                type: Schema.Literal("browser"),
+                name: Schema.String,
+                raw: Schema.optional(Schema.Boolean),
+              }),
+              Schema.Struct({
+                type: Schema.Literal("images"),
+                name: Schema.String,
+                raw: Schema.optional(Schema.Boolean),
+              }),
+              Schema.Struct({
+                type: Schema.Literal("analytics_engine"),
+                name: Schema.String,
+                dataset: Schema.optional(Schema.String),
+              }),
+              Schema.Struct({
+                type: Schema.Literal("send_email"),
+                name: Schema.String,
+                destinationAddress: Schema.optional(Schema.String),
+                allowedDestinationAddresses: Schema.optional(
+                  Schema.Array(Schema.String),
+                ),
+                allowedSenderAddresses: Schema.optional(
+                  Schema.Array(Schema.String),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  destinationAddress: "destination_address",
+                  allowedDestinationAddresses: "allowed_destination_addresses",
+                  allowedSenderAddresses: "allowed_sender_addresses",
                 }),
               ),
               Schema.Struct({
@@ -14581,43 +14618,6 @@ export const CreateServiceEdgePreviewRequest =
                 type: Schema.Literal("worker_loader"),
                 name: Schema.String,
               }),
-              Schema.Struct({
-                type: Schema.Literal("logfwdr"),
-                name: Schema.String,
-                destination: Schema.String,
-              }),
-              Schema.Struct({
-                type: Schema.Literal("ai_search_namespace"),
-                name: Schema.String,
-                namespace: Schema.String,
-              }),
-              Schema.Struct({
-                type: Schema.Literal("ai_search"),
-                name: Schema.String,
-                instanceName: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  type: "type",
-                  name: "name",
-                  instanceName: "instance_name",
-                }),
-              ),
-              Schema.Struct({
-                type: Schema.Literal("ratelimit"),
-                name: Schema.String,
-                namespaceId: Schema.String,
-                simple: Schema.Struct({
-                  limit: Schema.Number,
-                  period: Schema.Literals(["10", "60"]),
-                }),
-              }).pipe(
-                Schema.encodeKeys({
-                  type: "type",
-                  name: "name",
-                  namespaceId: "namespace_id",
-                  simple: "simple",
-                }),
-              ),
               Schema.Struct({
                 type: Schema.Literal("inherit"),
                 name: Schema.String,

--- a/packages/cloudflare/src/services/workflows.ts
+++ b/packages/cloudflare/src/services/workflows.ts
@@ -219,14 +219,9 @@ export const GetInstanceResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         ]),
         finished: Schema.Boolean,
         name: Schema.String,
+        output: Schema.Union([Schema.String, Schema.Number, Schema.Boolean]),
         start: Schema.String,
-        type: Schema.Literal("sleep"),
-      }),
-      Schema.Struct({
-        trigger: Schema.Struct({
-          source: Schema.String,
-        }),
-        type: Schema.Literal("termination"),
+        type: Schema.Literal("waitForEvent"),
       }),
       Schema.Struct({
         end: Schema.String,
@@ -239,9 +234,14 @@ export const GetInstanceResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         ]),
         finished: Schema.Boolean,
         name: Schema.String,
-        output: Schema.Union([Schema.String, Schema.Number, Schema.Boolean]),
         start: Schema.String,
-        type: Schema.Literal("waitForEvent"),
+        type: Schema.Literal("sleep"),
+      }),
+      Schema.Struct({
+        trigger: Schema.Struct({
+          source: Schema.String,
+        }),
+        type: Schema.Literal("termination"),
       }),
     ]),
   ),

--- a/packages/cloudflare/src/services/zero-trust.ts
+++ b/packages/cloudflare/src/services/zero-trust.ts
@@ -2868,6 +2868,19 @@ export const GetAccessApplicationResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
       domain: Schema.String,
+      targetCriteria: Schema.Array(
+        Schema.Struct({
+          port: Schema.Number,
+          protocol: Schema.Literal("RDP"),
+          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
+        }).pipe(
+          Schema.encodeKeys({
+            port: "port",
+            protocol: "protocol",
+            targetAttributes: "target_attributes",
+          }),
+        ),
+      ),
       type: Schema.Literals([
         "self_hosted",
         "saas",
@@ -3792,15 +3805,6 @@ export const GetAccessApplicationResponse =
               Schema.Union([
                 Schema.Union([
                   Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
-                  Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
@@ -3820,6 +3824,11 @@ export const GetAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -3830,17 +3839,12 @@ export const GetAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -3864,6 +3868,11 @@ export const GetAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -3874,6 +3883,10 @@ export const GetAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -3967,6 +3980,7 @@ export const GetAccessApplicationResponse =
     }).pipe(
       Schema.encodeKeys({
         domain: "domain",
+        targetCriteria: "target_criteria",
         type: "type",
         id: "id",
         allowAuthenticateViaWarp: "allow_authenticate_via_warp",
@@ -3999,7 +4013,28 @@ export const GetAccessApplicationResponse =
       }),
     ),
     Schema.Struct({
+      domain: Schema.String,
+      type: Schema.Literals([
+        "self_hosted",
+        "saas",
+        "ssh",
+        "vnc",
+        "app_launcher",
+        "warp",
+        "biso",
+        "bookmark",
+        "dash_sso",
+        "infrastructure",
+        "rdp",
+        "mcp",
+        "mcp_portal",
+        "proxy_endpoint",
+      ]),
       id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      allowAuthenticateViaWarp: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      allowIframe: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
       allowedIdps: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
@@ -4010,11 +4045,149 @@ export const GetAccessApplicationResponse =
       autoRedirectToIdentity: Schema.optional(
         Schema.Union([Schema.Boolean, Schema.Null]),
       ),
+      corsHeaders: Schema.optional(
+        Schema.Union([
+          Schema.Struct({
+            allowAllHeaders: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowAllMethods: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowAllOrigins: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowCredentials: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowedHeaders: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            allowedMethods: Schema.optional(
+              Schema.Union([
+                Schema.Array(
+                  Schema.Literals([
+                    "GET",
+                    "POST",
+                    "HEAD",
+                    "PUT",
+                    "DELETE",
+                    "CONNECT",
+                    "OPTIONS",
+                    "TRACE",
+                    "PATCH",
+                  ]),
+                ),
+                Schema.Null,
+              ]),
+            ),
+            allowedOrigins: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            maxAge: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          }).pipe(
+            Schema.encodeKeys({
+              allowAllHeaders: "allow_all_headers",
+              allowAllMethods: "allow_all_methods",
+              allowAllOrigins: "allow_all_origins",
+              allowCredentials: "allow_credentials",
+              allowedHeaders: "allowed_headers",
+              allowedMethods: "allowed_methods",
+              allowedOrigins: "allowed_origins",
+              maxAge: "max_age",
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      customDenyMessage: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      customDenyUrl: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      customNonIdentityDenyUrl: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
       customPages: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
+      destinations: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Union([
+              Schema.Struct({
+                type: Schema.optional(
+                  Schema.Union([Schema.Literal("public"), Schema.Null]),
+                ),
+                uri: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }),
+              Schema.Struct({
+                cidr: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                hostname: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                l4Protocol: Schema.optional(
+                  Schema.Union([Schema.Literals(["tcp", "udp"]), Schema.Null]),
+                ),
+                portRange: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                type: Schema.optional(
+                  Schema.Union([Schema.Literal("private"), Schema.Null]),
+                ),
+                vnetId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  cidr: "cidr",
+                  hostname: "hostname",
+                  l4Protocol: "l4_protocol",
+                  portRange: "port_range",
+                  type: "type",
+                  vnetId: "vnet_id",
+                }),
+              ),
+              Schema.Struct({
+                mcpServerId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                type: Schema.optional(
+                  Schema.Union([
+                    Schema.Literal("via_mcp_server_portal"),
+                    Schema.Null,
+                  ]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  mcpServerId: "mcp_server_id",
+                  type: "type",
+                }),
+              ),
+            ]),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      enableBindingCookie: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      httpOnlyCookieAttribute: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
       name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      optionsPreflightBypass: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      pathCookieAttribute: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       policies: Schema.optional(
         Schema.Union([
           Schema.Array(
@@ -4750,282 +4923,11 @@ export const GetAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      saasApp: Schema.optional(
-        Schema.Union([
-          Schema.Union([
-            Schema.Struct({
-              authType: Schema.optional(
-                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
-              ),
-              consumerServiceUrl: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              customAttributes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Struct({
-                      friendlyName: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      name: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      nameFormat: Schema.optional(
-                        Schema.Union([
-                          Schema.Literals([
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
-                          ]),
-                          Schema.Null,
-                        ]),
-                      ),
-                      required: Schema.optional(
-                        Schema.Union([Schema.Boolean, Schema.Null]),
-                      ),
-                      source: Schema.optional(
-                        Schema.Union([
-                          Schema.Struct({
-                            name: Schema.optional(
-                              Schema.Union([Schema.String, Schema.Null]),
-                            ),
-                            nameByIdp: Schema.optional(
-                              Schema.Union([
-                                Schema.Array(
-                                  Schema.Struct({
-                                    idpId: Schema.optional(
-                                      Schema.Union([
-                                        Schema.String,
-                                        Schema.Null,
-                                      ]),
-                                    ),
-                                    sourceName: Schema.optional(
-                                      Schema.Union([
-                                        Schema.String,
-                                        Schema.Null,
-                                      ]),
-                                    ),
-                                  }).pipe(
-                                    Schema.encodeKeys({
-                                      idpId: "idp_id",
-                                      sourceName: "source_name",
-                                    }),
-                                  ),
-                                ),
-                                Schema.Null,
-                              ]),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              name: "name",
-                              nameByIdp: "name_by_idp",
-                            }),
-                          ),
-                          Schema.Null,
-                        ]),
-                      ),
-                    }).pipe(
-                      Schema.encodeKeys({
-                        friendlyName: "friendly_name",
-                        name: "name",
-                        nameFormat: "name_format",
-                        required: "required",
-                        source: "source",
-                      }),
-                    ),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              defaultRelayState: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              idpEntityId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              nameIdFormat: Schema.optional(
-                Schema.Union([Schema.Literals(["id", "email"]), Schema.Null]),
-              ),
-              nameIdTransformJsonata: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              publicKey: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              samlAttributeTransformJsonata: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              spEntityId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              ssoEndpoint: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                authType: "auth_type",
-                consumerServiceUrl: "consumer_service_url",
-                customAttributes: "custom_attributes",
-                defaultRelayState: "default_relay_state",
-                idpEntityId: "idp_entity_id",
-                nameIdFormat: "name_id_format",
-                nameIdTransformJsonata: "name_id_transform_jsonata",
-                publicKey: "public_key",
-                samlAttributeTransformJsonata:
-                  "saml_attribute_transform_jsonata",
-                spEntityId: "sp_entity_id",
-                ssoEndpoint: "sso_endpoint",
-              }),
-            ),
-            Schema.Struct({
-              accessTokenLifetime: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              allowPkceWithoutClientSecret: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-              appLauncherUrl: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              authType: Schema.optional(
-                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
-              ),
-              clientId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              clientSecret: Schema.optional(
-                Schema.Union([SensitiveString, Schema.Null]),
-              ),
-              customClaims: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Struct({
-                      name: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      required: Schema.optional(
-                        Schema.Union([Schema.Boolean, Schema.Null]),
-                      ),
-                      scope: Schema.optional(
-                        Schema.Union([
-                          Schema.Literals([
-                            "groups",
-                            "profile",
-                            "email",
-                            "openid",
-                          ]),
-                          Schema.Null,
-                        ]),
-                      ),
-                      source: Schema.optional(
-                        Schema.Union([
-                          Schema.Struct({
-                            name: Schema.optional(
-                              Schema.Union([Schema.String, Schema.Null]),
-                            ),
-                            nameByIdp: Schema.optional(
-                              Schema.Union([
-                                Schema.Record(Schema.String, Schema.Unknown),
-                                Schema.Null,
-                              ]),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              name: "name",
-                              nameByIdp: "name_by_idp",
-                            }),
-                          ),
-                          Schema.Null,
-                        ]),
-                      ),
-                    }),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              grantTypes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Literals([
-                      "authorization_code",
-                      "authorization_code_with_pkce",
-                      "refresh_tokens",
-                      "hybrid",
-                      "implicit",
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              groupFilterRegex: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              hybridAndImplicitOptions: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    returnAccessTokenFromAuthorizationEndpoint: Schema.optional(
-                      Schema.Union([Schema.Boolean, Schema.Null]),
-                    ),
-                    returnIdTokenFromAuthorizationEndpoint: Schema.optional(
-                      Schema.Union([Schema.Boolean, Schema.Null]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      returnAccessTokenFromAuthorizationEndpoint:
-                        "return_access_token_from_authorization_endpoint",
-                      returnIdTokenFromAuthorizationEndpoint:
-                        "return_id_token_from_authorization_endpoint",
-                    }),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              publicKey: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              redirectUris: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              refreshTokenOptions: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    lifetime: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }),
-                  Schema.Null,
-                ]),
-              ),
-              scopes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Literals(["openid", "groups", "email", "profile"]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                accessTokenLifetime: "access_token_lifetime",
-                allowPkceWithoutClientSecret:
-                  "allow_pkce_without_client_secret",
-                appLauncherUrl: "app_launcher_url",
-                authType: "auth_type",
-                clientId: "client_id",
-                clientSecret: "client_secret",
-                customClaims: "custom_claims",
-                grantTypes: "grant_types",
-                groupFilterRegex: "group_filter_regex",
-                hybridAndImplicitOptions: "hybrid_and_implicit_options",
-                publicKey: "public_key",
-                redirectUris: "redirect_uris",
-                refreshTokenOptions: "refresh_token_options",
-                scopes: "scopes",
-              }),
-            ),
-          ]),
-          Schema.Null,
-        ]),
+      readServiceTokensFromHeader: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      sameSiteCookieAttribute: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
       ),
       scimConfig: Schema.optional(
         Schema.Union([
@@ -5035,15 +4937,6 @@ export const GetAccessApplicationResponse =
             authentication: Schema.optional(
               Schema.Union([
                 Schema.Union([
-                  Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
                   Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
@@ -5064,6 +4957,11 @@ export const GetAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -5074,17 +4972,12 @@ export const GetAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -5108,6 +5001,11 @@ export const GetAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -5118,6 +5016,10 @@ export const GetAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -5193,45 +5095,805 @@ export const GetAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
+      selfHostedDomains: Schema.optional(
+        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+      ),
+      serviceAuth_401Redirect: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      sessionDuration: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      skipInterstitial: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       tags: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
-      type: Schema.optional(
+    }).pipe(
+      Schema.encodeKeys({
+        domain: "domain",
+        type: "type",
+        id: "id",
+        allowAuthenticateViaWarp: "allow_authenticate_via_warp",
+        allowIframe: "allow_iframe",
+        allowedIdps: "allowed_idps",
+        appLauncherVisible: "app_launcher_visible",
+        aud: "aud",
+        autoRedirectToIdentity: "auto_redirect_to_identity",
+        corsHeaders: "cors_headers",
+        customDenyMessage: "custom_deny_message",
+        customDenyUrl: "custom_deny_url",
+        customNonIdentityDenyUrl: "custom_non_identity_deny_url",
+        customPages: "custom_pages",
+        destinations: "destinations",
+        enableBindingCookie: "enable_binding_cookie",
+        httpOnlyCookieAttribute: "http_only_cookie_attribute",
+        logoUrl: "logo_url",
+        name: "name",
+        optionsPreflightBypass: "options_preflight_bypass",
+        pathCookieAttribute: "path_cookie_attribute",
+        policies: "policies",
+        readServiceTokensFromHeader: "read_service_tokens_from_header",
+        sameSiteCookieAttribute: "same_site_cookie_attribute",
+        scimConfig: "scim_config",
+        selfHostedDomains: "self_hosted_domains",
+        serviceAuth_401Redirect: "service_auth_401_redirect",
+        sessionDuration: "session_duration",
+        skipInterstitial: "skip_interstitial",
+        tags: "tags",
+      }),
+    ),
+    Schema.Struct({
+      targetCriteria: Schema.Array(
+        Schema.Struct({
+          port: Schema.Number,
+          protocol: Schema.Literal("SSH"),
+          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
+        }).pipe(
+          Schema.encodeKeys({
+            port: "port",
+            protocol: "protocol",
+            targetAttributes: "target_attributes",
+          }),
+        ),
+      ),
+      type: Schema.Literals([
+        "self_hosted",
+        "saas",
+        "ssh",
+        "vnc",
+        "app_launcher",
+        "warp",
+        "biso",
+        "bookmark",
+        "dash_sso",
+        "infrastructure",
+        "rdp",
+        "mcp",
+        "mcp_portal",
+        "proxy_endpoint",
+      ]),
+      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      policies: Schema.optional(
         Schema.Union([
-          Schema.Literals([
-            "self_hosted",
-            "saas",
-            "ssh",
-            "vnc",
-            "app_launcher",
-            "warp",
-            "biso",
-            "bookmark",
-            "dash_sso",
-            "infrastructure",
-            "rdp",
-            "mcp",
-            "mcp_portal",
-            "proxy_endpoint",
-          ]),
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+              connectionRules: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    ssh: Schema.optional(
+                      Schema.Union([
+                        Schema.Struct({
+                          usernames: Schema.Array(Schema.String),
+                          allowEmailAlias: Schema.optional(
+                            Schema.Union([Schema.Boolean, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            usernames: "usernames",
+                            allowEmailAlias: "allow_email_alias",
+                          }),
+                        ),
+                        Schema.Null,
+                      ]),
+                    ),
+                  }),
+                  Schema.Null,
+                ]),
+              ),
+              createdAt: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              decision: Schema.optional(
+                Schema.Union([
+                  Schema.Literals(["allow", "deny", "non_identity", "bypass"]),
+                  Schema.Null,
+                ]),
+              ),
+              exclude: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              include: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+              require: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              updatedAt: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                id: "id",
+                connectionRules: "connection_rules",
+                createdAt: "created_at",
+                decision: "decision",
+                exclude: "exclude",
+                include: "include",
+                name: "name",
+                require: "require",
+                updatedAt: "updated_at",
+              }),
+            ),
+          ),
           Schema.Null,
         ]),
       ),
     }).pipe(
       Schema.encodeKeys({
+        targetCriteria: "target_criteria",
+        type: "type",
         id: "id",
-        allowedIdps: "allowed_idps",
-        appLauncherVisible: "app_launcher_visible",
         aud: "aud",
-        autoRedirectToIdentity: "auto_redirect_to_identity",
-        customPages: "custom_pages",
-        logoUrl: "logo_url",
         name: "name",
         policies: "policies",
-        saasApp: "saas_app",
-        scimConfig: "scim_config",
-        tags: "tags",
-        type: "type",
       }),
     ),
     Schema.Struct({
@@ -6871,837 +7533,6 @@ export const GetAccessApplicationResponse =
     ),
     Schema.Struct({
       id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      appLauncherVisible: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      tags: Schema.optional(
-        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-      ),
-      type: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "self_hosted",
-            "saas",
-            "ssh",
-            "vnc",
-            "app_launcher",
-            "warp",
-            "biso",
-            "bookmark",
-            "dash_sso",
-            "infrastructure",
-            "rdp",
-            "mcp",
-            "mcp_portal",
-            "proxy_endpoint",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        appLauncherVisible: "app_launcher_visible",
-        aud: "aud",
-        domain: "domain",
-        logoUrl: "logo_url",
-        name: "name",
-        tags: "tags",
-        type: "type",
-      }),
-    ),
-    Schema.Struct({
-      targetCriteria: Schema.Array(
-        Schema.Struct({
-          port: Schema.Number,
-          protocol: Schema.Literal("SSH"),
-          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
-        }).pipe(
-          Schema.encodeKeys({
-            port: "port",
-            protocol: "protocol",
-            targetAttributes: "target_attributes",
-          }),
-        ),
-      ),
-      type: Schema.Literals([
-        "self_hosted",
-        "saas",
-        "ssh",
-        "vnc",
-        "app_launcher",
-        "warp",
-        "biso",
-        "bookmark",
-        "dash_sso",
-        "infrastructure",
-        "rdp",
-        "mcp",
-        "mcp_portal",
-        "proxy_endpoint",
-      ]),
-      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      policies: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-              connectionRules: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    ssh: Schema.optional(
-                      Schema.Union([
-                        Schema.Struct({
-                          usernames: Schema.Array(Schema.String),
-                          allowEmailAlias: Schema.optional(
-                            Schema.Union([Schema.Boolean, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            usernames: "usernames",
-                            allowEmailAlias: "allow_email_alias",
-                          }),
-                        ),
-                        Schema.Null,
-                      ]),
-                    ),
-                  }),
-                  Schema.Null,
-                ]),
-              ),
-              createdAt: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              decision: Schema.optional(
-                Schema.Union([
-                  Schema.Literals(["allow", "deny", "non_identity", "bypass"]),
-                  Schema.Null,
-                ]),
-              ),
-              exclude: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              include: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-              require: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              updatedAt: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                connectionRules: "connection_rules",
-                createdAt: "created_at",
-                decision: "decision",
-                exclude: "exclude",
-                include: "include",
-                name: "name",
-                require: "require",
-                updatedAt: "updated_at",
-              }),
-            ),
-          ),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        targetCriteria: "target_criteria",
-        type: "type",
-        id: "id",
-        aud: "aud",
-        name: "name",
-        policies: "policies",
-      }),
-    ),
-    Schema.Struct({
-      domain: Schema.String,
-      targetCriteria: Schema.Array(
-        Schema.Struct({
-          port: Schema.Number,
-          protocol: Schema.Literal("RDP"),
-          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
-        }).pipe(
-          Schema.encodeKeys({
-            port: "port",
-            protocol: "protocol",
-            targetAttributes: "target_attributes",
-          }),
-        ),
-      ),
-      type: Schema.Literals([
-        "self_hosted",
-        "saas",
-        "ssh",
-        "vnc",
-        "app_launcher",
-        "warp",
-        "biso",
-        "bookmark",
-        "dash_sso",
-        "infrastructure",
-        "rdp",
-        "mcp",
-        "mcp_portal",
-        "proxy_endpoint",
-      ]),
-      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      allowAuthenticateViaWarp: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      allowIframe: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
       allowedIdps: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
@@ -7712,149 +7543,11 @@ export const GetAccessApplicationResponse =
       autoRedirectToIdentity: Schema.optional(
         Schema.Union([Schema.Boolean, Schema.Null]),
       ),
-      corsHeaders: Schema.optional(
-        Schema.Union([
-          Schema.Struct({
-            allowAllHeaders: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowAllMethods: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowAllOrigins: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowCredentials: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowedHeaders: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            allowedMethods: Schema.optional(
-              Schema.Union([
-                Schema.Array(
-                  Schema.Literals([
-                    "GET",
-                    "POST",
-                    "HEAD",
-                    "PUT",
-                    "DELETE",
-                    "CONNECT",
-                    "OPTIONS",
-                    "TRACE",
-                    "PATCH",
-                  ]),
-                ),
-                Schema.Null,
-              ]),
-            ),
-            allowedOrigins: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            maxAge: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-          }).pipe(
-            Schema.encodeKeys({
-              allowAllHeaders: "allow_all_headers",
-              allowAllMethods: "allow_all_methods",
-              allowAllOrigins: "allow_all_origins",
-              allowCredentials: "allow_credentials",
-              allowedHeaders: "allowed_headers",
-              allowedMethods: "allowed_methods",
-              allowedOrigins: "allowed_origins",
-              maxAge: "max_age",
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      customDenyMessage: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      customDenyUrl: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      customNonIdentityDenyUrl: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
       customPages: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
-      destinations: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Union([
-              Schema.Struct({
-                type: Schema.optional(
-                  Schema.Union([Schema.Literal("public"), Schema.Null]),
-                ),
-                uri: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }),
-              Schema.Struct({
-                cidr: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                hostname: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                l4Protocol: Schema.optional(
-                  Schema.Union([Schema.Literals(["tcp", "udp"]), Schema.Null]),
-                ),
-                portRange: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                type: Schema.optional(
-                  Schema.Union([Schema.Literal("private"), Schema.Null]),
-                ),
-                vnetId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  cidr: "cidr",
-                  hostname: "hostname",
-                  l4Protocol: "l4_protocol",
-                  portRange: "port_range",
-                  type: "type",
-                  vnetId: "vnet_id",
-                }),
-              ),
-              Schema.Struct({
-                mcpServerId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                type: Schema.optional(
-                  Schema.Union([
-                    Schema.Literal("via_mcp_server_portal"),
-                    Schema.Null,
-                  ]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  mcpServerId: "mcp_server_id",
-                  type: "type",
-                }),
-              ),
-            ]),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      enableBindingCookie: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      httpOnlyCookieAttribute: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
       name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      optionsPreflightBypass: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      pathCookieAttribute: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       policies: Schema.optional(
         Schema.Union([
           Schema.Array(
@@ -8590,11 +8283,282 @@ export const GetAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      readServiceTokensFromHeader: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      sameSiteCookieAttribute: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
+      saasApp: Schema.optional(
+        Schema.Union([
+          Schema.Union([
+            Schema.Struct({
+              authType: Schema.optional(
+                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
+              ),
+              consumerServiceUrl: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              customAttributes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Struct({
+                      friendlyName: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      name: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      nameFormat: Schema.optional(
+                        Schema.Union([
+                          Schema.Literals([
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                          ]),
+                          Schema.Null,
+                        ]),
+                      ),
+                      required: Schema.optional(
+                        Schema.Union([Schema.Boolean, Schema.Null]),
+                      ),
+                      source: Schema.optional(
+                        Schema.Union([
+                          Schema.Struct({
+                            name: Schema.optional(
+                              Schema.Union([Schema.String, Schema.Null]),
+                            ),
+                            nameByIdp: Schema.optional(
+                              Schema.Union([
+                                Schema.Array(
+                                  Schema.Struct({
+                                    idpId: Schema.optional(
+                                      Schema.Union([
+                                        Schema.String,
+                                        Schema.Null,
+                                      ]),
+                                    ),
+                                    sourceName: Schema.optional(
+                                      Schema.Union([
+                                        Schema.String,
+                                        Schema.Null,
+                                      ]),
+                                    ),
+                                  }).pipe(
+                                    Schema.encodeKeys({
+                                      idpId: "idp_id",
+                                      sourceName: "source_name",
+                                    }),
+                                  ),
+                                ),
+                                Schema.Null,
+                              ]),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              name: "name",
+                              nameByIdp: "name_by_idp",
+                            }),
+                          ),
+                          Schema.Null,
+                        ]),
+                      ),
+                    }).pipe(
+                      Schema.encodeKeys({
+                        friendlyName: "friendly_name",
+                        name: "name",
+                        nameFormat: "name_format",
+                        required: "required",
+                        source: "source",
+                      }),
+                    ),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              defaultRelayState: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              idpEntityId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              nameIdFormat: Schema.optional(
+                Schema.Union([Schema.Literals(["id", "email"]), Schema.Null]),
+              ),
+              nameIdTransformJsonata: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              publicKey: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              samlAttributeTransformJsonata: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              spEntityId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              ssoEndpoint: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                authType: "auth_type",
+                consumerServiceUrl: "consumer_service_url",
+                customAttributes: "custom_attributes",
+                defaultRelayState: "default_relay_state",
+                idpEntityId: "idp_entity_id",
+                nameIdFormat: "name_id_format",
+                nameIdTransformJsonata: "name_id_transform_jsonata",
+                publicKey: "public_key",
+                samlAttributeTransformJsonata:
+                  "saml_attribute_transform_jsonata",
+                spEntityId: "sp_entity_id",
+                ssoEndpoint: "sso_endpoint",
+              }),
+            ),
+            Schema.Struct({
+              accessTokenLifetime: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              allowPkceWithoutClientSecret: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+              appLauncherUrl: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              authType: Schema.optional(
+                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
+              ),
+              clientId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              clientSecret: Schema.optional(
+                Schema.Union([SensitiveString, Schema.Null]),
+              ),
+              customClaims: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Struct({
+                      name: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      required: Schema.optional(
+                        Schema.Union([Schema.Boolean, Schema.Null]),
+                      ),
+                      scope: Schema.optional(
+                        Schema.Union([
+                          Schema.Literals([
+                            "groups",
+                            "profile",
+                            "email",
+                            "openid",
+                          ]),
+                          Schema.Null,
+                        ]),
+                      ),
+                      source: Schema.optional(
+                        Schema.Union([
+                          Schema.Struct({
+                            name: Schema.optional(
+                              Schema.Union([Schema.String, Schema.Null]),
+                            ),
+                            nameByIdp: Schema.optional(
+                              Schema.Union([
+                                Schema.Record(Schema.String, Schema.Unknown),
+                                Schema.Null,
+                              ]),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              name: "name",
+                              nameByIdp: "name_by_idp",
+                            }),
+                          ),
+                          Schema.Null,
+                        ]),
+                      ),
+                    }),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              grantTypes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Literals([
+                      "authorization_code",
+                      "authorization_code_with_pkce",
+                      "refresh_tokens",
+                      "hybrid",
+                      "implicit",
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              groupFilterRegex: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              hybridAndImplicitOptions: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    returnAccessTokenFromAuthorizationEndpoint: Schema.optional(
+                      Schema.Union([Schema.Boolean, Schema.Null]),
+                    ),
+                    returnIdTokenFromAuthorizationEndpoint: Schema.optional(
+                      Schema.Union([Schema.Boolean, Schema.Null]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      returnAccessTokenFromAuthorizationEndpoint:
+                        "return_access_token_from_authorization_endpoint",
+                      returnIdTokenFromAuthorizationEndpoint:
+                        "return_id_token_from_authorization_endpoint",
+                    }),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              publicKey: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              redirectUris: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              refreshTokenOptions: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    lifetime: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                  }),
+                  Schema.Null,
+                ]),
+              ),
+              scopes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Literals(["openid", "groups", "email", "profile"]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                accessTokenLifetime: "access_token_lifetime",
+                allowPkceWithoutClientSecret:
+                  "allow_pkce_without_client_secret",
+                appLauncherUrl: "app_launcher_url",
+                authType: "auth_type",
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                customClaims: "custom_claims",
+                grantTypes: "grant_types",
+                groupFilterRegex: "group_filter_regex",
+                hybridAndImplicitOptions: "hybrid_and_implicit_options",
+                publicKey: "public_key",
+                redirectUris: "redirect_uris",
+                refreshTokenOptions: "refresh_token_options",
+                scopes: "scopes",
+              }),
+            ),
+          ]),
+          Schema.Null,
+        ]),
       ),
       scimConfig: Schema.optional(
         Schema.Union([
@@ -8604,15 +8568,6 @@ export const GetAccessApplicationResponse =
             authentication: Schema.optional(
               Schema.Union([
                 Schema.Union([
-                  Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
                   Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
@@ -8633,6 +8588,11 @@ export const GetAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -8643,17 +8603,12 @@ export const GetAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -8677,6 +8632,11 @@ export const GetAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -8687,6 +8647,10 @@ export const GetAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -8762,54 +8726,90 @@ export const GetAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      selfHostedDomains: Schema.optional(
-        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-      ),
-      serviceAuth_401Redirect: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      sessionDuration: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      skipInterstitial: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       tags: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
+      type: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "self_hosted",
+            "saas",
+            "ssh",
+            "vnc",
+            "app_launcher",
+            "warp",
+            "biso",
+            "bookmark",
+            "dash_sso",
+            "infrastructure",
+            "rdp",
+            "mcp",
+            "mcp_portal",
+            "proxy_endpoint",
+          ]),
+          Schema.Null,
+        ]),
+      ),
     }).pipe(
       Schema.encodeKeys({
-        domain: "domain",
-        targetCriteria: "target_criteria",
-        type: "type",
         id: "id",
-        allowAuthenticateViaWarp: "allow_authenticate_via_warp",
-        allowIframe: "allow_iframe",
         allowedIdps: "allowed_idps",
         appLauncherVisible: "app_launcher_visible",
         aud: "aud",
         autoRedirectToIdentity: "auto_redirect_to_identity",
-        corsHeaders: "cors_headers",
-        customDenyMessage: "custom_deny_message",
-        customDenyUrl: "custom_deny_url",
-        customNonIdentityDenyUrl: "custom_non_identity_deny_url",
         customPages: "custom_pages",
-        destinations: "destinations",
-        enableBindingCookie: "enable_binding_cookie",
-        httpOnlyCookieAttribute: "http_only_cookie_attribute",
         logoUrl: "logo_url",
         name: "name",
-        optionsPreflightBypass: "options_preflight_bypass",
-        pathCookieAttribute: "path_cookie_attribute",
         policies: "policies",
-        readServiceTokensFromHeader: "read_service_tokens_from_header",
-        sameSiteCookieAttribute: "same_site_cookie_attribute",
+        saasApp: "saas_app",
         scimConfig: "scim_config",
-        selfHostedDomains: "self_hosted_domains",
-        serviceAuth_401Redirect: "service_auth_401_redirect",
-        sessionDuration: "session_duration",
-        skipInterstitial: "skip_interstitial",
         tags: "tags",
+        type: "type",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      appLauncherVisible: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      tags: Schema.optional(
+        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+      ),
+      type: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "self_hosted",
+            "saas",
+            "ssh",
+            "vnc",
+            "app_launcher",
+            "warp",
+            "biso",
+            "bookmark",
+            "dash_sso",
+            "infrastructure",
+            "rdp",
+            "mcp",
+            "mcp_portal",
+            "proxy_endpoint",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        appLauncherVisible: "app_launcher_visible",
+        aud: "aud",
+        domain: "domain",
+        logoUrl: "logo_url",
+        name: "name",
+        tags: "tags",
+        type: "type",
       }),
     ),
   ]).pipe(
@@ -10551,6 +10551,19 @@ export const ListAccessApplicationsResponse =
       Schema.Union([
         Schema.Struct({
           domain: Schema.String,
+          targetCriteria: Schema.Array(
+            Schema.Struct({
+              port: Schema.Number,
+              protocol: Schema.Literal("RDP"),
+              targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
+            }).pipe(
+              Schema.encodeKeys({
+                port: "port",
+                protocol: "protocol",
+                targetAttributes: "target_attributes",
+              }),
+            ),
+          ),
           type: Schema.Literals([
             "self_hosted",
             "saas",
@@ -11528,15 +11541,6 @@ export const ListAccessApplicationsResponse =
                   Schema.Union([
                     Schema.Union([
                       Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
-                      Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
@@ -11559,6 +11563,11 @@ export const ListAccessApplicationsResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -11569,17 +11578,12 @@ export const ListAccessApplicationsResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                       Schema.Array(
                         Schema.Union([
-                          Schema.Struct({
-                            password: SensitiveString,
-                            scheme: Schema.Literal("httpbasic"),
-                            user: Schema.String,
-                          }),
-                          Schema.Struct({
-                            token: Schema.String,
-                            scheme: Schema.Literal("oauthbearertoken"),
-                          }),
                           Schema.Struct({
                             authorizationUrl: Schema.String,
                             clientId: Schema.String,
@@ -11603,6 +11607,11 @@ export const ListAccessApplicationsResponse =
                             }),
                           ),
                           Schema.Struct({
+                            password: SensitiveString,
+                            scheme: Schema.Literal("httpbasic"),
+                            user: Schema.String,
+                          }),
+                          Schema.Struct({
                             clientId: Schema.String,
                             clientSecret: SensitiveString,
                             scheme: Schema.Literal("access_service_token"),
@@ -11613,6 +11622,10 @@ export const ListAccessApplicationsResponse =
                               scheme: "scheme",
                             }),
                           ),
+                          Schema.Struct({
+                            token: Schema.String,
+                            scheme: Schema.Literal("oauthbearertoken"),
+                          }),
                         ]),
                       ),
                     ]),
@@ -11706,6 +11719,7 @@ export const ListAccessApplicationsResponse =
         }).pipe(
           Schema.encodeKeys({
             domain: "domain",
+            targetCriteria: "target_criteria",
             type: "type",
             id: "id",
             allowAuthenticateViaWarp: "allow_authenticate_via_warp",
@@ -11738,7 +11752,30 @@ export const ListAccessApplicationsResponse =
           }),
         ),
         Schema.Struct({
+          domain: Schema.String,
+          type: Schema.Literals([
+            "self_hosted",
+            "saas",
+            "ssh",
+            "vnc",
+            "app_launcher",
+            "warp",
+            "biso",
+            "bookmark",
+            "dash_sso",
+            "infrastructure",
+            "rdp",
+            "mcp",
+            "mcp_portal",
+            "proxy_endpoint",
+          ]),
           id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          allowAuthenticateViaWarp: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
+          allowIframe: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
           allowedIdps: Schema.optional(
             Schema.Union([Schema.Array(Schema.String), Schema.Null]),
           ),
@@ -11749,11 +11786,154 @@ export const ListAccessApplicationsResponse =
           autoRedirectToIdentity: Schema.optional(
             Schema.Union([Schema.Boolean, Schema.Null]),
           ),
+          corsHeaders: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                allowAllHeaders: Schema.optional(
+                  Schema.Union([Schema.Boolean, Schema.Null]),
+                ),
+                allowAllMethods: Schema.optional(
+                  Schema.Union([Schema.Boolean, Schema.Null]),
+                ),
+                allowAllOrigins: Schema.optional(
+                  Schema.Union([Schema.Boolean, Schema.Null]),
+                ),
+                allowCredentials: Schema.optional(
+                  Schema.Union([Schema.Boolean, Schema.Null]),
+                ),
+                allowedHeaders: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                allowedMethods: Schema.optional(
+                  Schema.Union([
+                    Schema.Array(
+                      Schema.Literals([
+                        "GET",
+                        "POST",
+                        "HEAD",
+                        "PUT",
+                        "DELETE",
+                        "CONNECT",
+                        "OPTIONS",
+                        "TRACE",
+                        "PATCH",
+                      ]),
+                    ),
+                    Schema.Null,
+                  ]),
+                ),
+                allowedOrigins: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                maxAge: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  allowAllHeaders: "allow_all_headers",
+                  allowAllMethods: "allow_all_methods",
+                  allowAllOrigins: "allow_all_origins",
+                  allowCredentials: "allow_credentials",
+                  allowedHeaders: "allowed_headers",
+                  allowedMethods: "allowed_methods",
+                  allowedOrigins: "allowed_origins",
+                  maxAge: "max_age",
+                }),
+              ),
+              Schema.Null,
+            ]),
+          ),
+          customDenyMessage: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          customDenyUrl: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          customNonIdentityDenyUrl: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
           customPages: Schema.optional(
             Schema.Union([Schema.Array(Schema.String), Schema.Null]),
           ),
+          destinations: Schema.optional(
+            Schema.Union([
+              Schema.Array(
+                Schema.Union([
+                  Schema.Struct({
+                    type: Schema.optional(
+                      Schema.Union([Schema.Literal("public"), Schema.Null]),
+                    ),
+                    uri: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                  }),
+                  Schema.Struct({
+                    cidr: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    hostname: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    l4Protocol: Schema.optional(
+                      Schema.Union([
+                        Schema.Literals(["tcp", "udp"]),
+                        Schema.Null,
+                      ]),
+                    ),
+                    portRange: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    type: Schema.optional(
+                      Schema.Union([Schema.Literal("private"), Schema.Null]),
+                    ),
+                    vnetId: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      cidr: "cidr",
+                      hostname: "hostname",
+                      l4Protocol: "l4_protocol",
+                      portRange: "port_range",
+                      type: "type",
+                      vnetId: "vnet_id",
+                    }),
+                  ),
+                  Schema.Struct({
+                    mcpServerId: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    type: Schema.optional(
+                      Schema.Union([
+                        Schema.Literal("via_mcp_server_portal"),
+                        Schema.Null,
+                      ]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      mcpServerId: "mcp_server_id",
+                      type: "type",
+                    }),
+                  ),
+                ]),
+              ),
+              Schema.Null,
+            ]),
+          ),
+          enableBindingCookie: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
+          httpOnlyCookieAttribute: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
           logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
           name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          optionsPreflightBypass: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
+          pathCookieAttribute: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
           policies: Schema.optional(
             Schema.Union([
               Schema.Array(
@@ -12535,300 +12715,11 @@ export const ListAccessApplicationsResponse =
               Schema.Null,
             ]),
           ),
-          saasApp: Schema.optional(
-            Schema.Union([
-              Schema.Union([
-                Schema.Struct({
-                  authType: Schema.optional(
-                    Schema.Union([
-                      Schema.Literals(["saml", "oidc"]),
-                      Schema.Null,
-                    ]),
-                  ),
-                  consumerServiceUrl: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  customAttributes: Schema.optional(
-                    Schema.Union([
-                      Schema.Array(
-                        Schema.Struct({
-                          friendlyName: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                          name: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                          nameFormat: Schema.optional(
-                            Schema.Union([
-                              Schema.Literals([
-                                "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
-                                "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
-                                "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
-                              ]),
-                              Schema.Null,
-                            ]),
-                          ),
-                          required: Schema.optional(
-                            Schema.Union([Schema.Boolean, Schema.Null]),
-                          ),
-                          source: Schema.optional(
-                            Schema.Union([
-                              Schema.Struct({
-                                name: Schema.optional(
-                                  Schema.Union([Schema.String, Schema.Null]),
-                                ),
-                                nameByIdp: Schema.optional(
-                                  Schema.Union([
-                                    Schema.Array(
-                                      Schema.Struct({
-                                        idpId: Schema.optional(
-                                          Schema.Union([
-                                            Schema.String,
-                                            Schema.Null,
-                                          ]),
-                                        ),
-                                        sourceName: Schema.optional(
-                                          Schema.Union([
-                                            Schema.String,
-                                            Schema.Null,
-                                          ]),
-                                        ),
-                                      }).pipe(
-                                        Schema.encodeKeys({
-                                          idpId: "idp_id",
-                                          sourceName: "source_name",
-                                        }),
-                                      ),
-                                    ),
-                                    Schema.Null,
-                                  ]),
-                                ),
-                              }).pipe(
-                                Schema.encodeKeys({
-                                  name: "name",
-                                  nameByIdp: "name_by_idp",
-                                }),
-                              ),
-                              Schema.Null,
-                            ]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            friendlyName: "friendly_name",
-                            name: "name",
-                            nameFormat: "name_format",
-                            required: "required",
-                            source: "source",
-                          }),
-                        ),
-                      ),
-                      Schema.Null,
-                    ]),
-                  ),
-                  defaultRelayState: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  idpEntityId: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  nameIdFormat: Schema.optional(
-                    Schema.Union([
-                      Schema.Literals(["id", "email"]),
-                      Schema.Null,
-                    ]),
-                  ),
-                  nameIdTransformJsonata: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  publicKey: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  samlAttributeTransformJsonata: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  spEntityId: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  ssoEndpoint: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    authType: "auth_type",
-                    consumerServiceUrl: "consumer_service_url",
-                    customAttributes: "custom_attributes",
-                    defaultRelayState: "default_relay_state",
-                    idpEntityId: "idp_entity_id",
-                    nameIdFormat: "name_id_format",
-                    nameIdTransformJsonata: "name_id_transform_jsonata",
-                    publicKey: "public_key",
-                    samlAttributeTransformJsonata:
-                      "saml_attribute_transform_jsonata",
-                    spEntityId: "sp_entity_id",
-                    ssoEndpoint: "sso_endpoint",
-                  }),
-                ),
-                Schema.Struct({
-                  accessTokenLifetime: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  allowPkceWithoutClientSecret: Schema.optional(
-                    Schema.Union([Schema.Boolean, Schema.Null]),
-                  ),
-                  appLauncherUrl: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  authType: Schema.optional(
-                    Schema.Union([
-                      Schema.Literals(["saml", "oidc"]),
-                      Schema.Null,
-                    ]),
-                  ),
-                  clientId: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  clientSecret: Schema.optional(
-                    Schema.Union([SensitiveString, Schema.Null]),
-                  ),
-                  customClaims: Schema.optional(
-                    Schema.Union([
-                      Schema.Array(
-                        Schema.Struct({
-                          name: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                          required: Schema.optional(
-                            Schema.Union([Schema.Boolean, Schema.Null]),
-                          ),
-                          scope: Schema.optional(
-                            Schema.Union([
-                              Schema.Literals([
-                                "groups",
-                                "profile",
-                                "email",
-                                "openid",
-                              ]),
-                              Schema.Null,
-                            ]),
-                          ),
-                          source: Schema.optional(
-                            Schema.Union([
-                              Schema.Struct({
-                                name: Schema.optional(
-                                  Schema.Union([Schema.String, Schema.Null]),
-                                ),
-                                nameByIdp: Schema.optional(
-                                  Schema.Union([
-                                    Schema.Record(
-                                      Schema.String,
-                                      Schema.Unknown,
-                                    ),
-                                    Schema.Null,
-                                  ]),
-                                ),
-                              }).pipe(
-                                Schema.encodeKeys({
-                                  name: "name",
-                                  nameByIdp: "name_by_idp",
-                                }),
-                              ),
-                              Schema.Null,
-                            ]),
-                          ),
-                        }),
-                      ),
-                      Schema.Null,
-                    ]),
-                  ),
-                  grantTypes: Schema.optional(
-                    Schema.Union([
-                      Schema.Array(
-                        Schema.Literals([
-                          "authorization_code",
-                          "authorization_code_with_pkce",
-                          "refresh_tokens",
-                          "hybrid",
-                          "implicit",
-                        ]),
-                      ),
-                      Schema.Null,
-                    ]),
-                  ),
-                  groupFilterRegex: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  hybridAndImplicitOptions: Schema.optional(
-                    Schema.Union([
-                      Schema.Struct({
-                        returnAccessTokenFromAuthorizationEndpoint:
-                          Schema.optional(
-                            Schema.Union([Schema.Boolean, Schema.Null]),
-                          ),
-                        returnIdTokenFromAuthorizationEndpoint: Schema.optional(
-                          Schema.Union([Schema.Boolean, Schema.Null]),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          returnAccessTokenFromAuthorizationEndpoint:
-                            "return_access_token_from_authorization_endpoint",
-                          returnIdTokenFromAuthorizationEndpoint:
-                            "return_id_token_from_authorization_endpoint",
-                        }),
-                      ),
-                      Schema.Null,
-                    ]),
-                  ),
-                  publicKey: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  redirectUris: Schema.optional(
-                    Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                  ),
-                  refreshTokenOptions: Schema.optional(
-                    Schema.Union([
-                      Schema.Struct({
-                        lifetime: Schema.optional(
-                          Schema.Union([Schema.String, Schema.Null]),
-                        ),
-                      }),
-                      Schema.Null,
-                    ]),
-                  ),
-                  scopes: Schema.optional(
-                    Schema.Union([
-                      Schema.Array(
-                        Schema.Literals([
-                          "openid",
-                          "groups",
-                          "email",
-                          "profile",
-                        ]),
-                      ),
-                      Schema.Null,
-                    ]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    accessTokenLifetime: "access_token_lifetime",
-                    allowPkceWithoutClientSecret:
-                      "allow_pkce_without_client_secret",
-                    appLauncherUrl: "app_launcher_url",
-                    authType: "auth_type",
-                    clientId: "client_id",
-                    clientSecret: "client_secret",
-                    customClaims: "custom_claims",
-                    grantTypes: "grant_types",
-                    groupFilterRegex: "group_filter_regex",
-                    hybridAndImplicitOptions: "hybrid_and_implicit_options",
-                    publicKey: "public_key",
-                    redirectUris: "redirect_uris",
-                    refreshTokenOptions: "refresh_token_options",
-                    scopes: "scopes",
-                  }),
-                ),
-              ]),
-              Schema.Null,
-            ]),
+          readServiceTokensFromHeader: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          sameSiteCookieAttribute: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
           ),
           scimConfig: Schema.optional(
             Schema.Union([
@@ -12838,15 +12729,6 @@ export const ListAccessApplicationsResponse =
                 authentication: Schema.optional(
                   Schema.Union([
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -12870,6 +12752,11 @@ export const ListAccessApplicationsResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -12880,17 +12767,12 @@ export const ListAccessApplicationsResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                       Schema.Array(
                         Schema.Union([
-                          Schema.Struct({
-                            password: SensitiveString,
-                            scheme: Schema.Literal("httpbasic"),
-                            user: Schema.String,
-                          }),
-                          Schema.Struct({
-                            token: Schema.String,
-                            scheme: Schema.Literal("oauthbearertoken"),
-                          }),
                           Schema.Struct({
                             authorizationUrl: Schema.String,
                             clientId: Schema.String,
@@ -12914,6 +12796,11 @@ export const ListAccessApplicationsResponse =
                             }),
                           ),
                           Schema.Struct({
+                            password: SensitiveString,
+                            scheme: Schema.Literal("httpbasic"),
+                            user: Schema.String,
+                          }),
+                          Schema.Struct({
                             clientId: Schema.String,
                             clientSecret: SensitiveString,
                             scheme: Schema.Literal("access_service_token"),
@@ -12924,6 +12811,10 @@ export const ListAccessApplicationsResponse =
                               scheme: "scheme",
                             }),
                           ),
+                          Schema.Struct({
+                            token: Schema.String,
+                            scheme: Schema.Literal("oauthbearertoken"),
+                          }),
                         ]),
                       ),
                     ]),
@@ -12999,45 +12890,850 @@ export const ListAccessApplicationsResponse =
               Schema.Null,
             ]),
           ),
+          selfHostedDomains: Schema.optional(
+            Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+          ),
+          serviceAuth_401Redirect: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
+          sessionDuration: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          skipInterstitial: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
           tags: Schema.optional(
             Schema.Union([Schema.Array(Schema.String), Schema.Null]),
           ),
-          type: Schema.optional(
+        }).pipe(
+          Schema.encodeKeys({
+            domain: "domain",
+            type: "type",
+            id: "id",
+            allowAuthenticateViaWarp: "allow_authenticate_via_warp",
+            allowIframe: "allow_iframe",
+            allowedIdps: "allowed_idps",
+            appLauncherVisible: "app_launcher_visible",
+            aud: "aud",
+            autoRedirectToIdentity: "auto_redirect_to_identity",
+            corsHeaders: "cors_headers",
+            customDenyMessage: "custom_deny_message",
+            customDenyUrl: "custom_deny_url",
+            customNonIdentityDenyUrl: "custom_non_identity_deny_url",
+            customPages: "custom_pages",
+            destinations: "destinations",
+            enableBindingCookie: "enable_binding_cookie",
+            httpOnlyCookieAttribute: "http_only_cookie_attribute",
+            logoUrl: "logo_url",
+            name: "name",
+            optionsPreflightBypass: "options_preflight_bypass",
+            pathCookieAttribute: "path_cookie_attribute",
+            policies: "policies",
+            readServiceTokensFromHeader: "read_service_tokens_from_header",
+            sameSiteCookieAttribute: "same_site_cookie_attribute",
+            scimConfig: "scim_config",
+            selfHostedDomains: "self_hosted_domains",
+            serviceAuth_401Redirect: "service_auth_401_redirect",
+            sessionDuration: "session_duration",
+            skipInterstitial: "skip_interstitial",
+            tags: "tags",
+          }),
+        ),
+        Schema.Struct({
+          targetCriteria: Schema.Array(
+            Schema.Struct({
+              port: Schema.Number,
+              protocol: Schema.Literal("SSH"),
+              targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
+            }).pipe(
+              Schema.encodeKeys({
+                port: "port",
+                protocol: "protocol",
+                targetAttributes: "target_attributes",
+              }),
+            ),
+          ),
+          type: Schema.Literals([
+            "self_hosted",
+            "saas",
+            "ssh",
+            "vnc",
+            "app_launcher",
+            "warp",
+            "biso",
+            "bookmark",
+            "dash_sso",
+            "infrastructure",
+            "rdp",
+            "mcp",
+            "mcp_portal",
+            "proxy_endpoint",
+          ]),
+          id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          policies: Schema.optional(
             Schema.Union([
-              Schema.Literals([
-                "self_hosted",
-                "saas",
-                "ssh",
-                "vnc",
-                "app_launcher",
-                "warp",
-                "biso",
-                "bookmark",
-                "dash_sso",
-                "infrastructure",
-                "rdp",
-                "mcp",
-                "mcp_portal",
-                "proxy_endpoint",
-              ]),
+              Schema.Array(
+                Schema.Struct({
+                  id: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  connectionRules: Schema.optional(
+                    Schema.Union([
+                      Schema.Struct({
+                        ssh: Schema.optional(
+                          Schema.Union([
+                            Schema.Struct({
+                              usernames: Schema.Array(Schema.String),
+                              allowEmailAlias: Schema.optional(
+                                Schema.Union([Schema.Boolean, Schema.Null]),
+                              ),
+                            }).pipe(
+                              Schema.encodeKeys({
+                                usernames: "usernames",
+                                allowEmailAlias: "allow_email_alias",
+                              }),
+                            ),
+                            Schema.Null,
+                          ]),
+                        ),
+                      }),
+                      Schema.Null,
+                    ]),
+                  ),
+                  createdAt: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  decision: Schema.optional(
+                    Schema.Union([
+                      Schema.Literals([
+                        "allow",
+                        "deny",
+                        "non_identity",
+                        "bypass",
+                      ]),
+                      Schema.Null,
+                    ]),
+                  ),
+                  exclude: Schema.optional(
+                    Schema.Union([
+                      Schema.Array(
+                        Schema.Union([
+                          Schema.Struct({
+                            group: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            anyValidServiceToken: Schema.Unknown,
+                          }).pipe(
+                            Schema.encodeKeys({
+                              anyValidServiceToken: "any_valid_service_token",
+                            }),
+                          ),
+                          Schema.Struct({
+                            authContext: Schema.Struct({
+                              id: Schema.String,
+                              acId: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                id: "id",
+                                acId: "ac_id",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ authContext: "auth_context" }),
+                          ),
+                          Schema.Struct({
+                            authMethod: Schema.Struct({
+                              authMethod: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({ authMethod: "auth_method" }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ authMethod: "auth_method" }),
+                          ),
+                          Schema.Struct({
+                            azureAD: Schema.Struct({
+                              id: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                id: "id",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            certificate: Schema.Unknown,
+                          }),
+                          Schema.Struct({
+                            commonName: Schema.Struct({
+                              commonName: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({ commonName: "common_name" }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ commonName: "common_name" }),
+                          ),
+                          Schema.Struct({
+                            geo: Schema.Struct({
+                              countryCode: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                countryCode: "country_code",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            devicePosture: Schema.Struct({
+                              integrationUid: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                integrationUid: "integration_uid",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              devicePosture: "device_posture",
+                            }),
+                          ),
+                          Schema.Struct({
+                            emailDomain: Schema.Struct({
+                              domain: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ emailDomain: "email_domain" }),
+                          ),
+                          Schema.Struct({
+                            emailList: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ emailList: "email_list" }),
+                          ),
+                          Schema.Struct({
+                            email: Schema.Struct({
+                              email: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            everyone: Schema.Unknown,
+                          }),
+                          Schema.Struct({
+                            externalEvaluation: Schema.Struct({
+                              evaluateUrl: Schema.String,
+                              keysUrl: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                evaluateUrl: "evaluate_url",
+                                keysUrl: "keys_url",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              externalEvaluation: "external_evaluation",
+                            }),
+                          ),
+                          Schema.Struct({
+                            githubOrganization: Schema.Struct({
+                              identityProviderId: Schema.String,
+                              name: Schema.String,
+                              team: Schema.optional(
+                                Schema.Union([Schema.String, Schema.Null]),
+                              ),
+                            }).pipe(
+                              Schema.encodeKeys({
+                                identityProviderId: "identity_provider_id",
+                                name: "name",
+                                team: "team",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              githubOrganization: "github-organization",
+                            }),
+                          ),
+                          Schema.Struct({
+                            gsuite: Schema.Struct({
+                              email: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                email: "email",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            loginMethod: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ loginMethod: "login_method" }),
+                          ),
+                          Schema.Struct({
+                            ipList: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                          Schema.Struct({
+                            ip: Schema.Struct({
+                              ip: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            okta: Schema.Struct({
+                              identityProviderId: Schema.String,
+                              name: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                identityProviderId: "identity_provider_id",
+                                name: "name",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            saml: Schema.Struct({
+                              attributeName: Schema.String,
+                              attributeValue: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                attributeName: "attribute_name",
+                                attributeValue: "attribute_value",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            oidc: Schema.Struct({
+                              claimName: Schema.String,
+                              claimValue: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                claimName: "claim_name",
+                                claimValue: "claim_value",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            serviceToken: Schema.Struct({
+                              tokenId: Schema.String,
+                            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              serviceToken: "service_token",
+                            }),
+                          ),
+                          Schema.Struct({
+                            linkedAppToken: Schema.Struct({
+                              appUid: Schema.String,
+                            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              linkedAppToken: "linked_app_token",
+                            }),
+                          ),
+                        ]),
+                      ),
+                      Schema.Null,
+                    ]),
+                  ),
+                  include: Schema.optional(
+                    Schema.Union([
+                      Schema.Array(
+                        Schema.Union([
+                          Schema.Struct({
+                            group: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            anyValidServiceToken: Schema.Unknown,
+                          }).pipe(
+                            Schema.encodeKeys({
+                              anyValidServiceToken: "any_valid_service_token",
+                            }),
+                          ),
+                          Schema.Struct({
+                            authContext: Schema.Struct({
+                              id: Schema.String,
+                              acId: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                id: "id",
+                                acId: "ac_id",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ authContext: "auth_context" }),
+                          ),
+                          Schema.Struct({
+                            authMethod: Schema.Struct({
+                              authMethod: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({ authMethod: "auth_method" }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ authMethod: "auth_method" }),
+                          ),
+                          Schema.Struct({
+                            azureAD: Schema.Struct({
+                              id: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                id: "id",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            certificate: Schema.Unknown,
+                          }),
+                          Schema.Struct({
+                            commonName: Schema.Struct({
+                              commonName: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({ commonName: "common_name" }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ commonName: "common_name" }),
+                          ),
+                          Schema.Struct({
+                            geo: Schema.Struct({
+                              countryCode: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                countryCode: "country_code",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            devicePosture: Schema.Struct({
+                              integrationUid: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                integrationUid: "integration_uid",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              devicePosture: "device_posture",
+                            }),
+                          ),
+                          Schema.Struct({
+                            emailDomain: Schema.Struct({
+                              domain: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ emailDomain: "email_domain" }),
+                          ),
+                          Schema.Struct({
+                            emailList: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ emailList: "email_list" }),
+                          ),
+                          Schema.Struct({
+                            email: Schema.Struct({
+                              email: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            everyone: Schema.Unknown,
+                          }),
+                          Schema.Struct({
+                            externalEvaluation: Schema.Struct({
+                              evaluateUrl: Schema.String,
+                              keysUrl: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                evaluateUrl: "evaluate_url",
+                                keysUrl: "keys_url",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              externalEvaluation: "external_evaluation",
+                            }),
+                          ),
+                          Schema.Struct({
+                            githubOrganization: Schema.Struct({
+                              identityProviderId: Schema.String,
+                              name: Schema.String,
+                              team: Schema.optional(
+                                Schema.Union([Schema.String, Schema.Null]),
+                              ),
+                            }).pipe(
+                              Schema.encodeKeys({
+                                identityProviderId: "identity_provider_id",
+                                name: "name",
+                                team: "team",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              githubOrganization: "github-organization",
+                            }),
+                          ),
+                          Schema.Struct({
+                            gsuite: Schema.Struct({
+                              email: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                email: "email",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            loginMethod: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ loginMethod: "login_method" }),
+                          ),
+                          Schema.Struct({
+                            ipList: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                          Schema.Struct({
+                            ip: Schema.Struct({
+                              ip: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            okta: Schema.Struct({
+                              identityProviderId: Schema.String,
+                              name: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                identityProviderId: "identity_provider_id",
+                                name: "name",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            saml: Schema.Struct({
+                              attributeName: Schema.String,
+                              attributeValue: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                attributeName: "attribute_name",
+                                attributeValue: "attribute_value",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            oidc: Schema.Struct({
+                              claimName: Schema.String,
+                              claimValue: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                claimName: "claim_name",
+                                claimValue: "claim_value",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            serviceToken: Schema.Struct({
+                              tokenId: Schema.String,
+                            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              serviceToken: "service_token",
+                            }),
+                          ),
+                          Schema.Struct({
+                            linkedAppToken: Schema.Struct({
+                              appUid: Schema.String,
+                            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              linkedAppToken: "linked_app_token",
+                            }),
+                          ),
+                        ]),
+                      ),
+                      Schema.Null,
+                    ]),
+                  ),
+                  name: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  require: Schema.optional(
+                    Schema.Union([
+                      Schema.Array(
+                        Schema.Union([
+                          Schema.Struct({
+                            group: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            anyValidServiceToken: Schema.Unknown,
+                          }).pipe(
+                            Schema.encodeKeys({
+                              anyValidServiceToken: "any_valid_service_token",
+                            }),
+                          ),
+                          Schema.Struct({
+                            authContext: Schema.Struct({
+                              id: Schema.String,
+                              acId: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                id: "id",
+                                acId: "ac_id",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ authContext: "auth_context" }),
+                          ),
+                          Schema.Struct({
+                            authMethod: Schema.Struct({
+                              authMethod: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({ authMethod: "auth_method" }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ authMethod: "auth_method" }),
+                          ),
+                          Schema.Struct({
+                            azureAD: Schema.Struct({
+                              id: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                id: "id",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            certificate: Schema.Unknown,
+                          }),
+                          Schema.Struct({
+                            commonName: Schema.Struct({
+                              commonName: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({ commonName: "common_name" }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({ commonName: "common_name" }),
+                          ),
+                          Schema.Struct({
+                            geo: Schema.Struct({
+                              countryCode: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                countryCode: "country_code",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            devicePosture: Schema.Struct({
+                              integrationUid: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                integrationUid: "integration_uid",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              devicePosture: "device_posture",
+                            }),
+                          ),
+                          Schema.Struct({
+                            emailDomain: Schema.Struct({
+                              domain: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ emailDomain: "email_domain" }),
+                          ),
+                          Schema.Struct({
+                            emailList: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ emailList: "email_list" }),
+                          ),
+                          Schema.Struct({
+                            email: Schema.Struct({
+                              email: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            everyone: Schema.Unknown,
+                          }),
+                          Schema.Struct({
+                            externalEvaluation: Schema.Struct({
+                              evaluateUrl: Schema.String,
+                              keysUrl: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                evaluateUrl: "evaluate_url",
+                                keysUrl: "keys_url",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              externalEvaluation: "external_evaluation",
+                            }),
+                          ),
+                          Schema.Struct({
+                            githubOrganization: Schema.Struct({
+                              identityProviderId: Schema.String,
+                              name: Schema.String,
+                              team: Schema.optional(
+                                Schema.Union([Schema.String, Schema.Null]),
+                              ),
+                            }).pipe(
+                              Schema.encodeKeys({
+                                identityProviderId: "identity_provider_id",
+                                name: "name",
+                                team: "team",
+                              }),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              githubOrganization: "github-organization",
+                            }),
+                          ),
+                          Schema.Struct({
+                            gsuite: Schema.Struct({
+                              email: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                email: "email",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            loginMethod: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(
+                            Schema.encodeKeys({ loginMethod: "login_method" }),
+                          ),
+                          Schema.Struct({
+                            ipList: Schema.Struct({
+                              id: Schema.String,
+                            }),
+                          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                          Schema.Struct({
+                            ip: Schema.Struct({
+                              ip: Schema.String,
+                            }),
+                          }),
+                          Schema.Struct({
+                            okta: Schema.Struct({
+                              identityProviderId: Schema.String,
+                              name: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                identityProviderId: "identity_provider_id",
+                                name: "name",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            saml: Schema.Struct({
+                              attributeName: Schema.String,
+                              attributeValue: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                attributeName: "attribute_name",
+                                attributeValue: "attribute_value",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            oidc: Schema.Struct({
+                              claimName: Schema.String,
+                              claimValue: Schema.String,
+                              identityProviderId: Schema.String,
+                            }).pipe(
+                              Schema.encodeKeys({
+                                claimName: "claim_name",
+                                claimValue: "claim_value",
+                                identityProviderId: "identity_provider_id",
+                              }),
+                            ),
+                          }),
+                          Schema.Struct({
+                            serviceToken: Schema.Struct({
+                              tokenId: Schema.String,
+                            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              serviceToken: "service_token",
+                            }),
+                          ),
+                          Schema.Struct({
+                            linkedAppToken: Schema.Struct({
+                              appUid: Schema.String,
+                            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              linkedAppToken: "linked_app_token",
+                            }),
+                          ),
+                        ]),
+                      ),
+                      Schema.Null,
+                    ]),
+                  ),
+                  updatedAt: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    id: "id",
+                    connectionRules: "connection_rules",
+                    createdAt: "created_at",
+                    decision: "decision",
+                    exclude: "exclude",
+                    include: "include",
+                    name: "name",
+                    require: "require",
+                    updatedAt: "updated_at",
+                  }),
+                ),
+              ),
               Schema.Null,
             ]),
           ),
         }).pipe(
           Schema.encodeKeys({
+            targetCriteria: "target_criteria",
+            type: "type",
             id: "id",
-            allowedIdps: "allowed_idps",
-            appLauncherVisible: "app_launcher_visible",
             aud: "aud",
-            autoRedirectToIdentity: "auto_redirect_to_identity",
-            customPages: "custom_pages",
-            logoUrl: "logo_url",
             name: "name",
             policies: "policies",
-            saasApp: "saas_app",
-            scimConfig: "scim_config",
-            tags: "tags",
-            type: "type",
           }),
         ),
         Schema.Struct({
@@ -14771,884 +15467,6 @@ export const ListAccessApplicationsResponse =
         ),
         Schema.Struct({
           id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          appLauncherVisible: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
-          aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          tags: Schema.optional(
-            Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-          ),
-          type: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "self_hosted",
-                "saas",
-                "ssh",
-                "vnc",
-                "app_launcher",
-                "warp",
-                "biso",
-                "bookmark",
-                "dash_sso",
-                "infrastructure",
-                "rdp",
-                "mcp",
-                "mcp_portal",
-                "proxy_endpoint",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            appLauncherVisible: "app_launcher_visible",
-            aud: "aud",
-            domain: "domain",
-            logoUrl: "logo_url",
-            name: "name",
-            tags: "tags",
-            type: "type",
-          }),
-        ),
-        Schema.Struct({
-          targetCriteria: Schema.Array(
-            Schema.Struct({
-              port: Schema.Number,
-              protocol: Schema.Literal("SSH"),
-              targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
-            }).pipe(
-              Schema.encodeKeys({
-                port: "port",
-                protocol: "protocol",
-                targetAttributes: "target_attributes",
-              }),
-            ),
-          ),
-          type: Schema.Literals([
-            "self_hosted",
-            "saas",
-            "ssh",
-            "vnc",
-            "app_launcher",
-            "warp",
-            "biso",
-            "bookmark",
-            "dash_sso",
-            "infrastructure",
-            "rdp",
-            "mcp",
-            "mcp_portal",
-            "proxy_endpoint",
-          ]),
-          id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          policies: Schema.optional(
-            Schema.Union([
-              Schema.Array(
-                Schema.Struct({
-                  id: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  connectionRules: Schema.optional(
-                    Schema.Union([
-                      Schema.Struct({
-                        ssh: Schema.optional(
-                          Schema.Union([
-                            Schema.Struct({
-                              usernames: Schema.Array(Schema.String),
-                              allowEmailAlias: Schema.optional(
-                                Schema.Union([Schema.Boolean, Schema.Null]),
-                              ),
-                            }).pipe(
-                              Schema.encodeKeys({
-                                usernames: "usernames",
-                                allowEmailAlias: "allow_email_alias",
-                              }),
-                            ),
-                            Schema.Null,
-                          ]),
-                        ),
-                      }),
-                      Schema.Null,
-                    ]),
-                  ),
-                  createdAt: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  decision: Schema.optional(
-                    Schema.Union([
-                      Schema.Literals([
-                        "allow",
-                        "deny",
-                        "non_identity",
-                        "bypass",
-                      ]),
-                      Schema.Null,
-                    ]),
-                  ),
-                  exclude: Schema.optional(
-                    Schema.Union([
-                      Schema.Array(
-                        Schema.Union([
-                          Schema.Struct({
-                            group: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            anyValidServiceToken: Schema.Unknown,
-                          }).pipe(
-                            Schema.encodeKeys({
-                              anyValidServiceToken: "any_valid_service_token",
-                            }),
-                          ),
-                          Schema.Struct({
-                            authContext: Schema.Struct({
-                              id: Schema.String,
-                              acId: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                id: "id",
-                                acId: "ac_id",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ authContext: "auth_context" }),
-                          ),
-                          Schema.Struct({
-                            authMethod: Schema.Struct({
-                              authMethod: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({ authMethod: "auth_method" }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ authMethod: "auth_method" }),
-                          ),
-                          Schema.Struct({
-                            azureAD: Schema.Struct({
-                              id: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                id: "id",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            certificate: Schema.Unknown,
-                          }),
-                          Schema.Struct({
-                            commonName: Schema.Struct({
-                              commonName: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({ commonName: "common_name" }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ commonName: "common_name" }),
-                          ),
-                          Schema.Struct({
-                            geo: Schema.Struct({
-                              countryCode: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                countryCode: "country_code",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            devicePosture: Schema.Struct({
-                              integrationUid: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                integrationUid: "integration_uid",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              devicePosture: "device_posture",
-                            }),
-                          ),
-                          Schema.Struct({
-                            emailDomain: Schema.Struct({
-                              domain: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ emailDomain: "email_domain" }),
-                          ),
-                          Schema.Struct({
-                            emailList: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ emailList: "email_list" }),
-                          ),
-                          Schema.Struct({
-                            email: Schema.Struct({
-                              email: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            everyone: Schema.Unknown,
-                          }),
-                          Schema.Struct({
-                            externalEvaluation: Schema.Struct({
-                              evaluateUrl: Schema.String,
-                              keysUrl: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                evaluateUrl: "evaluate_url",
-                                keysUrl: "keys_url",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              externalEvaluation: "external_evaluation",
-                            }),
-                          ),
-                          Schema.Struct({
-                            githubOrganization: Schema.Struct({
-                              identityProviderId: Schema.String,
-                              name: Schema.String,
-                              team: Schema.optional(
-                                Schema.Union([Schema.String, Schema.Null]),
-                              ),
-                            }).pipe(
-                              Schema.encodeKeys({
-                                identityProviderId: "identity_provider_id",
-                                name: "name",
-                                team: "team",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              githubOrganization: "github-organization",
-                            }),
-                          ),
-                          Schema.Struct({
-                            gsuite: Schema.Struct({
-                              email: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                email: "email",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            loginMethod: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ loginMethod: "login_method" }),
-                          ),
-                          Schema.Struct({
-                            ipList: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                          Schema.Struct({
-                            ip: Schema.Struct({
-                              ip: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            okta: Schema.Struct({
-                              identityProviderId: Schema.String,
-                              name: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                identityProviderId: "identity_provider_id",
-                                name: "name",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            saml: Schema.Struct({
-                              attributeName: Schema.String,
-                              attributeValue: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                attributeName: "attribute_name",
-                                attributeValue: "attribute_value",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            oidc: Schema.Struct({
-                              claimName: Schema.String,
-                              claimValue: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                claimName: "claim_name",
-                                claimValue: "claim_value",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            serviceToken: Schema.Struct({
-                              tokenId: Schema.String,
-                            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              serviceToken: "service_token",
-                            }),
-                          ),
-                          Schema.Struct({
-                            linkedAppToken: Schema.Struct({
-                              appUid: Schema.String,
-                            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              linkedAppToken: "linked_app_token",
-                            }),
-                          ),
-                        ]),
-                      ),
-                      Schema.Null,
-                    ]),
-                  ),
-                  include: Schema.optional(
-                    Schema.Union([
-                      Schema.Array(
-                        Schema.Union([
-                          Schema.Struct({
-                            group: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            anyValidServiceToken: Schema.Unknown,
-                          }).pipe(
-                            Schema.encodeKeys({
-                              anyValidServiceToken: "any_valid_service_token",
-                            }),
-                          ),
-                          Schema.Struct({
-                            authContext: Schema.Struct({
-                              id: Schema.String,
-                              acId: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                id: "id",
-                                acId: "ac_id",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ authContext: "auth_context" }),
-                          ),
-                          Schema.Struct({
-                            authMethod: Schema.Struct({
-                              authMethod: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({ authMethod: "auth_method" }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ authMethod: "auth_method" }),
-                          ),
-                          Schema.Struct({
-                            azureAD: Schema.Struct({
-                              id: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                id: "id",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            certificate: Schema.Unknown,
-                          }),
-                          Schema.Struct({
-                            commonName: Schema.Struct({
-                              commonName: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({ commonName: "common_name" }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ commonName: "common_name" }),
-                          ),
-                          Schema.Struct({
-                            geo: Schema.Struct({
-                              countryCode: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                countryCode: "country_code",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            devicePosture: Schema.Struct({
-                              integrationUid: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                integrationUid: "integration_uid",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              devicePosture: "device_posture",
-                            }),
-                          ),
-                          Schema.Struct({
-                            emailDomain: Schema.Struct({
-                              domain: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ emailDomain: "email_domain" }),
-                          ),
-                          Schema.Struct({
-                            emailList: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ emailList: "email_list" }),
-                          ),
-                          Schema.Struct({
-                            email: Schema.Struct({
-                              email: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            everyone: Schema.Unknown,
-                          }),
-                          Schema.Struct({
-                            externalEvaluation: Schema.Struct({
-                              evaluateUrl: Schema.String,
-                              keysUrl: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                evaluateUrl: "evaluate_url",
-                                keysUrl: "keys_url",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              externalEvaluation: "external_evaluation",
-                            }),
-                          ),
-                          Schema.Struct({
-                            githubOrganization: Schema.Struct({
-                              identityProviderId: Schema.String,
-                              name: Schema.String,
-                              team: Schema.optional(
-                                Schema.Union([Schema.String, Schema.Null]),
-                              ),
-                            }).pipe(
-                              Schema.encodeKeys({
-                                identityProviderId: "identity_provider_id",
-                                name: "name",
-                                team: "team",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              githubOrganization: "github-organization",
-                            }),
-                          ),
-                          Schema.Struct({
-                            gsuite: Schema.Struct({
-                              email: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                email: "email",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            loginMethod: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ loginMethod: "login_method" }),
-                          ),
-                          Schema.Struct({
-                            ipList: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                          Schema.Struct({
-                            ip: Schema.Struct({
-                              ip: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            okta: Schema.Struct({
-                              identityProviderId: Schema.String,
-                              name: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                identityProviderId: "identity_provider_id",
-                                name: "name",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            saml: Schema.Struct({
-                              attributeName: Schema.String,
-                              attributeValue: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                attributeName: "attribute_name",
-                                attributeValue: "attribute_value",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            oidc: Schema.Struct({
-                              claimName: Schema.String,
-                              claimValue: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                claimName: "claim_name",
-                                claimValue: "claim_value",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            serviceToken: Schema.Struct({
-                              tokenId: Schema.String,
-                            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              serviceToken: "service_token",
-                            }),
-                          ),
-                          Schema.Struct({
-                            linkedAppToken: Schema.Struct({
-                              appUid: Schema.String,
-                            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              linkedAppToken: "linked_app_token",
-                            }),
-                          ),
-                        ]),
-                      ),
-                      Schema.Null,
-                    ]),
-                  ),
-                  name: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                  require: Schema.optional(
-                    Schema.Union([
-                      Schema.Array(
-                        Schema.Union([
-                          Schema.Struct({
-                            group: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            anyValidServiceToken: Schema.Unknown,
-                          }).pipe(
-                            Schema.encodeKeys({
-                              anyValidServiceToken: "any_valid_service_token",
-                            }),
-                          ),
-                          Schema.Struct({
-                            authContext: Schema.Struct({
-                              id: Schema.String,
-                              acId: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                id: "id",
-                                acId: "ac_id",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ authContext: "auth_context" }),
-                          ),
-                          Schema.Struct({
-                            authMethod: Schema.Struct({
-                              authMethod: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({ authMethod: "auth_method" }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ authMethod: "auth_method" }),
-                          ),
-                          Schema.Struct({
-                            azureAD: Schema.Struct({
-                              id: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                id: "id",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            certificate: Schema.Unknown,
-                          }),
-                          Schema.Struct({
-                            commonName: Schema.Struct({
-                              commonName: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({ commonName: "common_name" }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({ commonName: "common_name" }),
-                          ),
-                          Schema.Struct({
-                            geo: Schema.Struct({
-                              countryCode: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                countryCode: "country_code",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            devicePosture: Schema.Struct({
-                              integrationUid: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                integrationUid: "integration_uid",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              devicePosture: "device_posture",
-                            }),
-                          ),
-                          Schema.Struct({
-                            emailDomain: Schema.Struct({
-                              domain: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ emailDomain: "email_domain" }),
-                          ),
-                          Schema.Struct({
-                            emailList: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ emailList: "email_list" }),
-                          ),
-                          Schema.Struct({
-                            email: Schema.Struct({
-                              email: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            everyone: Schema.Unknown,
-                          }),
-                          Schema.Struct({
-                            externalEvaluation: Schema.Struct({
-                              evaluateUrl: Schema.String,
-                              keysUrl: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                evaluateUrl: "evaluate_url",
-                                keysUrl: "keys_url",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              externalEvaluation: "external_evaluation",
-                            }),
-                          ),
-                          Schema.Struct({
-                            githubOrganization: Schema.Struct({
-                              identityProviderId: Schema.String,
-                              name: Schema.String,
-                              team: Schema.optional(
-                                Schema.Union([Schema.String, Schema.Null]),
-                              ),
-                            }).pipe(
-                              Schema.encodeKeys({
-                                identityProviderId: "identity_provider_id",
-                                name: "name",
-                                team: "team",
-                              }),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              githubOrganization: "github-organization",
-                            }),
-                          ),
-                          Schema.Struct({
-                            gsuite: Schema.Struct({
-                              email: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                email: "email",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            loginMethod: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(
-                            Schema.encodeKeys({ loginMethod: "login_method" }),
-                          ),
-                          Schema.Struct({
-                            ipList: Schema.Struct({
-                              id: Schema.String,
-                            }),
-                          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                          Schema.Struct({
-                            ip: Schema.Struct({
-                              ip: Schema.String,
-                            }),
-                          }),
-                          Schema.Struct({
-                            okta: Schema.Struct({
-                              identityProviderId: Schema.String,
-                              name: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                identityProviderId: "identity_provider_id",
-                                name: "name",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            saml: Schema.Struct({
-                              attributeName: Schema.String,
-                              attributeValue: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                attributeName: "attribute_name",
-                                attributeValue: "attribute_value",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            oidc: Schema.Struct({
-                              claimName: Schema.String,
-                              claimValue: Schema.String,
-                              identityProviderId: Schema.String,
-                            }).pipe(
-                              Schema.encodeKeys({
-                                claimName: "claim_name",
-                                claimValue: "claim_value",
-                                identityProviderId: "identity_provider_id",
-                              }),
-                            ),
-                          }),
-                          Schema.Struct({
-                            serviceToken: Schema.Struct({
-                              tokenId: Schema.String,
-                            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              serviceToken: "service_token",
-                            }),
-                          ),
-                          Schema.Struct({
-                            linkedAppToken: Schema.Struct({
-                              appUid: Schema.String,
-                            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              linkedAppToken: "linked_app_token",
-                            }),
-                          ),
-                        ]),
-                      ),
-                      Schema.Null,
-                    ]),
-                  ),
-                  updatedAt: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    id: "id",
-                    connectionRules: "connection_rules",
-                    createdAt: "created_at",
-                    decision: "decision",
-                    exclude: "exclude",
-                    include: "include",
-                    name: "name",
-                    require: "require",
-                    updatedAt: "updated_at",
-                  }),
-                ),
-              ),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            targetCriteria: "target_criteria",
-            type: "type",
-            id: "id",
-            aud: "aud",
-            name: "name",
-            policies: "policies",
-          }),
-        ),
-        Schema.Struct({
-          domain: Schema.String,
-          targetCriteria: Schema.Array(
-            Schema.Struct({
-              port: Schema.Number,
-              protocol: Schema.Literal("RDP"),
-              targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
-            }).pipe(
-              Schema.encodeKeys({
-                port: "port",
-                protocol: "protocol",
-                targetAttributes: "target_attributes",
-              }),
-            ),
-          ),
-          type: Schema.Literals([
-            "self_hosted",
-            "saas",
-            "ssh",
-            "vnc",
-            "app_launcher",
-            "warp",
-            "biso",
-            "bookmark",
-            "dash_sso",
-            "infrastructure",
-            "rdp",
-            "mcp",
-            "mcp_portal",
-            "proxy_endpoint",
-          ]),
-          id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          allowAuthenticateViaWarp: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
-          allowIframe: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
           allowedIdps: Schema.optional(
             Schema.Union([Schema.Array(Schema.String), Schema.Null]),
           ),
@@ -15659,154 +15477,11 @@ export const ListAccessApplicationsResponse =
           autoRedirectToIdentity: Schema.optional(
             Schema.Union([Schema.Boolean, Schema.Null]),
           ),
-          corsHeaders: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                allowAllHeaders: Schema.optional(
-                  Schema.Union([Schema.Boolean, Schema.Null]),
-                ),
-                allowAllMethods: Schema.optional(
-                  Schema.Union([Schema.Boolean, Schema.Null]),
-                ),
-                allowAllOrigins: Schema.optional(
-                  Schema.Union([Schema.Boolean, Schema.Null]),
-                ),
-                allowCredentials: Schema.optional(
-                  Schema.Union([Schema.Boolean, Schema.Null]),
-                ),
-                allowedHeaders: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                allowedMethods: Schema.optional(
-                  Schema.Union([
-                    Schema.Array(
-                      Schema.Literals([
-                        "GET",
-                        "POST",
-                        "HEAD",
-                        "PUT",
-                        "DELETE",
-                        "CONNECT",
-                        "OPTIONS",
-                        "TRACE",
-                        "PATCH",
-                      ]),
-                    ),
-                    Schema.Null,
-                  ]),
-                ),
-                allowedOrigins: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                maxAge: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  allowAllHeaders: "allow_all_headers",
-                  allowAllMethods: "allow_all_methods",
-                  allowAllOrigins: "allow_all_origins",
-                  allowCredentials: "allow_credentials",
-                  allowedHeaders: "allowed_headers",
-                  allowedMethods: "allowed_methods",
-                  allowedOrigins: "allowed_origins",
-                  maxAge: "max_age",
-                }),
-              ),
-              Schema.Null,
-            ]),
-          ),
-          customDenyMessage: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          customDenyUrl: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          customNonIdentityDenyUrl: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
           customPages: Schema.optional(
             Schema.Union([Schema.Array(Schema.String), Schema.Null]),
           ),
-          destinations: Schema.optional(
-            Schema.Union([
-              Schema.Array(
-                Schema.Union([
-                  Schema.Struct({
-                    type: Schema.optional(
-                      Schema.Union([Schema.Literal("public"), Schema.Null]),
-                    ),
-                    uri: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }),
-                  Schema.Struct({
-                    cidr: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    hostname: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    l4Protocol: Schema.optional(
-                      Schema.Union([
-                        Schema.Literals(["tcp", "udp"]),
-                        Schema.Null,
-                      ]),
-                    ),
-                    portRange: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    type: Schema.optional(
-                      Schema.Union([Schema.Literal("private"), Schema.Null]),
-                    ),
-                    vnetId: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      cidr: "cidr",
-                      hostname: "hostname",
-                      l4Protocol: "l4_protocol",
-                      portRange: "port_range",
-                      type: "type",
-                      vnetId: "vnet_id",
-                    }),
-                  ),
-                  Schema.Struct({
-                    mcpServerId: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    type: Schema.optional(
-                      Schema.Union([
-                        Schema.Literal("via_mcp_server_portal"),
-                        Schema.Null,
-                      ]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      mcpServerId: "mcp_server_id",
-                      type: "type",
-                    }),
-                  ),
-                ]),
-              ),
-              Schema.Null,
-            ]),
-          ),
-          enableBindingCookie: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
-          httpOnlyCookieAttribute: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
           logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
           name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          optionsPreflightBypass: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
-          pathCookieAttribute: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
           policies: Schema.optional(
             Schema.Union([
               Schema.Array(
@@ -16588,11 +16263,300 @@ export const ListAccessApplicationsResponse =
               Schema.Null,
             ]),
           ),
-          readServiceTokensFromHeader: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          sameSiteCookieAttribute: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
+          saasApp: Schema.optional(
+            Schema.Union([
+              Schema.Union([
+                Schema.Struct({
+                  authType: Schema.optional(
+                    Schema.Union([
+                      Schema.Literals(["saml", "oidc"]),
+                      Schema.Null,
+                    ]),
+                  ),
+                  consumerServiceUrl: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  customAttributes: Schema.optional(
+                    Schema.Union([
+                      Schema.Array(
+                        Schema.Struct({
+                          friendlyName: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                          name: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                          nameFormat: Schema.optional(
+                            Schema.Union([
+                              Schema.Literals([
+                                "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
+                                "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                                "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                              ]),
+                              Schema.Null,
+                            ]),
+                          ),
+                          required: Schema.optional(
+                            Schema.Union([Schema.Boolean, Schema.Null]),
+                          ),
+                          source: Schema.optional(
+                            Schema.Union([
+                              Schema.Struct({
+                                name: Schema.optional(
+                                  Schema.Union([Schema.String, Schema.Null]),
+                                ),
+                                nameByIdp: Schema.optional(
+                                  Schema.Union([
+                                    Schema.Array(
+                                      Schema.Struct({
+                                        idpId: Schema.optional(
+                                          Schema.Union([
+                                            Schema.String,
+                                            Schema.Null,
+                                          ]),
+                                        ),
+                                        sourceName: Schema.optional(
+                                          Schema.Union([
+                                            Schema.String,
+                                            Schema.Null,
+                                          ]),
+                                        ),
+                                      }).pipe(
+                                        Schema.encodeKeys({
+                                          idpId: "idp_id",
+                                          sourceName: "source_name",
+                                        }),
+                                      ),
+                                    ),
+                                    Schema.Null,
+                                  ]),
+                                ),
+                              }).pipe(
+                                Schema.encodeKeys({
+                                  name: "name",
+                                  nameByIdp: "name_by_idp",
+                                }),
+                              ),
+                              Schema.Null,
+                            ]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            friendlyName: "friendly_name",
+                            name: "name",
+                            nameFormat: "name_format",
+                            required: "required",
+                            source: "source",
+                          }),
+                        ),
+                      ),
+                      Schema.Null,
+                    ]),
+                  ),
+                  defaultRelayState: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  idpEntityId: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  nameIdFormat: Schema.optional(
+                    Schema.Union([
+                      Schema.Literals(["id", "email"]),
+                      Schema.Null,
+                    ]),
+                  ),
+                  nameIdTransformJsonata: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  publicKey: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  samlAttributeTransformJsonata: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  spEntityId: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  ssoEndpoint: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    authType: "auth_type",
+                    consumerServiceUrl: "consumer_service_url",
+                    customAttributes: "custom_attributes",
+                    defaultRelayState: "default_relay_state",
+                    idpEntityId: "idp_entity_id",
+                    nameIdFormat: "name_id_format",
+                    nameIdTransformJsonata: "name_id_transform_jsonata",
+                    publicKey: "public_key",
+                    samlAttributeTransformJsonata:
+                      "saml_attribute_transform_jsonata",
+                    spEntityId: "sp_entity_id",
+                    ssoEndpoint: "sso_endpoint",
+                  }),
+                ),
+                Schema.Struct({
+                  accessTokenLifetime: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  allowPkceWithoutClientSecret: Schema.optional(
+                    Schema.Union([Schema.Boolean, Schema.Null]),
+                  ),
+                  appLauncherUrl: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  authType: Schema.optional(
+                    Schema.Union([
+                      Schema.Literals(["saml", "oidc"]),
+                      Schema.Null,
+                    ]),
+                  ),
+                  clientId: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  clientSecret: Schema.optional(
+                    Schema.Union([SensitiveString, Schema.Null]),
+                  ),
+                  customClaims: Schema.optional(
+                    Schema.Union([
+                      Schema.Array(
+                        Schema.Struct({
+                          name: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                          required: Schema.optional(
+                            Schema.Union([Schema.Boolean, Schema.Null]),
+                          ),
+                          scope: Schema.optional(
+                            Schema.Union([
+                              Schema.Literals([
+                                "groups",
+                                "profile",
+                                "email",
+                                "openid",
+                              ]),
+                              Schema.Null,
+                            ]),
+                          ),
+                          source: Schema.optional(
+                            Schema.Union([
+                              Schema.Struct({
+                                name: Schema.optional(
+                                  Schema.Union([Schema.String, Schema.Null]),
+                                ),
+                                nameByIdp: Schema.optional(
+                                  Schema.Union([
+                                    Schema.Record(
+                                      Schema.String,
+                                      Schema.Unknown,
+                                    ),
+                                    Schema.Null,
+                                  ]),
+                                ),
+                              }).pipe(
+                                Schema.encodeKeys({
+                                  name: "name",
+                                  nameByIdp: "name_by_idp",
+                                }),
+                              ),
+                              Schema.Null,
+                            ]),
+                          ),
+                        }),
+                      ),
+                      Schema.Null,
+                    ]),
+                  ),
+                  grantTypes: Schema.optional(
+                    Schema.Union([
+                      Schema.Array(
+                        Schema.Literals([
+                          "authorization_code",
+                          "authorization_code_with_pkce",
+                          "refresh_tokens",
+                          "hybrid",
+                          "implicit",
+                        ]),
+                      ),
+                      Schema.Null,
+                    ]),
+                  ),
+                  groupFilterRegex: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  hybridAndImplicitOptions: Schema.optional(
+                    Schema.Union([
+                      Schema.Struct({
+                        returnAccessTokenFromAuthorizationEndpoint:
+                          Schema.optional(
+                            Schema.Union([Schema.Boolean, Schema.Null]),
+                          ),
+                        returnIdTokenFromAuthorizationEndpoint: Schema.optional(
+                          Schema.Union([Schema.Boolean, Schema.Null]),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          returnAccessTokenFromAuthorizationEndpoint:
+                            "return_access_token_from_authorization_endpoint",
+                          returnIdTokenFromAuthorizationEndpoint:
+                            "return_id_token_from_authorization_endpoint",
+                        }),
+                      ),
+                      Schema.Null,
+                    ]),
+                  ),
+                  publicKey: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                  redirectUris: Schema.optional(
+                    Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                  ),
+                  refreshTokenOptions: Schema.optional(
+                    Schema.Union([
+                      Schema.Struct({
+                        lifetime: Schema.optional(
+                          Schema.Union([Schema.String, Schema.Null]),
+                        ),
+                      }),
+                      Schema.Null,
+                    ]),
+                  ),
+                  scopes: Schema.optional(
+                    Schema.Union([
+                      Schema.Array(
+                        Schema.Literals([
+                          "openid",
+                          "groups",
+                          "email",
+                          "profile",
+                        ]),
+                      ),
+                      Schema.Null,
+                    ]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    accessTokenLifetime: "access_token_lifetime",
+                    allowPkceWithoutClientSecret:
+                      "allow_pkce_without_client_secret",
+                    appLauncherUrl: "app_launcher_url",
+                    authType: "auth_type",
+                    clientId: "client_id",
+                    clientSecret: "client_secret",
+                    customClaims: "custom_claims",
+                    grantTypes: "grant_types",
+                    groupFilterRegex: "group_filter_regex",
+                    hybridAndImplicitOptions: "hybrid_and_implicit_options",
+                    publicKey: "public_key",
+                    redirectUris: "redirect_uris",
+                    refreshTokenOptions: "refresh_token_options",
+                    scopes: "scopes",
+                  }),
+                ),
+              ]),
+              Schema.Null,
+            ]),
           ),
           scimConfig: Schema.optional(
             Schema.Union([
@@ -16602,15 +16566,6 @@ export const ListAccessApplicationsResponse =
                 authentication: Schema.optional(
                   Schema.Union([
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -16634,6 +16589,11 @@ export const ListAccessApplicationsResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -16644,17 +16604,12 @@ export const ListAccessApplicationsResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                       Schema.Array(
                         Schema.Union([
-                          Schema.Struct({
-                            password: SensitiveString,
-                            scheme: Schema.Literal("httpbasic"),
-                            user: Schema.String,
-                          }),
-                          Schema.Struct({
-                            token: Schema.String,
-                            scheme: Schema.Literal("oauthbearertoken"),
-                          }),
                           Schema.Struct({
                             authorizationUrl: Schema.String,
                             clientId: Schema.String,
@@ -16678,6 +16633,11 @@ export const ListAccessApplicationsResponse =
                             }),
                           ),
                           Schema.Struct({
+                            password: SensitiveString,
+                            scheme: Schema.Literal("httpbasic"),
+                            user: Schema.String,
+                          }),
+                          Schema.Struct({
                             clientId: Schema.String,
                             clientSecret: SensitiveString,
                             scheme: Schema.Literal("access_service_token"),
@@ -16688,6 +16648,10 @@ export const ListAccessApplicationsResponse =
                               scheme: "scheme",
                             }),
                           ),
+                          Schema.Struct({
+                            token: Schema.String,
+                            scheme: Schema.Literal("oauthbearertoken"),
+                          }),
                         ]),
                       ),
                     ]),
@@ -16763,54 +16727,90 @@ export const ListAccessApplicationsResponse =
               Schema.Null,
             ]),
           ),
-          selfHostedDomains: Schema.optional(
-            Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-          ),
-          serviceAuth_401Redirect: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
-          sessionDuration: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          skipInterstitial: Schema.optional(
-            Schema.Union([Schema.Boolean, Schema.Null]),
-          ),
           tags: Schema.optional(
             Schema.Union([Schema.Array(Schema.String), Schema.Null]),
           ),
+          type: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "self_hosted",
+                "saas",
+                "ssh",
+                "vnc",
+                "app_launcher",
+                "warp",
+                "biso",
+                "bookmark",
+                "dash_sso",
+                "infrastructure",
+                "rdp",
+                "mcp",
+                "mcp_portal",
+                "proxy_endpoint",
+              ]),
+              Schema.Null,
+            ]),
+          ),
         }).pipe(
           Schema.encodeKeys({
-            domain: "domain",
-            targetCriteria: "target_criteria",
-            type: "type",
             id: "id",
-            allowAuthenticateViaWarp: "allow_authenticate_via_warp",
-            allowIframe: "allow_iframe",
             allowedIdps: "allowed_idps",
             appLauncherVisible: "app_launcher_visible",
             aud: "aud",
             autoRedirectToIdentity: "auto_redirect_to_identity",
-            corsHeaders: "cors_headers",
-            customDenyMessage: "custom_deny_message",
-            customDenyUrl: "custom_deny_url",
-            customNonIdentityDenyUrl: "custom_non_identity_deny_url",
             customPages: "custom_pages",
-            destinations: "destinations",
-            enableBindingCookie: "enable_binding_cookie",
-            httpOnlyCookieAttribute: "http_only_cookie_attribute",
             logoUrl: "logo_url",
             name: "name",
-            optionsPreflightBypass: "options_preflight_bypass",
-            pathCookieAttribute: "path_cookie_attribute",
             policies: "policies",
-            readServiceTokensFromHeader: "read_service_tokens_from_header",
-            sameSiteCookieAttribute: "same_site_cookie_attribute",
+            saasApp: "saas_app",
             scimConfig: "scim_config",
-            selfHostedDomains: "self_hosted_domains",
-            serviceAuth_401Redirect: "service_auth_401_redirect",
-            sessionDuration: "session_duration",
-            skipInterstitial: "skip_interstitial",
             tags: "tags",
+            type: "type",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          appLauncherVisible: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
+          aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          tags: Schema.optional(
+            Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+          ),
+          type: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "self_hosted",
+                "saas",
+                "ssh",
+                "vnc",
+                "app_launcher",
+                "warp",
+                "biso",
+                "bookmark",
+                "dash_sso",
+                "infrastructure",
+                "rdp",
+                "mcp",
+                "mcp_portal",
+                "proxy_endpoint",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            appLauncherVisible: "app_launcher_visible",
+            aud: "aud",
+            domain: "domain",
+            logoUrl: "logo_url",
+            name: "name",
+            tags: "tags",
+            type: "type",
           }),
         ),
       ]),
@@ -17183,15 +17183,6 @@ export const CreateAccessApplicationRequest =
         authentication: Schema.optional(
           Schema.Union([
             Schema.Struct({
-              password: SensitiveString,
-              scheme: Schema.Literal("httpbasic"),
-              user: Schema.String,
-            }),
-            Schema.Struct({
-              token: Schema.String,
-              scheme: Schema.Literal("oauthbearertoken"),
-            }),
-            Schema.Struct({
               authorizationUrl: Schema.String,
               clientId: Schema.String,
               clientSecret: SensitiveString,
@@ -17209,6 +17200,11 @@ export const CreateAccessApplicationRequest =
               }),
             ),
             Schema.Struct({
+              password: SensitiveString,
+              scheme: Schema.Literal("httpbasic"),
+              user: Schema.String,
+            }),
+            Schema.Struct({
               clientId: Schema.String,
               clientSecret: SensitiveString,
               scheme: Schema.Literal("access_service_token"),
@@ -17219,17 +17215,12 @@ export const CreateAccessApplicationRequest =
                 scheme: "scheme",
               }),
             ),
+            Schema.Struct({
+              token: Schema.String,
+              scheme: Schema.Literal("oauthbearertoken"),
+            }),
             Schema.Array(
               Schema.Union([
-                Schema.Struct({
-                  password: SensitiveString,
-                  scheme: Schema.Literal("httpbasic"),
-                  user: Schema.String,
-                }),
-                Schema.Struct({
-                  token: Schema.String,
-                  scheme: Schema.Literal("oauthbearertoken"),
-                }),
                 Schema.Struct({
                   authorizationUrl: Schema.String,
                   clientId: Schema.String,
@@ -17248,6 +17239,11 @@ export const CreateAccessApplicationRequest =
                   }),
                 ),
                 Schema.Struct({
+                  password: SensitiveString,
+                  scheme: Schema.Literal("httpbasic"),
+                  user: Schema.String,
+                }),
+                Schema.Struct({
                   clientId: Schema.String,
                   clientSecret: SensitiveString,
                   scheme: Schema.Literal("access_service_token"),
@@ -17258,6 +17254,10 @@ export const CreateAccessApplicationRequest =
                     scheme: "scheme",
                   }),
                 ),
+                Schema.Struct({
+                  token: Schema.String,
+                  scheme: Schema.Literal("oauthbearertoken"),
+                }),
               ]),
             ),
           ]),
@@ -19044,6 +19044,19 @@ export const CreateAccessApplicationResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
       domain: Schema.String,
+      targetCriteria: Schema.Array(
+        Schema.Struct({
+          port: Schema.Number,
+          protocol: Schema.Literal("RDP"),
+          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
+        }).pipe(
+          Schema.encodeKeys({
+            port: "port",
+            protocol: "protocol",
+            targetAttributes: "target_attributes",
+          }),
+        ),
+      ),
       type: Schema.Literals([
         "self_hosted",
         "saas",
@@ -19968,15 +19981,6 @@ export const CreateAccessApplicationResponse =
               Schema.Union([
                 Schema.Union([
                   Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
-                  Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
@@ -19996,6 +20000,11 @@ export const CreateAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -20006,17 +20015,12 @@ export const CreateAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -20040,6 +20044,11 @@ export const CreateAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -20050,6 +20059,10 @@ export const CreateAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -20143,6 +20156,7 @@ export const CreateAccessApplicationResponse =
     }).pipe(
       Schema.encodeKeys({
         domain: "domain",
+        targetCriteria: "target_criteria",
         type: "type",
         id: "id",
         allowAuthenticateViaWarp: "allow_authenticate_via_warp",
@@ -20175,7 +20189,28 @@ export const CreateAccessApplicationResponse =
       }),
     ),
     Schema.Struct({
+      domain: Schema.String,
+      type: Schema.Literals([
+        "self_hosted",
+        "saas",
+        "ssh",
+        "vnc",
+        "app_launcher",
+        "warp",
+        "biso",
+        "bookmark",
+        "dash_sso",
+        "infrastructure",
+        "rdp",
+        "mcp",
+        "mcp_portal",
+        "proxy_endpoint",
+      ]),
       id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      allowAuthenticateViaWarp: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      allowIframe: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
       allowedIdps: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
@@ -20186,11 +20221,149 @@ export const CreateAccessApplicationResponse =
       autoRedirectToIdentity: Schema.optional(
         Schema.Union([Schema.Boolean, Schema.Null]),
       ),
+      corsHeaders: Schema.optional(
+        Schema.Union([
+          Schema.Struct({
+            allowAllHeaders: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowAllMethods: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowAllOrigins: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowCredentials: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowedHeaders: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            allowedMethods: Schema.optional(
+              Schema.Union([
+                Schema.Array(
+                  Schema.Literals([
+                    "GET",
+                    "POST",
+                    "HEAD",
+                    "PUT",
+                    "DELETE",
+                    "CONNECT",
+                    "OPTIONS",
+                    "TRACE",
+                    "PATCH",
+                  ]),
+                ),
+                Schema.Null,
+              ]),
+            ),
+            allowedOrigins: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            maxAge: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          }).pipe(
+            Schema.encodeKeys({
+              allowAllHeaders: "allow_all_headers",
+              allowAllMethods: "allow_all_methods",
+              allowAllOrigins: "allow_all_origins",
+              allowCredentials: "allow_credentials",
+              allowedHeaders: "allowed_headers",
+              allowedMethods: "allowed_methods",
+              allowedOrigins: "allowed_origins",
+              maxAge: "max_age",
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      customDenyMessage: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      customDenyUrl: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      customNonIdentityDenyUrl: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
       customPages: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
+      destinations: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Union([
+              Schema.Struct({
+                type: Schema.optional(
+                  Schema.Union([Schema.Literal("public"), Schema.Null]),
+                ),
+                uri: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }),
+              Schema.Struct({
+                cidr: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                hostname: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                l4Protocol: Schema.optional(
+                  Schema.Union([Schema.Literals(["tcp", "udp"]), Schema.Null]),
+                ),
+                portRange: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                type: Schema.optional(
+                  Schema.Union([Schema.Literal("private"), Schema.Null]),
+                ),
+                vnetId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  cidr: "cidr",
+                  hostname: "hostname",
+                  l4Protocol: "l4_protocol",
+                  portRange: "port_range",
+                  type: "type",
+                  vnetId: "vnet_id",
+                }),
+              ),
+              Schema.Struct({
+                mcpServerId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                type: Schema.optional(
+                  Schema.Union([
+                    Schema.Literal("via_mcp_server_portal"),
+                    Schema.Null,
+                  ]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  mcpServerId: "mcp_server_id",
+                  type: "type",
+                }),
+              ),
+            ]),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      enableBindingCookie: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      httpOnlyCookieAttribute: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
       name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      optionsPreflightBypass: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      pathCookieAttribute: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       policies: Schema.optional(
         Schema.Union([
           Schema.Array(
@@ -20926,282 +21099,11 @@ export const CreateAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      saasApp: Schema.optional(
-        Schema.Union([
-          Schema.Union([
-            Schema.Struct({
-              authType: Schema.optional(
-                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
-              ),
-              consumerServiceUrl: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              customAttributes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Struct({
-                      friendlyName: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      name: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      nameFormat: Schema.optional(
-                        Schema.Union([
-                          Schema.Literals([
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
-                          ]),
-                          Schema.Null,
-                        ]),
-                      ),
-                      required: Schema.optional(
-                        Schema.Union([Schema.Boolean, Schema.Null]),
-                      ),
-                      source: Schema.optional(
-                        Schema.Union([
-                          Schema.Struct({
-                            name: Schema.optional(
-                              Schema.Union([Schema.String, Schema.Null]),
-                            ),
-                            nameByIdp: Schema.optional(
-                              Schema.Union([
-                                Schema.Array(
-                                  Schema.Struct({
-                                    idpId: Schema.optional(
-                                      Schema.Union([
-                                        Schema.String,
-                                        Schema.Null,
-                                      ]),
-                                    ),
-                                    sourceName: Schema.optional(
-                                      Schema.Union([
-                                        Schema.String,
-                                        Schema.Null,
-                                      ]),
-                                    ),
-                                  }).pipe(
-                                    Schema.encodeKeys({
-                                      idpId: "idp_id",
-                                      sourceName: "source_name",
-                                    }),
-                                  ),
-                                ),
-                                Schema.Null,
-                              ]),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              name: "name",
-                              nameByIdp: "name_by_idp",
-                            }),
-                          ),
-                          Schema.Null,
-                        ]),
-                      ),
-                    }).pipe(
-                      Schema.encodeKeys({
-                        friendlyName: "friendly_name",
-                        name: "name",
-                        nameFormat: "name_format",
-                        required: "required",
-                        source: "source",
-                      }),
-                    ),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              defaultRelayState: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              idpEntityId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              nameIdFormat: Schema.optional(
-                Schema.Union([Schema.Literals(["id", "email"]), Schema.Null]),
-              ),
-              nameIdTransformJsonata: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              publicKey: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              samlAttributeTransformJsonata: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              spEntityId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              ssoEndpoint: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                authType: "auth_type",
-                consumerServiceUrl: "consumer_service_url",
-                customAttributes: "custom_attributes",
-                defaultRelayState: "default_relay_state",
-                idpEntityId: "idp_entity_id",
-                nameIdFormat: "name_id_format",
-                nameIdTransformJsonata: "name_id_transform_jsonata",
-                publicKey: "public_key",
-                samlAttributeTransformJsonata:
-                  "saml_attribute_transform_jsonata",
-                spEntityId: "sp_entity_id",
-                ssoEndpoint: "sso_endpoint",
-              }),
-            ),
-            Schema.Struct({
-              accessTokenLifetime: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              allowPkceWithoutClientSecret: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-              appLauncherUrl: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              authType: Schema.optional(
-                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
-              ),
-              clientId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              clientSecret: Schema.optional(
-                Schema.Union([SensitiveString, Schema.Null]),
-              ),
-              customClaims: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Struct({
-                      name: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      required: Schema.optional(
-                        Schema.Union([Schema.Boolean, Schema.Null]),
-                      ),
-                      scope: Schema.optional(
-                        Schema.Union([
-                          Schema.Literals([
-                            "groups",
-                            "profile",
-                            "email",
-                            "openid",
-                          ]),
-                          Schema.Null,
-                        ]),
-                      ),
-                      source: Schema.optional(
-                        Schema.Union([
-                          Schema.Struct({
-                            name: Schema.optional(
-                              Schema.Union([Schema.String, Schema.Null]),
-                            ),
-                            nameByIdp: Schema.optional(
-                              Schema.Union([
-                                Schema.Record(Schema.String, Schema.Unknown),
-                                Schema.Null,
-                              ]),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              name: "name",
-                              nameByIdp: "name_by_idp",
-                            }),
-                          ),
-                          Schema.Null,
-                        ]),
-                      ),
-                    }),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              grantTypes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Literals([
-                      "authorization_code",
-                      "authorization_code_with_pkce",
-                      "refresh_tokens",
-                      "hybrid",
-                      "implicit",
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              groupFilterRegex: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              hybridAndImplicitOptions: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    returnAccessTokenFromAuthorizationEndpoint: Schema.optional(
-                      Schema.Union([Schema.Boolean, Schema.Null]),
-                    ),
-                    returnIdTokenFromAuthorizationEndpoint: Schema.optional(
-                      Schema.Union([Schema.Boolean, Schema.Null]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      returnAccessTokenFromAuthorizationEndpoint:
-                        "return_access_token_from_authorization_endpoint",
-                      returnIdTokenFromAuthorizationEndpoint:
-                        "return_id_token_from_authorization_endpoint",
-                    }),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              publicKey: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              redirectUris: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              refreshTokenOptions: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    lifetime: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }),
-                  Schema.Null,
-                ]),
-              ),
-              scopes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Literals(["openid", "groups", "email", "profile"]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                accessTokenLifetime: "access_token_lifetime",
-                allowPkceWithoutClientSecret:
-                  "allow_pkce_without_client_secret",
-                appLauncherUrl: "app_launcher_url",
-                authType: "auth_type",
-                clientId: "client_id",
-                clientSecret: "client_secret",
-                customClaims: "custom_claims",
-                grantTypes: "grant_types",
-                groupFilterRegex: "group_filter_regex",
-                hybridAndImplicitOptions: "hybrid_and_implicit_options",
-                publicKey: "public_key",
-                redirectUris: "redirect_uris",
-                refreshTokenOptions: "refresh_token_options",
-                scopes: "scopes",
-              }),
-            ),
-          ]),
-          Schema.Null,
-        ]),
+      readServiceTokensFromHeader: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      sameSiteCookieAttribute: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
       ),
       scimConfig: Schema.optional(
         Schema.Union([
@@ -21211,15 +21113,6 @@ export const CreateAccessApplicationResponse =
             authentication: Schema.optional(
               Schema.Union([
                 Schema.Union([
-                  Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
                   Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
@@ -21240,6 +21133,11 @@ export const CreateAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -21250,17 +21148,12 @@ export const CreateAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -21284,6 +21177,11 @@ export const CreateAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -21294,6 +21192,10 @@ export const CreateAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -21369,45 +21271,805 @@ export const CreateAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
+      selfHostedDomains: Schema.optional(
+        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+      ),
+      serviceAuth_401Redirect: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      sessionDuration: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      skipInterstitial: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       tags: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
-      type: Schema.optional(
+    }).pipe(
+      Schema.encodeKeys({
+        domain: "domain",
+        type: "type",
+        id: "id",
+        allowAuthenticateViaWarp: "allow_authenticate_via_warp",
+        allowIframe: "allow_iframe",
+        allowedIdps: "allowed_idps",
+        appLauncherVisible: "app_launcher_visible",
+        aud: "aud",
+        autoRedirectToIdentity: "auto_redirect_to_identity",
+        corsHeaders: "cors_headers",
+        customDenyMessage: "custom_deny_message",
+        customDenyUrl: "custom_deny_url",
+        customNonIdentityDenyUrl: "custom_non_identity_deny_url",
+        customPages: "custom_pages",
+        destinations: "destinations",
+        enableBindingCookie: "enable_binding_cookie",
+        httpOnlyCookieAttribute: "http_only_cookie_attribute",
+        logoUrl: "logo_url",
+        name: "name",
+        optionsPreflightBypass: "options_preflight_bypass",
+        pathCookieAttribute: "path_cookie_attribute",
+        policies: "policies",
+        readServiceTokensFromHeader: "read_service_tokens_from_header",
+        sameSiteCookieAttribute: "same_site_cookie_attribute",
+        scimConfig: "scim_config",
+        selfHostedDomains: "self_hosted_domains",
+        serviceAuth_401Redirect: "service_auth_401_redirect",
+        sessionDuration: "session_duration",
+        skipInterstitial: "skip_interstitial",
+        tags: "tags",
+      }),
+    ),
+    Schema.Struct({
+      targetCriteria: Schema.Array(
+        Schema.Struct({
+          port: Schema.Number,
+          protocol: Schema.Literal("SSH"),
+          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
+        }).pipe(
+          Schema.encodeKeys({
+            port: "port",
+            protocol: "protocol",
+            targetAttributes: "target_attributes",
+          }),
+        ),
+      ),
+      type: Schema.Literals([
+        "self_hosted",
+        "saas",
+        "ssh",
+        "vnc",
+        "app_launcher",
+        "warp",
+        "biso",
+        "bookmark",
+        "dash_sso",
+        "infrastructure",
+        "rdp",
+        "mcp",
+        "mcp_portal",
+        "proxy_endpoint",
+      ]),
+      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      policies: Schema.optional(
         Schema.Union([
-          Schema.Literals([
-            "self_hosted",
-            "saas",
-            "ssh",
-            "vnc",
-            "app_launcher",
-            "warp",
-            "biso",
-            "bookmark",
-            "dash_sso",
-            "infrastructure",
-            "rdp",
-            "mcp",
-            "mcp_portal",
-            "proxy_endpoint",
-          ]),
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+              connectionRules: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    ssh: Schema.optional(
+                      Schema.Union([
+                        Schema.Struct({
+                          usernames: Schema.Array(Schema.String),
+                          allowEmailAlias: Schema.optional(
+                            Schema.Union([Schema.Boolean, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            usernames: "usernames",
+                            allowEmailAlias: "allow_email_alias",
+                          }),
+                        ),
+                        Schema.Null,
+                      ]),
+                    ),
+                  }),
+                  Schema.Null,
+                ]),
+              ),
+              createdAt: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              decision: Schema.optional(
+                Schema.Union([
+                  Schema.Literals(["allow", "deny", "non_identity", "bypass"]),
+                  Schema.Null,
+                ]),
+              ),
+              exclude: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              include: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+              require: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              updatedAt: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                id: "id",
+                connectionRules: "connection_rules",
+                createdAt: "created_at",
+                decision: "decision",
+                exclude: "exclude",
+                include: "include",
+                name: "name",
+                require: "require",
+                updatedAt: "updated_at",
+              }),
+            ),
+          ),
           Schema.Null,
         ]),
       ),
     }).pipe(
       Schema.encodeKeys({
+        targetCriteria: "target_criteria",
+        type: "type",
         id: "id",
-        allowedIdps: "allowed_idps",
-        appLauncherVisible: "app_launcher_visible",
         aud: "aud",
-        autoRedirectToIdentity: "auto_redirect_to_identity",
-        customPages: "custom_pages",
-        logoUrl: "logo_url",
         name: "name",
         policies: "policies",
-        saasApp: "saas_app",
-        scimConfig: "scim_config",
-        tags: "tags",
-        type: "type",
       }),
     ),
     Schema.Struct({
@@ -23047,837 +23709,6 @@ export const CreateAccessApplicationResponse =
     ),
     Schema.Struct({
       id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      appLauncherVisible: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      tags: Schema.optional(
-        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-      ),
-      type: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "self_hosted",
-            "saas",
-            "ssh",
-            "vnc",
-            "app_launcher",
-            "warp",
-            "biso",
-            "bookmark",
-            "dash_sso",
-            "infrastructure",
-            "rdp",
-            "mcp",
-            "mcp_portal",
-            "proxy_endpoint",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        appLauncherVisible: "app_launcher_visible",
-        aud: "aud",
-        domain: "domain",
-        logoUrl: "logo_url",
-        name: "name",
-        tags: "tags",
-        type: "type",
-      }),
-    ),
-    Schema.Struct({
-      targetCriteria: Schema.Array(
-        Schema.Struct({
-          port: Schema.Number,
-          protocol: Schema.Literal("SSH"),
-          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
-        }).pipe(
-          Schema.encodeKeys({
-            port: "port",
-            protocol: "protocol",
-            targetAttributes: "target_attributes",
-          }),
-        ),
-      ),
-      type: Schema.Literals([
-        "self_hosted",
-        "saas",
-        "ssh",
-        "vnc",
-        "app_launcher",
-        "warp",
-        "biso",
-        "bookmark",
-        "dash_sso",
-        "infrastructure",
-        "rdp",
-        "mcp",
-        "mcp_portal",
-        "proxy_endpoint",
-      ]),
-      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      policies: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-              connectionRules: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    ssh: Schema.optional(
-                      Schema.Union([
-                        Schema.Struct({
-                          usernames: Schema.Array(Schema.String),
-                          allowEmailAlias: Schema.optional(
-                            Schema.Union([Schema.Boolean, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            usernames: "usernames",
-                            allowEmailAlias: "allow_email_alias",
-                          }),
-                        ),
-                        Schema.Null,
-                      ]),
-                    ),
-                  }),
-                  Schema.Null,
-                ]),
-              ),
-              createdAt: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              decision: Schema.optional(
-                Schema.Union([
-                  Schema.Literals(["allow", "deny", "non_identity", "bypass"]),
-                  Schema.Null,
-                ]),
-              ),
-              exclude: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              include: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-              require: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              updatedAt: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                connectionRules: "connection_rules",
-                createdAt: "created_at",
-                decision: "decision",
-                exclude: "exclude",
-                include: "include",
-                name: "name",
-                require: "require",
-                updatedAt: "updated_at",
-              }),
-            ),
-          ),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        targetCriteria: "target_criteria",
-        type: "type",
-        id: "id",
-        aud: "aud",
-        name: "name",
-        policies: "policies",
-      }),
-    ),
-    Schema.Struct({
-      domain: Schema.String,
-      targetCriteria: Schema.Array(
-        Schema.Struct({
-          port: Schema.Number,
-          protocol: Schema.Literal("RDP"),
-          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
-        }).pipe(
-          Schema.encodeKeys({
-            port: "port",
-            protocol: "protocol",
-            targetAttributes: "target_attributes",
-          }),
-        ),
-      ),
-      type: Schema.Literals([
-        "self_hosted",
-        "saas",
-        "ssh",
-        "vnc",
-        "app_launcher",
-        "warp",
-        "biso",
-        "bookmark",
-        "dash_sso",
-        "infrastructure",
-        "rdp",
-        "mcp",
-        "mcp_portal",
-        "proxy_endpoint",
-      ]),
-      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      allowAuthenticateViaWarp: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      allowIframe: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
       allowedIdps: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
@@ -23888,149 +23719,11 @@ export const CreateAccessApplicationResponse =
       autoRedirectToIdentity: Schema.optional(
         Schema.Union([Schema.Boolean, Schema.Null]),
       ),
-      corsHeaders: Schema.optional(
-        Schema.Union([
-          Schema.Struct({
-            allowAllHeaders: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowAllMethods: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowAllOrigins: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowCredentials: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowedHeaders: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            allowedMethods: Schema.optional(
-              Schema.Union([
-                Schema.Array(
-                  Schema.Literals([
-                    "GET",
-                    "POST",
-                    "HEAD",
-                    "PUT",
-                    "DELETE",
-                    "CONNECT",
-                    "OPTIONS",
-                    "TRACE",
-                    "PATCH",
-                  ]),
-                ),
-                Schema.Null,
-              ]),
-            ),
-            allowedOrigins: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            maxAge: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-          }).pipe(
-            Schema.encodeKeys({
-              allowAllHeaders: "allow_all_headers",
-              allowAllMethods: "allow_all_methods",
-              allowAllOrigins: "allow_all_origins",
-              allowCredentials: "allow_credentials",
-              allowedHeaders: "allowed_headers",
-              allowedMethods: "allowed_methods",
-              allowedOrigins: "allowed_origins",
-              maxAge: "max_age",
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      customDenyMessage: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      customDenyUrl: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      customNonIdentityDenyUrl: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
       customPages: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
-      destinations: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Union([
-              Schema.Struct({
-                type: Schema.optional(
-                  Schema.Union([Schema.Literal("public"), Schema.Null]),
-                ),
-                uri: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }),
-              Schema.Struct({
-                cidr: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                hostname: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                l4Protocol: Schema.optional(
-                  Schema.Union([Schema.Literals(["tcp", "udp"]), Schema.Null]),
-                ),
-                portRange: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                type: Schema.optional(
-                  Schema.Union([Schema.Literal("private"), Schema.Null]),
-                ),
-                vnetId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  cidr: "cidr",
-                  hostname: "hostname",
-                  l4Protocol: "l4_protocol",
-                  portRange: "port_range",
-                  type: "type",
-                  vnetId: "vnet_id",
-                }),
-              ),
-              Schema.Struct({
-                mcpServerId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                type: Schema.optional(
-                  Schema.Union([
-                    Schema.Literal("via_mcp_server_portal"),
-                    Schema.Null,
-                  ]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  mcpServerId: "mcp_server_id",
-                  type: "type",
-                }),
-              ),
-            ]),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      enableBindingCookie: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      httpOnlyCookieAttribute: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
       name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      optionsPreflightBypass: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      pathCookieAttribute: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       policies: Schema.optional(
         Schema.Union([
           Schema.Array(
@@ -24766,11 +24459,282 @@ export const CreateAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      readServiceTokensFromHeader: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      sameSiteCookieAttribute: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
+      saasApp: Schema.optional(
+        Schema.Union([
+          Schema.Union([
+            Schema.Struct({
+              authType: Schema.optional(
+                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
+              ),
+              consumerServiceUrl: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              customAttributes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Struct({
+                      friendlyName: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      name: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      nameFormat: Schema.optional(
+                        Schema.Union([
+                          Schema.Literals([
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                          ]),
+                          Schema.Null,
+                        ]),
+                      ),
+                      required: Schema.optional(
+                        Schema.Union([Schema.Boolean, Schema.Null]),
+                      ),
+                      source: Schema.optional(
+                        Schema.Union([
+                          Schema.Struct({
+                            name: Schema.optional(
+                              Schema.Union([Schema.String, Schema.Null]),
+                            ),
+                            nameByIdp: Schema.optional(
+                              Schema.Union([
+                                Schema.Array(
+                                  Schema.Struct({
+                                    idpId: Schema.optional(
+                                      Schema.Union([
+                                        Schema.String,
+                                        Schema.Null,
+                                      ]),
+                                    ),
+                                    sourceName: Schema.optional(
+                                      Schema.Union([
+                                        Schema.String,
+                                        Schema.Null,
+                                      ]),
+                                    ),
+                                  }).pipe(
+                                    Schema.encodeKeys({
+                                      idpId: "idp_id",
+                                      sourceName: "source_name",
+                                    }),
+                                  ),
+                                ),
+                                Schema.Null,
+                              ]),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              name: "name",
+                              nameByIdp: "name_by_idp",
+                            }),
+                          ),
+                          Schema.Null,
+                        ]),
+                      ),
+                    }).pipe(
+                      Schema.encodeKeys({
+                        friendlyName: "friendly_name",
+                        name: "name",
+                        nameFormat: "name_format",
+                        required: "required",
+                        source: "source",
+                      }),
+                    ),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              defaultRelayState: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              idpEntityId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              nameIdFormat: Schema.optional(
+                Schema.Union([Schema.Literals(["id", "email"]), Schema.Null]),
+              ),
+              nameIdTransformJsonata: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              publicKey: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              samlAttributeTransformJsonata: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              spEntityId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              ssoEndpoint: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                authType: "auth_type",
+                consumerServiceUrl: "consumer_service_url",
+                customAttributes: "custom_attributes",
+                defaultRelayState: "default_relay_state",
+                idpEntityId: "idp_entity_id",
+                nameIdFormat: "name_id_format",
+                nameIdTransformJsonata: "name_id_transform_jsonata",
+                publicKey: "public_key",
+                samlAttributeTransformJsonata:
+                  "saml_attribute_transform_jsonata",
+                spEntityId: "sp_entity_id",
+                ssoEndpoint: "sso_endpoint",
+              }),
+            ),
+            Schema.Struct({
+              accessTokenLifetime: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              allowPkceWithoutClientSecret: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+              appLauncherUrl: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              authType: Schema.optional(
+                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
+              ),
+              clientId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              clientSecret: Schema.optional(
+                Schema.Union([SensitiveString, Schema.Null]),
+              ),
+              customClaims: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Struct({
+                      name: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      required: Schema.optional(
+                        Schema.Union([Schema.Boolean, Schema.Null]),
+                      ),
+                      scope: Schema.optional(
+                        Schema.Union([
+                          Schema.Literals([
+                            "groups",
+                            "profile",
+                            "email",
+                            "openid",
+                          ]),
+                          Schema.Null,
+                        ]),
+                      ),
+                      source: Schema.optional(
+                        Schema.Union([
+                          Schema.Struct({
+                            name: Schema.optional(
+                              Schema.Union([Schema.String, Schema.Null]),
+                            ),
+                            nameByIdp: Schema.optional(
+                              Schema.Union([
+                                Schema.Record(Schema.String, Schema.Unknown),
+                                Schema.Null,
+                              ]),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              name: "name",
+                              nameByIdp: "name_by_idp",
+                            }),
+                          ),
+                          Schema.Null,
+                        ]),
+                      ),
+                    }),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              grantTypes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Literals([
+                      "authorization_code",
+                      "authorization_code_with_pkce",
+                      "refresh_tokens",
+                      "hybrid",
+                      "implicit",
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              groupFilterRegex: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              hybridAndImplicitOptions: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    returnAccessTokenFromAuthorizationEndpoint: Schema.optional(
+                      Schema.Union([Schema.Boolean, Schema.Null]),
+                    ),
+                    returnIdTokenFromAuthorizationEndpoint: Schema.optional(
+                      Schema.Union([Schema.Boolean, Schema.Null]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      returnAccessTokenFromAuthorizationEndpoint:
+                        "return_access_token_from_authorization_endpoint",
+                      returnIdTokenFromAuthorizationEndpoint:
+                        "return_id_token_from_authorization_endpoint",
+                    }),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              publicKey: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              redirectUris: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              refreshTokenOptions: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    lifetime: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                  }),
+                  Schema.Null,
+                ]),
+              ),
+              scopes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Literals(["openid", "groups", "email", "profile"]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                accessTokenLifetime: "access_token_lifetime",
+                allowPkceWithoutClientSecret:
+                  "allow_pkce_without_client_secret",
+                appLauncherUrl: "app_launcher_url",
+                authType: "auth_type",
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                customClaims: "custom_claims",
+                grantTypes: "grant_types",
+                groupFilterRegex: "group_filter_regex",
+                hybridAndImplicitOptions: "hybrid_and_implicit_options",
+                publicKey: "public_key",
+                redirectUris: "redirect_uris",
+                refreshTokenOptions: "refresh_token_options",
+                scopes: "scopes",
+              }),
+            ),
+          ]),
+          Schema.Null,
+        ]),
       ),
       scimConfig: Schema.optional(
         Schema.Union([
@@ -24780,15 +24744,6 @@ export const CreateAccessApplicationResponse =
             authentication: Schema.optional(
               Schema.Union([
                 Schema.Union([
-                  Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
                   Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
@@ -24809,6 +24764,11 @@ export const CreateAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -24819,17 +24779,12 @@ export const CreateAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -24853,6 +24808,11 @@ export const CreateAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -24863,6 +24823,10 @@ export const CreateAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -24938,54 +24902,90 @@ export const CreateAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      selfHostedDomains: Schema.optional(
-        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-      ),
-      serviceAuth_401Redirect: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      sessionDuration: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      skipInterstitial: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       tags: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
+      type: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "self_hosted",
+            "saas",
+            "ssh",
+            "vnc",
+            "app_launcher",
+            "warp",
+            "biso",
+            "bookmark",
+            "dash_sso",
+            "infrastructure",
+            "rdp",
+            "mcp",
+            "mcp_portal",
+            "proxy_endpoint",
+          ]),
+          Schema.Null,
+        ]),
+      ),
     }).pipe(
       Schema.encodeKeys({
-        domain: "domain",
-        targetCriteria: "target_criteria",
-        type: "type",
         id: "id",
-        allowAuthenticateViaWarp: "allow_authenticate_via_warp",
-        allowIframe: "allow_iframe",
         allowedIdps: "allowed_idps",
         appLauncherVisible: "app_launcher_visible",
         aud: "aud",
         autoRedirectToIdentity: "auto_redirect_to_identity",
-        corsHeaders: "cors_headers",
-        customDenyMessage: "custom_deny_message",
-        customDenyUrl: "custom_deny_url",
-        customNonIdentityDenyUrl: "custom_non_identity_deny_url",
         customPages: "custom_pages",
-        destinations: "destinations",
-        enableBindingCookie: "enable_binding_cookie",
-        httpOnlyCookieAttribute: "http_only_cookie_attribute",
         logoUrl: "logo_url",
         name: "name",
-        optionsPreflightBypass: "options_preflight_bypass",
-        pathCookieAttribute: "path_cookie_attribute",
         policies: "policies",
-        readServiceTokensFromHeader: "read_service_tokens_from_header",
-        sameSiteCookieAttribute: "same_site_cookie_attribute",
+        saasApp: "saas_app",
         scimConfig: "scim_config",
-        selfHostedDomains: "self_hosted_domains",
-        serviceAuth_401Redirect: "service_auth_401_redirect",
-        sessionDuration: "session_duration",
-        skipInterstitial: "skip_interstitial",
         tags: "tags",
+        type: "type",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      appLauncherVisible: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      tags: Schema.optional(
+        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+      ),
+      type: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "self_hosted",
+            "saas",
+            "ssh",
+            "vnc",
+            "app_launcher",
+            "warp",
+            "biso",
+            "bookmark",
+            "dash_sso",
+            "infrastructure",
+            "rdp",
+            "mcp",
+            "mcp_portal",
+            "proxy_endpoint",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        appLauncherVisible: "app_launcher_visible",
+        aud: "aud",
+        domain: "domain",
+        logoUrl: "logo_url",
+        name: "name",
+        tags: "tags",
+        type: "type",
       }),
     ),
   ]).pipe(
@@ -25336,15 +25336,6 @@ export const UpdateAccessApplicationRequest =
         authentication: Schema.optional(
           Schema.Union([
             Schema.Struct({
-              password: SensitiveString,
-              scheme: Schema.Literal("httpbasic"),
-              user: Schema.String,
-            }),
-            Schema.Struct({
-              token: Schema.String,
-              scheme: Schema.Literal("oauthbearertoken"),
-            }),
-            Schema.Struct({
               authorizationUrl: Schema.String,
               clientId: Schema.String,
               clientSecret: SensitiveString,
@@ -25362,6 +25353,11 @@ export const UpdateAccessApplicationRequest =
               }),
             ),
             Schema.Struct({
+              password: SensitiveString,
+              scheme: Schema.Literal("httpbasic"),
+              user: Schema.String,
+            }),
+            Schema.Struct({
               clientId: Schema.String,
               clientSecret: SensitiveString,
               scheme: Schema.Literal("access_service_token"),
@@ -25372,17 +25368,12 @@ export const UpdateAccessApplicationRequest =
                 scheme: "scheme",
               }),
             ),
+            Schema.Struct({
+              token: Schema.String,
+              scheme: Schema.Literal("oauthbearertoken"),
+            }),
             Schema.Array(
               Schema.Union([
-                Schema.Struct({
-                  password: SensitiveString,
-                  scheme: Schema.Literal("httpbasic"),
-                  user: Schema.String,
-                }),
-                Schema.Struct({
-                  token: Schema.String,
-                  scheme: Schema.Literal("oauthbearertoken"),
-                }),
                 Schema.Struct({
                   authorizationUrl: Schema.String,
                   clientId: Schema.String,
@@ -25401,6 +25392,11 @@ export const UpdateAccessApplicationRequest =
                   }),
                 ),
                 Schema.Struct({
+                  password: SensitiveString,
+                  scheme: Schema.Literal("httpbasic"),
+                  user: Schema.String,
+                }),
+                Schema.Struct({
                   clientId: Schema.String,
                   clientSecret: SensitiveString,
                   scheme: Schema.Literal("access_service_token"),
@@ -25411,6 +25407,10 @@ export const UpdateAccessApplicationRequest =
                     scheme: "scheme",
                   }),
                 ),
+                Schema.Struct({
+                  token: Schema.String,
+                  scheme: Schema.Literal("oauthbearertoken"),
+                }),
               ]),
             ),
           ]),
@@ -27197,6 +27197,19 @@ export const UpdateAccessApplicationResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
       domain: Schema.String,
+      targetCriteria: Schema.Array(
+        Schema.Struct({
+          port: Schema.Number,
+          protocol: Schema.Literal("RDP"),
+          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
+        }).pipe(
+          Schema.encodeKeys({
+            port: "port",
+            protocol: "protocol",
+            targetAttributes: "target_attributes",
+          }),
+        ),
+      ),
       type: Schema.Literals([
         "self_hosted",
         "saas",
@@ -28121,15 +28134,6 @@ export const UpdateAccessApplicationResponse =
               Schema.Union([
                 Schema.Union([
                   Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
-                  Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
@@ -28149,6 +28153,11 @@ export const UpdateAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -28159,17 +28168,12 @@ export const UpdateAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -28193,6 +28197,11 @@ export const UpdateAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -28203,6 +28212,10 @@ export const UpdateAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -28296,6 +28309,7 @@ export const UpdateAccessApplicationResponse =
     }).pipe(
       Schema.encodeKeys({
         domain: "domain",
+        targetCriteria: "target_criteria",
         type: "type",
         id: "id",
         allowAuthenticateViaWarp: "allow_authenticate_via_warp",
@@ -28328,7 +28342,28 @@ export const UpdateAccessApplicationResponse =
       }),
     ),
     Schema.Struct({
+      domain: Schema.String,
+      type: Schema.Literals([
+        "self_hosted",
+        "saas",
+        "ssh",
+        "vnc",
+        "app_launcher",
+        "warp",
+        "biso",
+        "bookmark",
+        "dash_sso",
+        "infrastructure",
+        "rdp",
+        "mcp",
+        "mcp_portal",
+        "proxy_endpoint",
+      ]),
       id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      allowAuthenticateViaWarp: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      allowIframe: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
       allowedIdps: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
@@ -28339,11 +28374,149 @@ export const UpdateAccessApplicationResponse =
       autoRedirectToIdentity: Schema.optional(
         Schema.Union([Schema.Boolean, Schema.Null]),
       ),
+      corsHeaders: Schema.optional(
+        Schema.Union([
+          Schema.Struct({
+            allowAllHeaders: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowAllMethods: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowAllOrigins: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowCredentials: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            allowedHeaders: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            allowedMethods: Schema.optional(
+              Schema.Union([
+                Schema.Array(
+                  Schema.Literals([
+                    "GET",
+                    "POST",
+                    "HEAD",
+                    "PUT",
+                    "DELETE",
+                    "CONNECT",
+                    "OPTIONS",
+                    "TRACE",
+                    "PATCH",
+                  ]),
+                ),
+                Schema.Null,
+              ]),
+            ),
+            allowedOrigins: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            maxAge: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          }).pipe(
+            Schema.encodeKeys({
+              allowAllHeaders: "allow_all_headers",
+              allowAllMethods: "allow_all_methods",
+              allowAllOrigins: "allow_all_origins",
+              allowCredentials: "allow_credentials",
+              allowedHeaders: "allowed_headers",
+              allowedMethods: "allowed_methods",
+              allowedOrigins: "allowed_origins",
+              maxAge: "max_age",
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      customDenyMessage: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      customDenyUrl: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      customNonIdentityDenyUrl: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
       customPages: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
+      destinations: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Union([
+              Schema.Struct({
+                type: Schema.optional(
+                  Schema.Union([Schema.Literal("public"), Schema.Null]),
+                ),
+                uri: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }),
+              Schema.Struct({
+                cidr: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                hostname: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                l4Protocol: Schema.optional(
+                  Schema.Union([Schema.Literals(["tcp", "udp"]), Schema.Null]),
+                ),
+                portRange: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                type: Schema.optional(
+                  Schema.Union([Schema.Literal("private"), Schema.Null]),
+                ),
+                vnetId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  cidr: "cidr",
+                  hostname: "hostname",
+                  l4Protocol: "l4_protocol",
+                  portRange: "port_range",
+                  type: "type",
+                  vnetId: "vnet_id",
+                }),
+              ),
+              Schema.Struct({
+                mcpServerId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                type: Schema.optional(
+                  Schema.Union([
+                    Schema.Literal("via_mcp_server_portal"),
+                    Schema.Null,
+                  ]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  mcpServerId: "mcp_server_id",
+                  type: "type",
+                }),
+              ),
+            ]),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      enableBindingCookie: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      httpOnlyCookieAttribute: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
       name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      optionsPreflightBypass: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      pathCookieAttribute: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       policies: Schema.optional(
         Schema.Union([
           Schema.Array(
@@ -29079,282 +29252,11 @@ export const UpdateAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      saasApp: Schema.optional(
-        Schema.Union([
-          Schema.Union([
-            Schema.Struct({
-              authType: Schema.optional(
-                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
-              ),
-              consumerServiceUrl: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              customAttributes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Struct({
-                      friendlyName: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      name: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      nameFormat: Schema.optional(
-                        Schema.Union([
-                          Schema.Literals([
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
-                            "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
-                          ]),
-                          Schema.Null,
-                        ]),
-                      ),
-                      required: Schema.optional(
-                        Schema.Union([Schema.Boolean, Schema.Null]),
-                      ),
-                      source: Schema.optional(
-                        Schema.Union([
-                          Schema.Struct({
-                            name: Schema.optional(
-                              Schema.Union([Schema.String, Schema.Null]),
-                            ),
-                            nameByIdp: Schema.optional(
-                              Schema.Union([
-                                Schema.Array(
-                                  Schema.Struct({
-                                    idpId: Schema.optional(
-                                      Schema.Union([
-                                        Schema.String,
-                                        Schema.Null,
-                                      ]),
-                                    ),
-                                    sourceName: Schema.optional(
-                                      Schema.Union([
-                                        Schema.String,
-                                        Schema.Null,
-                                      ]),
-                                    ),
-                                  }).pipe(
-                                    Schema.encodeKeys({
-                                      idpId: "idp_id",
-                                      sourceName: "source_name",
-                                    }),
-                                  ),
-                                ),
-                                Schema.Null,
-                              ]),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              name: "name",
-                              nameByIdp: "name_by_idp",
-                            }),
-                          ),
-                          Schema.Null,
-                        ]),
-                      ),
-                    }).pipe(
-                      Schema.encodeKeys({
-                        friendlyName: "friendly_name",
-                        name: "name",
-                        nameFormat: "name_format",
-                        required: "required",
-                        source: "source",
-                      }),
-                    ),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              defaultRelayState: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              idpEntityId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              nameIdFormat: Schema.optional(
-                Schema.Union([Schema.Literals(["id", "email"]), Schema.Null]),
-              ),
-              nameIdTransformJsonata: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              publicKey: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              samlAttributeTransformJsonata: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              spEntityId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              ssoEndpoint: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                authType: "auth_type",
-                consumerServiceUrl: "consumer_service_url",
-                customAttributes: "custom_attributes",
-                defaultRelayState: "default_relay_state",
-                idpEntityId: "idp_entity_id",
-                nameIdFormat: "name_id_format",
-                nameIdTransformJsonata: "name_id_transform_jsonata",
-                publicKey: "public_key",
-                samlAttributeTransformJsonata:
-                  "saml_attribute_transform_jsonata",
-                spEntityId: "sp_entity_id",
-                ssoEndpoint: "sso_endpoint",
-              }),
-            ),
-            Schema.Struct({
-              accessTokenLifetime: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              allowPkceWithoutClientSecret: Schema.optional(
-                Schema.Union([Schema.Boolean, Schema.Null]),
-              ),
-              appLauncherUrl: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              authType: Schema.optional(
-                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
-              ),
-              clientId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              clientSecret: Schema.optional(
-                Schema.Union([SensitiveString, Schema.Null]),
-              ),
-              customClaims: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Struct({
-                      name: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                      required: Schema.optional(
-                        Schema.Union([Schema.Boolean, Schema.Null]),
-                      ),
-                      scope: Schema.optional(
-                        Schema.Union([
-                          Schema.Literals([
-                            "groups",
-                            "profile",
-                            "email",
-                            "openid",
-                          ]),
-                          Schema.Null,
-                        ]),
-                      ),
-                      source: Schema.optional(
-                        Schema.Union([
-                          Schema.Struct({
-                            name: Schema.optional(
-                              Schema.Union([Schema.String, Schema.Null]),
-                            ),
-                            nameByIdp: Schema.optional(
-                              Schema.Union([
-                                Schema.Record(Schema.String, Schema.Unknown),
-                                Schema.Null,
-                              ]),
-                            ),
-                          }).pipe(
-                            Schema.encodeKeys({
-                              name: "name",
-                              nameByIdp: "name_by_idp",
-                            }),
-                          ),
-                          Schema.Null,
-                        ]),
-                      ),
-                    }),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              grantTypes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Literals([
-                      "authorization_code",
-                      "authorization_code_with_pkce",
-                      "refresh_tokens",
-                      "hybrid",
-                      "implicit",
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              groupFilterRegex: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              hybridAndImplicitOptions: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    returnAccessTokenFromAuthorizationEndpoint: Schema.optional(
-                      Schema.Union([Schema.Boolean, Schema.Null]),
-                    ),
-                    returnIdTokenFromAuthorizationEndpoint: Schema.optional(
-                      Schema.Union([Schema.Boolean, Schema.Null]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      returnAccessTokenFromAuthorizationEndpoint:
-                        "return_access_token_from_authorization_endpoint",
-                      returnIdTokenFromAuthorizationEndpoint:
-                        "return_id_token_from_authorization_endpoint",
-                    }),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              publicKey: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              redirectUris: Schema.optional(
-                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-              ),
-              refreshTokenOptions: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    lifetime: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }),
-                  Schema.Null,
-                ]),
-              ),
-              scopes: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Literals(["openid", "groups", "email", "profile"]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                accessTokenLifetime: "access_token_lifetime",
-                allowPkceWithoutClientSecret:
-                  "allow_pkce_without_client_secret",
-                appLauncherUrl: "app_launcher_url",
-                authType: "auth_type",
-                clientId: "client_id",
-                clientSecret: "client_secret",
-                customClaims: "custom_claims",
-                grantTypes: "grant_types",
-                groupFilterRegex: "group_filter_regex",
-                hybridAndImplicitOptions: "hybrid_and_implicit_options",
-                publicKey: "public_key",
-                redirectUris: "redirect_uris",
-                refreshTokenOptions: "refresh_token_options",
-                scopes: "scopes",
-              }),
-            ),
-          ]),
-          Schema.Null,
-        ]),
+      readServiceTokensFromHeader: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      sameSiteCookieAttribute: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
       ),
       scimConfig: Schema.optional(
         Schema.Union([
@@ -29364,15 +29266,6 @@ export const UpdateAccessApplicationResponse =
             authentication: Schema.optional(
               Schema.Union([
                 Schema.Union([
-                  Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
                   Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
@@ -29393,6 +29286,11 @@ export const UpdateAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -29403,17 +29301,12 @@ export const UpdateAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -29437,6 +29330,11 @@ export const UpdateAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -29447,6 +29345,10 @@ export const UpdateAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -29522,45 +29424,805 @@ export const UpdateAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
+      selfHostedDomains: Schema.optional(
+        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+      ),
+      serviceAuth_401Redirect: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      sessionDuration: Schema.optional(
+        Schema.Union([Schema.String, Schema.Null]),
+      ),
+      skipInterstitial: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
       tags: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
-      type: Schema.optional(
+    }).pipe(
+      Schema.encodeKeys({
+        domain: "domain",
+        type: "type",
+        id: "id",
+        allowAuthenticateViaWarp: "allow_authenticate_via_warp",
+        allowIframe: "allow_iframe",
+        allowedIdps: "allowed_idps",
+        appLauncherVisible: "app_launcher_visible",
+        aud: "aud",
+        autoRedirectToIdentity: "auto_redirect_to_identity",
+        corsHeaders: "cors_headers",
+        customDenyMessage: "custom_deny_message",
+        customDenyUrl: "custom_deny_url",
+        customNonIdentityDenyUrl: "custom_non_identity_deny_url",
+        customPages: "custom_pages",
+        destinations: "destinations",
+        enableBindingCookie: "enable_binding_cookie",
+        httpOnlyCookieAttribute: "http_only_cookie_attribute",
+        logoUrl: "logo_url",
+        name: "name",
+        optionsPreflightBypass: "options_preflight_bypass",
+        pathCookieAttribute: "path_cookie_attribute",
+        policies: "policies",
+        readServiceTokensFromHeader: "read_service_tokens_from_header",
+        sameSiteCookieAttribute: "same_site_cookie_attribute",
+        scimConfig: "scim_config",
+        selfHostedDomains: "self_hosted_domains",
+        serviceAuth_401Redirect: "service_auth_401_redirect",
+        sessionDuration: "session_duration",
+        skipInterstitial: "skip_interstitial",
+        tags: "tags",
+      }),
+    ),
+    Schema.Struct({
+      targetCriteria: Schema.Array(
+        Schema.Struct({
+          port: Schema.Number,
+          protocol: Schema.Literal("SSH"),
+          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
+        }).pipe(
+          Schema.encodeKeys({
+            port: "port",
+            protocol: "protocol",
+            targetAttributes: "target_attributes",
+          }),
+        ),
+      ),
+      type: Schema.Literals([
+        "self_hosted",
+        "saas",
+        "ssh",
+        "vnc",
+        "app_launcher",
+        "warp",
+        "biso",
+        "bookmark",
+        "dash_sso",
+        "infrastructure",
+        "rdp",
+        "mcp",
+        "mcp_portal",
+        "proxy_endpoint",
+      ]),
+      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      policies: Schema.optional(
         Schema.Union([
-          Schema.Literals([
-            "self_hosted",
-            "saas",
-            "ssh",
-            "vnc",
-            "app_launcher",
-            "warp",
-            "biso",
-            "bookmark",
-            "dash_sso",
-            "infrastructure",
-            "rdp",
-            "mcp",
-            "mcp_portal",
-            "proxy_endpoint",
-          ]),
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+              connectionRules: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    ssh: Schema.optional(
+                      Schema.Union([
+                        Schema.Struct({
+                          usernames: Schema.Array(Schema.String),
+                          allowEmailAlias: Schema.optional(
+                            Schema.Union([Schema.Boolean, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            usernames: "usernames",
+                            allowEmailAlias: "allow_email_alias",
+                          }),
+                        ),
+                        Schema.Null,
+                      ]),
+                    ),
+                  }),
+                  Schema.Null,
+                ]),
+              ),
+              createdAt: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              decision: Schema.optional(
+                Schema.Union([
+                  Schema.Literals(["allow", "deny", "non_identity", "bypass"]),
+                  Schema.Null,
+                ]),
+              ),
+              exclude: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              include: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+              require: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Union([
+                      Schema.Struct({
+                        group: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        anyValidServiceToken: Schema.Unknown,
+                      }).pipe(
+                        Schema.encodeKeys({
+                          anyValidServiceToken: "any_valid_service_token",
+                        }),
+                      ),
+                      Schema.Struct({
+                        authContext: Schema.Struct({
+                          id: Schema.String,
+                          acId: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            acId: "ac_id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ authContext: "auth_context" }),
+                      ),
+                      Schema.Struct({
+                        authMethod: Schema.Struct({
+                          authMethod: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ authMethod: "auth_method" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+                      Schema.Struct({
+                        azureAD: Schema.Struct({
+                          id: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            id: "id",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        certificate: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        commonName: Schema.Struct({
+                          commonName: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ commonName: "common_name" }),
+                        ),
+                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+                      Schema.Struct({
+                        geo: Schema.Struct({
+                          countryCode: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({ countryCode: "country_code" }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        devicePosture: Schema.Struct({
+                          integrationUid: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            integrationUid: "integration_uid",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({ devicePosture: "device_posture" }),
+                      ),
+                      Schema.Struct({
+                        emailDomain: Schema.Struct({
+                          domain: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ emailDomain: "email_domain" }),
+                      ),
+                      Schema.Struct({
+                        emailList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+                      Schema.Struct({
+                        email: Schema.Struct({
+                          email: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        everyone: Schema.Unknown,
+                      }),
+                      Schema.Struct({
+                        externalEvaluation: Schema.Struct({
+                          evaluateUrl: Schema.String,
+                          keysUrl: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            evaluateUrl: "evaluate_url",
+                            keysUrl: "keys_url",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          externalEvaluation: "external_evaluation",
+                        }),
+                      ),
+                      Schema.Struct({
+                        githubOrganization: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                          team: Schema.optional(
+                            Schema.Union([Schema.String, Schema.Null]),
+                          ),
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                            team: "team",
+                          }),
+                        ),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          githubOrganization: "github-organization",
+                        }),
+                      ),
+                      Schema.Struct({
+                        gsuite: Schema.Struct({
+                          email: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            email: "email",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        loginMethod: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(
+                        Schema.encodeKeys({ loginMethod: "login_method" }),
+                      ),
+                      Schema.Struct({
+                        ipList: Schema.Struct({
+                          id: Schema.String,
+                        }),
+                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+                      Schema.Struct({
+                        ip: Schema.Struct({
+                          ip: Schema.String,
+                        }),
+                      }),
+                      Schema.Struct({
+                        okta: Schema.Struct({
+                          identityProviderId: Schema.String,
+                          name: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            identityProviderId: "identity_provider_id",
+                            name: "name",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        saml: Schema.Struct({
+                          attributeName: Schema.String,
+                          attributeValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            attributeName: "attribute_name",
+                            attributeValue: "attribute_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        oidc: Schema.Struct({
+                          claimName: Schema.String,
+                          claimValue: Schema.String,
+                          identityProviderId: Schema.String,
+                        }).pipe(
+                          Schema.encodeKeys({
+                            claimName: "claim_name",
+                            claimValue: "claim_value",
+                            identityProviderId: "identity_provider_id",
+                          }),
+                        ),
+                      }),
+                      Schema.Struct({
+                        serviceToken: Schema.Struct({
+                          tokenId: Schema.String,
+                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+                      }).pipe(
+                        Schema.encodeKeys({ serviceToken: "service_token" }),
+                      ),
+                      Schema.Struct({
+                        linkedAppToken: Schema.Struct({
+                          appUid: Schema.String,
+                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+                      }).pipe(
+                        Schema.encodeKeys({
+                          linkedAppToken: "linked_app_token",
+                        }),
+                      ),
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              updatedAt: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                id: "id",
+                connectionRules: "connection_rules",
+                createdAt: "created_at",
+                decision: "decision",
+                exclude: "exclude",
+                include: "include",
+                name: "name",
+                require: "require",
+                updatedAt: "updated_at",
+              }),
+            ),
+          ),
           Schema.Null,
         ]),
       ),
     }).pipe(
       Schema.encodeKeys({
+        targetCriteria: "target_criteria",
+        type: "type",
         id: "id",
-        allowedIdps: "allowed_idps",
-        appLauncherVisible: "app_launcher_visible",
         aud: "aud",
-        autoRedirectToIdentity: "auto_redirect_to_identity",
-        customPages: "custom_pages",
-        logoUrl: "logo_url",
         name: "name",
         policies: "policies",
-        saasApp: "saas_app",
-        scimConfig: "scim_config",
-        tags: "tags",
-        type: "type",
       }),
     ),
     Schema.Struct({
@@ -31200,837 +31862,6 @@ export const UpdateAccessApplicationResponse =
     ),
     Schema.Struct({
       id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      appLauncherVisible: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      tags: Schema.optional(
-        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-      ),
-      type: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "self_hosted",
-            "saas",
-            "ssh",
-            "vnc",
-            "app_launcher",
-            "warp",
-            "biso",
-            "bookmark",
-            "dash_sso",
-            "infrastructure",
-            "rdp",
-            "mcp",
-            "mcp_portal",
-            "proxy_endpoint",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        appLauncherVisible: "app_launcher_visible",
-        aud: "aud",
-        domain: "domain",
-        logoUrl: "logo_url",
-        name: "name",
-        tags: "tags",
-        type: "type",
-      }),
-    ),
-    Schema.Struct({
-      targetCriteria: Schema.Array(
-        Schema.Struct({
-          port: Schema.Number,
-          protocol: Schema.Literal("SSH"),
-          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
-        }).pipe(
-          Schema.encodeKeys({
-            port: "port",
-            protocol: "protocol",
-            targetAttributes: "target_attributes",
-          }),
-        ),
-      ),
-      type: Schema.Literals([
-        "self_hosted",
-        "saas",
-        "ssh",
-        "vnc",
-        "app_launcher",
-        "warp",
-        "biso",
-        "bookmark",
-        "dash_sso",
-        "infrastructure",
-        "rdp",
-        "mcp",
-        "mcp_portal",
-        "proxy_endpoint",
-      ]),
-      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      policies: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-              connectionRules: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    ssh: Schema.optional(
-                      Schema.Union([
-                        Schema.Struct({
-                          usernames: Schema.Array(Schema.String),
-                          allowEmailAlias: Schema.optional(
-                            Schema.Union([Schema.Boolean, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            usernames: "usernames",
-                            allowEmailAlias: "allow_email_alias",
-                          }),
-                        ),
-                        Schema.Null,
-                      ]),
-                    ),
-                  }),
-                  Schema.Null,
-                ]),
-              ),
-              createdAt: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              decision: Schema.optional(
-                Schema.Union([
-                  Schema.Literals(["allow", "deny", "non_identity", "bypass"]),
-                  Schema.Null,
-                ]),
-              ),
-              exclude: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              include: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-              require: Schema.optional(
-                Schema.Union([
-                  Schema.Array(
-                    Schema.Union([
-                      Schema.Struct({
-                        group: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        anyValidServiceToken: Schema.Unknown,
-                      }).pipe(
-                        Schema.encodeKeys({
-                          anyValidServiceToken: "any_valid_service_token",
-                        }),
-                      ),
-                      Schema.Struct({
-                        authContext: Schema.Struct({
-                          id: Schema.String,
-                          acId: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            acId: "ac_id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ authContext: "auth_context" }),
-                      ),
-                      Schema.Struct({
-                        authMethod: Schema.Struct({
-                          authMethod: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ authMethod: "auth_method" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-                      Schema.Struct({
-                        azureAD: Schema.Struct({
-                          id: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            id: "id",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        certificate: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        commonName: Schema.Struct({
-                          commonName: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ commonName: "common_name" }),
-                        ),
-                      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-                      Schema.Struct({
-                        geo: Schema.Struct({
-                          countryCode: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({ countryCode: "country_code" }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        devicePosture: Schema.Struct({
-                          integrationUid: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            integrationUid: "integration_uid",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({ devicePosture: "device_posture" }),
-                      ),
-                      Schema.Struct({
-                        emailDomain: Schema.Struct({
-                          domain: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ emailDomain: "email_domain" }),
-                      ),
-                      Schema.Struct({
-                        emailList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-                      Schema.Struct({
-                        email: Schema.Struct({
-                          email: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        everyone: Schema.Unknown,
-                      }),
-                      Schema.Struct({
-                        externalEvaluation: Schema.Struct({
-                          evaluateUrl: Schema.String,
-                          keysUrl: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            evaluateUrl: "evaluate_url",
-                            keysUrl: "keys_url",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          externalEvaluation: "external_evaluation",
-                        }),
-                      ),
-                      Schema.Struct({
-                        githubOrganization: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                          team: Schema.optional(
-                            Schema.Union([Schema.String, Schema.Null]),
-                          ),
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                            team: "team",
-                          }),
-                        ),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          githubOrganization: "github-organization",
-                        }),
-                      ),
-                      Schema.Struct({
-                        gsuite: Schema.Struct({
-                          email: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            email: "email",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        loginMethod: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(
-                        Schema.encodeKeys({ loginMethod: "login_method" }),
-                      ),
-                      Schema.Struct({
-                        ipList: Schema.Struct({
-                          id: Schema.String,
-                        }),
-                      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-                      Schema.Struct({
-                        ip: Schema.Struct({
-                          ip: Schema.String,
-                        }),
-                      }),
-                      Schema.Struct({
-                        okta: Schema.Struct({
-                          identityProviderId: Schema.String,
-                          name: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            identityProviderId: "identity_provider_id",
-                            name: "name",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        saml: Schema.Struct({
-                          attributeName: Schema.String,
-                          attributeValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            attributeName: "attribute_name",
-                            attributeValue: "attribute_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        oidc: Schema.Struct({
-                          claimName: Schema.String,
-                          claimValue: Schema.String,
-                          identityProviderId: Schema.String,
-                        }).pipe(
-                          Schema.encodeKeys({
-                            claimName: "claim_name",
-                            claimValue: "claim_value",
-                            identityProviderId: "identity_provider_id",
-                          }),
-                        ),
-                      }),
-                      Schema.Struct({
-                        serviceToken: Schema.Struct({
-                          tokenId: Schema.String,
-                        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-                      }).pipe(
-                        Schema.encodeKeys({ serviceToken: "service_token" }),
-                      ),
-                      Schema.Struct({
-                        linkedAppToken: Schema.Struct({
-                          appUid: Schema.String,
-                        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-                      }).pipe(
-                        Schema.encodeKeys({
-                          linkedAppToken: "linked_app_token",
-                        }),
-                      ),
-                    ]),
-                  ),
-                  Schema.Null,
-                ]),
-              ),
-              updatedAt: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                connectionRules: "connection_rules",
-                createdAt: "created_at",
-                decision: "decision",
-                exclude: "exclude",
-                include: "include",
-                name: "name",
-                require: "require",
-                updatedAt: "updated_at",
-              }),
-            ),
-          ),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        targetCriteria: "target_criteria",
-        type: "type",
-        id: "id",
-        aud: "aud",
-        name: "name",
-        policies: "policies",
-      }),
-    ),
-    Schema.Struct({
-      domain: Schema.String,
-      targetCriteria: Schema.Array(
-        Schema.Struct({
-          port: Schema.Number,
-          protocol: Schema.Literal("RDP"),
-          targetAttributes: Schema.Record(Schema.String, Schema.Unknown),
-        }).pipe(
-          Schema.encodeKeys({
-            port: "port",
-            protocol: "protocol",
-            targetAttributes: "target_attributes",
-          }),
-        ),
-      ),
-      type: Schema.Literals([
-        "self_hosted",
-        "saas",
-        "ssh",
-        "vnc",
-        "app_launcher",
-        "warp",
-        "biso",
-        "bookmark",
-        "dash_sso",
-        "infrastructure",
-        "rdp",
-        "mcp",
-        "mcp_portal",
-        "proxy_endpoint",
-      ]),
-      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      allowAuthenticateViaWarp: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      allowIframe: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
       allowedIdps: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
@@ -32041,149 +31872,11 @@ export const UpdateAccessApplicationResponse =
       autoRedirectToIdentity: Schema.optional(
         Schema.Union([Schema.Boolean, Schema.Null]),
       ),
-      corsHeaders: Schema.optional(
-        Schema.Union([
-          Schema.Struct({
-            allowAllHeaders: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowAllMethods: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowAllOrigins: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowCredentials: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            allowedHeaders: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            allowedMethods: Schema.optional(
-              Schema.Union([
-                Schema.Array(
-                  Schema.Literals([
-                    "GET",
-                    "POST",
-                    "HEAD",
-                    "PUT",
-                    "DELETE",
-                    "CONNECT",
-                    "OPTIONS",
-                    "TRACE",
-                    "PATCH",
-                  ]),
-                ),
-                Schema.Null,
-              ]),
-            ),
-            allowedOrigins: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            maxAge: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-          }).pipe(
-            Schema.encodeKeys({
-              allowAllHeaders: "allow_all_headers",
-              allowAllMethods: "allow_all_methods",
-              allowAllOrigins: "allow_all_origins",
-              allowCredentials: "allow_credentials",
-              allowedHeaders: "allowed_headers",
-              allowedMethods: "allowed_methods",
-              allowedOrigins: "allowed_origins",
-              maxAge: "max_age",
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      customDenyMessage: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      customDenyUrl: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      customNonIdentityDenyUrl: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
       customPages: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
-      destinations: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Union([
-              Schema.Struct({
-                type: Schema.optional(
-                  Schema.Union([Schema.Literal("public"), Schema.Null]),
-                ),
-                uri: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }),
-              Schema.Struct({
-                cidr: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                hostname: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                l4Protocol: Schema.optional(
-                  Schema.Union([Schema.Literals(["tcp", "udp"]), Schema.Null]),
-                ),
-                portRange: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                type: Schema.optional(
-                  Schema.Union([Schema.Literal("private"), Schema.Null]),
-                ),
-                vnetId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  cidr: "cidr",
-                  hostname: "hostname",
-                  l4Protocol: "l4_protocol",
-                  portRange: "port_range",
-                  type: "type",
-                  vnetId: "vnet_id",
-                }),
-              ),
-              Schema.Struct({
-                mcpServerId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                type: Schema.optional(
-                  Schema.Union([
-                    Schema.Literal("via_mcp_server_portal"),
-                    Schema.Null,
-                  ]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  mcpServerId: "mcp_server_id",
-                  type: "type",
-                }),
-              ),
-            ]),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      enableBindingCookie: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      httpOnlyCookieAttribute: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
       name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      optionsPreflightBypass: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      pathCookieAttribute: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       policies: Schema.optional(
         Schema.Union([
           Schema.Array(
@@ -32919,11 +32612,282 @@ export const UpdateAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      readServiceTokensFromHeader: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      sameSiteCookieAttribute: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
+      saasApp: Schema.optional(
+        Schema.Union([
+          Schema.Union([
+            Schema.Struct({
+              authType: Schema.optional(
+                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
+              ),
+              consumerServiceUrl: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              customAttributes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Struct({
+                      friendlyName: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      name: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      nameFormat: Schema.optional(
+                        Schema.Union([
+                          Schema.Literals([
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+                            "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+                          ]),
+                          Schema.Null,
+                        ]),
+                      ),
+                      required: Schema.optional(
+                        Schema.Union([Schema.Boolean, Schema.Null]),
+                      ),
+                      source: Schema.optional(
+                        Schema.Union([
+                          Schema.Struct({
+                            name: Schema.optional(
+                              Schema.Union([Schema.String, Schema.Null]),
+                            ),
+                            nameByIdp: Schema.optional(
+                              Schema.Union([
+                                Schema.Array(
+                                  Schema.Struct({
+                                    idpId: Schema.optional(
+                                      Schema.Union([
+                                        Schema.String,
+                                        Schema.Null,
+                                      ]),
+                                    ),
+                                    sourceName: Schema.optional(
+                                      Schema.Union([
+                                        Schema.String,
+                                        Schema.Null,
+                                      ]),
+                                    ),
+                                  }).pipe(
+                                    Schema.encodeKeys({
+                                      idpId: "idp_id",
+                                      sourceName: "source_name",
+                                    }),
+                                  ),
+                                ),
+                                Schema.Null,
+                              ]),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              name: "name",
+                              nameByIdp: "name_by_idp",
+                            }),
+                          ),
+                          Schema.Null,
+                        ]),
+                      ),
+                    }).pipe(
+                      Schema.encodeKeys({
+                        friendlyName: "friendly_name",
+                        name: "name",
+                        nameFormat: "name_format",
+                        required: "required",
+                        source: "source",
+                      }),
+                    ),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              defaultRelayState: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              idpEntityId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              nameIdFormat: Schema.optional(
+                Schema.Union([Schema.Literals(["id", "email"]), Schema.Null]),
+              ),
+              nameIdTransformJsonata: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              publicKey: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              samlAttributeTransformJsonata: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              spEntityId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              ssoEndpoint: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                authType: "auth_type",
+                consumerServiceUrl: "consumer_service_url",
+                customAttributes: "custom_attributes",
+                defaultRelayState: "default_relay_state",
+                idpEntityId: "idp_entity_id",
+                nameIdFormat: "name_id_format",
+                nameIdTransformJsonata: "name_id_transform_jsonata",
+                publicKey: "public_key",
+                samlAttributeTransformJsonata:
+                  "saml_attribute_transform_jsonata",
+                spEntityId: "sp_entity_id",
+                ssoEndpoint: "sso_endpoint",
+              }),
+            ),
+            Schema.Struct({
+              accessTokenLifetime: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              allowPkceWithoutClientSecret: Schema.optional(
+                Schema.Union([Schema.Boolean, Schema.Null]),
+              ),
+              appLauncherUrl: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              authType: Schema.optional(
+                Schema.Union([Schema.Literals(["saml", "oidc"]), Schema.Null]),
+              ),
+              clientId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              clientSecret: Schema.optional(
+                Schema.Union([SensitiveString, Schema.Null]),
+              ),
+              customClaims: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Struct({
+                      name: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                      required: Schema.optional(
+                        Schema.Union([Schema.Boolean, Schema.Null]),
+                      ),
+                      scope: Schema.optional(
+                        Schema.Union([
+                          Schema.Literals([
+                            "groups",
+                            "profile",
+                            "email",
+                            "openid",
+                          ]),
+                          Schema.Null,
+                        ]),
+                      ),
+                      source: Schema.optional(
+                        Schema.Union([
+                          Schema.Struct({
+                            name: Schema.optional(
+                              Schema.Union([Schema.String, Schema.Null]),
+                            ),
+                            nameByIdp: Schema.optional(
+                              Schema.Union([
+                                Schema.Record(Schema.String, Schema.Unknown),
+                                Schema.Null,
+                              ]),
+                            ),
+                          }).pipe(
+                            Schema.encodeKeys({
+                              name: "name",
+                              nameByIdp: "name_by_idp",
+                            }),
+                          ),
+                          Schema.Null,
+                        ]),
+                      ),
+                    }),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              grantTypes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Literals([
+                      "authorization_code",
+                      "authorization_code_with_pkce",
+                      "refresh_tokens",
+                      "hybrid",
+                      "implicit",
+                    ]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              groupFilterRegex: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              hybridAndImplicitOptions: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    returnAccessTokenFromAuthorizationEndpoint: Schema.optional(
+                      Schema.Union([Schema.Boolean, Schema.Null]),
+                    ),
+                    returnIdTokenFromAuthorizationEndpoint: Schema.optional(
+                      Schema.Union([Schema.Boolean, Schema.Null]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      returnAccessTokenFromAuthorizationEndpoint:
+                        "return_access_token_from_authorization_endpoint",
+                      returnIdTokenFromAuthorizationEndpoint:
+                        "return_id_token_from_authorization_endpoint",
+                    }),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+              publicKey: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              redirectUris: Schema.optional(
+                Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+              ),
+              refreshTokenOptions: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    lifetime: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                  }),
+                  Schema.Null,
+                ]),
+              ),
+              scopes: Schema.optional(
+                Schema.Union([
+                  Schema.Array(
+                    Schema.Literals(["openid", "groups", "email", "profile"]),
+                  ),
+                  Schema.Null,
+                ]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                accessTokenLifetime: "access_token_lifetime",
+                allowPkceWithoutClientSecret:
+                  "allow_pkce_without_client_secret",
+                appLauncherUrl: "app_launcher_url",
+                authType: "auth_type",
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                customClaims: "custom_claims",
+                grantTypes: "grant_types",
+                groupFilterRegex: "group_filter_regex",
+                hybridAndImplicitOptions: "hybrid_and_implicit_options",
+                publicKey: "public_key",
+                redirectUris: "redirect_uris",
+                refreshTokenOptions: "refresh_token_options",
+                scopes: "scopes",
+              }),
+            ),
+          ]),
+          Schema.Null,
+        ]),
       ),
       scimConfig: Schema.optional(
         Schema.Union([
@@ -32933,15 +32897,6 @@ export const UpdateAccessApplicationResponse =
             authentication: Schema.optional(
               Schema.Union([
                 Schema.Union([
-                  Schema.Struct({
-                    password: SensitiveString,
-                    scheme: Schema.Literal("httpbasic"),
-                    user: Schema.String,
-                  }),
-                  Schema.Struct({
-                    token: Schema.String,
-                    scheme: Schema.Literal("oauthbearertoken"),
-                  }),
                   Schema.Struct({
                     authorizationUrl: Schema.String,
                     clientId: Schema.String,
@@ -32962,6 +32917,11 @@ export const UpdateAccessApplicationResponse =
                     }),
                   ),
                   Schema.Struct({
+                    password: SensitiveString,
+                    scheme: Schema.Literal("httpbasic"),
+                    user: Schema.String,
+                  }),
+                  Schema.Struct({
                     clientId: Schema.String,
                     clientSecret: SensitiveString,
                     scheme: Schema.Literal("access_service_token"),
@@ -32972,17 +32932,12 @@ export const UpdateAccessApplicationResponse =
                       scheme: "scheme",
                     }),
                   ),
+                  Schema.Struct({
+                    token: Schema.String,
+                    scheme: Schema.Literal("oauthbearertoken"),
+                  }),
                   Schema.Array(
                     Schema.Union([
-                      Schema.Struct({
-                        password: SensitiveString,
-                        scheme: Schema.Literal("httpbasic"),
-                        user: Schema.String,
-                      }),
-                      Schema.Struct({
-                        token: Schema.String,
-                        scheme: Schema.Literal("oauthbearertoken"),
-                      }),
                       Schema.Struct({
                         authorizationUrl: Schema.String,
                         clientId: Schema.String,
@@ -33006,6 +32961,11 @@ export const UpdateAccessApplicationResponse =
                         }),
                       ),
                       Schema.Struct({
+                        password: SensitiveString,
+                        scheme: Schema.Literal("httpbasic"),
+                        user: Schema.String,
+                      }),
+                      Schema.Struct({
                         clientId: Schema.String,
                         clientSecret: SensitiveString,
                         scheme: Schema.Literal("access_service_token"),
@@ -33016,6 +32976,10 @@ export const UpdateAccessApplicationResponse =
                           scheme: "scheme",
                         }),
                       ),
+                      Schema.Struct({
+                        token: Schema.String,
+                        scheme: Schema.Literal("oauthbearertoken"),
+                      }),
                     ]),
                   ),
                 ]),
@@ -33091,54 +33055,90 @@ export const UpdateAccessApplicationResponse =
           Schema.Null,
         ]),
       ),
-      selfHostedDomains: Schema.optional(
-        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-      ),
-      serviceAuth_401Redirect: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
-      sessionDuration: Schema.optional(
-        Schema.Union([Schema.String, Schema.Null]),
-      ),
-      skipInterstitial: Schema.optional(
-        Schema.Union([Schema.Boolean, Schema.Null]),
-      ),
       tags: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
+      type: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "self_hosted",
+            "saas",
+            "ssh",
+            "vnc",
+            "app_launcher",
+            "warp",
+            "biso",
+            "bookmark",
+            "dash_sso",
+            "infrastructure",
+            "rdp",
+            "mcp",
+            "mcp_portal",
+            "proxy_endpoint",
+          ]),
+          Schema.Null,
+        ]),
+      ),
     }).pipe(
       Schema.encodeKeys({
-        domain: "domain",
-        targetCriteria: "target_criteria",
-        type: "type",
         id: "id",
-        allowAuthenticateViaWarp: "allow_authenticate_via_warp",
-        allowIframe: "allow_iframe",
         allowedIdps: "allowed_idps",
         appLauncherVisible: "app_launcher_visible",
         aud: "aud",
         autoRedirectToIdentity: "auto_redirect_to_identity",
-        corsHeaders: "cors_headers",
-        customDenyMessage: "custom_deny_message",
-        customDenyUrl: "custom_deny_url",
-        customNonIdentityDenyUrl: "custom_non_identity_deny_url",
         customPages: "custom_pages",
-        destinations: "destinations",
-        enableBindingCookie: "enable_binding_cookie",
-        httpOnlyCookieAttribute: "http_only_cookie_attribute",
         logoUrl: "logo_url",
         name: "name",
-        optionsPreflightBypass: "options_preflight_bypass",
-        pathCookieAttribute: "path_cookie_attribute",
         policies: "policies",
-        readServiceTokensFromHeader: "read_service_tokens_from_header",
-        sameSiteCookieAttribute: "same_site_cookie_attribute",
+        saasApp: "saas_app",
         scimConfig: "scim_config",
-        selfHostedDomains: "self_hosted_domains",
-        serviceAuth_401Redirect: "service_auth_401_redirect",
-        sessionDuration: "session_duration",
-        skipInterstitial: "skip_interstitial",
         tags: "tags",
+        type: "type",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      appLauncherVisible: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+      aud: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      logoUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      tags: Schema.optional(
+        Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+      ),
+      type: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "self_hosted",
+            "saas",
+            "ssh",
+            "vnc",
+            "app_launcher",
+            "warp",
+            "biso",
+            "bookmark",
+            "dash_sso",
+            "infrastructure",
+            "rdp",
+            "mcp",
+            "mcp_portal",
+            "proxy_endpoint",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        appLauncherVisible: "app_launcher_visible",
+        aud: "aud",
+        domain: "domain",
+        logoUrl: "logo_url",
+        name: "name",
+        tags: "tags",
+        type: "type",
       }),
     ),
   ]).pipe(
@@ -58214,43 +58214,6 @@ export const GetDevicePostureResponse =
       Schema.Union([
         Schema.Union([
           Schema.Struct({
-            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-            path: Schema.String,
-            exists: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            thumbprint: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              path: "path",
-              exists: "exists",
-              sha256: "sha256",
-              thumbprint: "thumbprint",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              operatingSystem: "operating_system",
-            }),
-          ),
-          Schema.Struct({
-            operatingSystem: Schema.Literal("windows"),
-            domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              domain: "domain",
-            }),
-          ),
-          Schema.Struct({
             operatingSystem: Schema.Literal("windows"),
             operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
             version: Schema.String,
@@ -58272,47 +58235,6 @@ export const GetDevicePostureResponse =
               osDistroRevision: "os_distro_revision",
               osVersionExtra: "os_version_extra",
             }),
-          ),
-          Schema.Struct({
-            enabled: Schema.Boolean,
-            operatingSystem: Schema.Literals(["windows", "mac"]),
-          }).pipe(
-            Schema.encodeKeys({
-              enabled: "enabled",
-              operatingSystem: "operating_system",
-            }),
-          ),
-          Schema.Struct({
-            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-            path: Schema.String,
-            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            thumbprint: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              path: "path",
-              sha256: "sha256",
-              thumbprint: "thumbprint",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-          }),
-          Schema.Struct({
-            checkDisks: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            requireAll: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-          }),
-          Schema.Struct({
-            certificateId: Schema.String,
-            cn: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
           ),
           Schema.Struct({
             certificateId: Schema.String,
@@ -58363,11 +58285,84 @@ export const GetDevicePostureResponse =
             }),
           ),
           Schema.Struct({
-            updateWindowDays: Schema.optional(
-              Schema.Union([Schema.Number, Schema.Null]),
+            connectionId: Schema.String,
+            countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+            issueCount: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              connectionId: "connection_id",
+              countOperator: "countOperator",
+              issueCount: "issue_count",
+            }),
+          ),
+          Schema.Struct({
+            connectionId: Schema.String,
+            operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+            score: Schema.Number,
+          }).pipe(
+            Schema.encodeKeys({
+              connectionId: "connection_id",
+              operator: "operator",
+              score: "score",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+            path: Schema.String,
+            exists: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            thumbprint: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
             ),
           }).pipe(
-            Schema.encodeKeys({ updateWindowDays: "update_window_days" }),
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              path: "path",
+              exists: "exists",
+              sha256: "sha256",
+              thumbprint: "thumbprint",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              operatingSystem: "operating_system",
+            }),
+          ),
+          Schema.Struct({
+            enabled: Schema.Boolean,
+            operatingSystem: Schema.Literals(["windows", "mac"]),
+          }).pipe(
+            Schema.encodeKeys({
+              enabled: "enabled",
+              operatingSystem: "operating_system",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+            path: Schema.String,
+            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            thumbprint: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              path: "path",
+              sha256: "sha256",
+              thumbprint: "thumbprint",
+            }),
+          ),
+          Schema.Struct({
+            certificateId: Schema.String,
+            cn: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
           ),
           Schema.Struct({
             complianceStatus: Schema.Literals([
@@ -58382,6 +58377,34 @@ export const GetDevicePostureResponse =
               connectionId: "connection_id",
             }),
           ),
+          Schema.Struct({
+            complianceStatus: Schema.Literals([
+              "compliant",
+              "noncompliant",
+              "unknown",
+              "notapplicable",
+              "ingraceperiod",
+              "error",
+            ]),
+            connectionId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              complianceStatus: "compliance_status",
+              connectionId: "connection_id",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literal("windows"),
+            domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          }).pipe(
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              domain: "domain",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+          }),
           Schema.Struct({
             connectionId: Schema.String,
             lastSeen: Schema.optional(
@@ -58426,33 +58449,6 @@ export const GetDevicePostureResponse =
               state: "state",
               version: "version",
               versionOperator: "versionOperator",
-            }),
-          ),
-          Schema.Struct({
-            complianceStatus: Schema.Literals([
-              "compliant",
-              "noncompliant",
-              "unknown",
-              "notapplicable",
-              "ingraceperiod",
-              "error",
-            ]),
-            connectionId: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              complianceStatus: "compliance_status",
-              connectionId: "connection_id",
-            }),
-          ),
-          Schema.Struct({
-            connectionId: Schema.String,
-            countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-            issueCount: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              connectionId: "connection_id",
-              countOperator: "countOperator",
-              issueCount: "issue_count",
             }),
           ),
           Schema.Struct({
@@ -58545,15 +58541,19 @@ export const GetDevicePostureResponse =
             }),
           ),
           Schema.Struct({
-            connectionId: Schema.String,
-            operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-            score: Schema.Number,
+            checkDisks: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            requireAll: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+          }),
+          Schema.Struct({
+            updateWindowDays: Schema.optional(
+              Schema.Union([Schema.Number, Schema.Null]),
+            ),
           }).pipe(
-            Schema.encodeKeys({
-              connectionId: "connection_id",
-              operator: "operator",
-              score: "score",
-            }),
+            Schema.encodeKeys({ updateWindowDays: "update_window_days" }),
           ),
         ]),
         Schema.Null,
@@ -58808,51 +58808,6 @@ export const ListDevicePosturesResponse =
           Schema.Union([
             Schema.Union([
               Schema.Struct({
-                operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-                path: Schema.String,
-                exists: Schema.optional(
-                  Schema.Union([Schema.Boolean, Schema.Null]),
-                ),
-                sha256: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                thumbprint: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  operatingSystem: "operating_system",
-                  path: "path",
-                  exists: "exists",
-                  sha256: "sha256",
-                  thumbprint: "thumbprint",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                operatingSystem: Schema.Literals([
-                  "android",
-                  "ios",
-                  "chromeos",
-                ]),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  operatingSystem: "operating_system",
-                }),
-              ),
-              Schema.Struct({
-                operatingSystem: Schema.Literal("windows"),
-                domain: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  operatingSystem: "operating_system",
-                  domain: "domain",
-                }),
-              ),
-              Schema.Struct({
                 operatingSystem: Schema.Literal("windows"),
                 operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
                 version: Schema.String,
@@ -58873,52 +58828,6 @@ export const ListDevicePosturesResponse =
                   osDistroName: "os_distro_name",
                   osDistroRevision: "os_distro_revision",
                   osVersionExtra: "os_version_extra",
-                }),
-              ),
-              Schema.Struct({
-                enabled: Schema.Boolean,
-                operatingSystem: Schema.Literals(["windows", "mac"]),
-              }).pipe(
-                Schema.encodeKeys({
-                  enabled: "enabled",
-                  operatingSystem: "operating_system",
-                }),
-              ),
-              Schema.Struct({
-                operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-                path: Schema.String,
-                sha256: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                thumbprint: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  operatingSystem: "operating_system",
-                  path: "path",
-                  sha256: "sha256",
-                  thumbprint: "thumbprint",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-              }),
-              Schema.Struct({
-                checkDisks: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                requireAll: Schema.optional(
-                  Schema.Union([Schema.Boolean, Schema.Null]),
-                ),
-              }),
-              Schema.Struct({
-                certificateId: Schema.String,
-                cn: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  certificateId: "certificate_id",
-                  cn: "cn",
                 }),
               ),
               Schema.Struct({
@@ -58973,11 +58882,95 @@ export const ListDevicePosturesResponse =
                 }),
               ),
               Schema.Struct({
-                updateWindowDays: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
+                connectionId: Schema.String,
+                countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+                issueCount: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  connectionId: "connection_id",
+                  countOperator: "countOperator",
+                  issueCount: "issue_count",
+                }),
+              ),
+              Schema.Struct({
+                connectionId: Schema.String,
+                operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+                score: Schema.Number,
+              }).pipe(
+                Schema.encodeKeys({
+                  connectionId: "connection_id",
+                  operator: "operator",
+                  score: "score",
+                }),
+              ),
+              Schema.Struct({
+                operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+                path: Schema.String,
+                exists: Schema.optional(
+                  Schema.Union([Schema.Boolean, Schema.Null]),
+                ),
+                sha256: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                thumbprint: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
                 ),
               }).pipe(
-                Schema.encodeKeys({ updateWindowDays: "update_window_days" }),
+                Schema.encodeKeys({
+                  operatingSystem: "operating_system",
+                  path: "path",
+                  exists: "exists",
+                  sha256: "sha256",
+                  thumbprint: "thumbprint",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                operatingSystem: Schema.Literals([
+                  "android",
+                  "ios",
+                  "chromeos",
+                ]),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  operatingSystem: "operating_system",
+                }),
+              ),
+              Schema.Struct({
+                enabled: Schema.Boolean,
+                operatingSystem: Schema.Literals(["windows", "mac"]),
+              }).pipe(
+                Schema.encodeKeys({
+                  enabled: "enabled",
+                  operatingSystem: "operating_system",
+                }),
+              ),
+              Schema.Struct({
+                operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+                path: Schema.String,
+                sha256: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                thumbprint: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  operatingSystem: "operating_system",
+                  path: "path",
+                  sha256: "sha256",
+                  thumbprint: "thumbprint",
+                }),
+              ),
+              Schema.Struct({
+                certificateId: Schema.String,
+                cn: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  certificateId: "certificate_id",
+                  cn: "cn",
+                }),
               ),
               Schema.Struct({
                 complianceStatus: Schema.Literals([
@@ -58992,6 +58985,36 @@ export const ListDevicePosturesResponse =
                   connectionId: "connection_id",
                 }),
               ),
+              Schema.Struct({
+                complianceStatus: Schema.Literals([
+                  "compliant",
+                  "noncompliant",
+                  "unknown",
+                  "notapplicable",
+                  "ingraceperiod",
+                  "error",
+                ]),
+                connectionId: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  complianceStatus: "compliance_status",
+                  connectionId: "connection_id",
+                }),
+              ),
+              Schema.Struct({
+                operatingSystem: Schema.Literal("windows"),
+                domain: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  operatingSystem: "operating_system",
+                  domain: "domain",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+              }),
               Schema.Struct({
                 connectionId: Schema.String,
                 lastSeen: Schema.optional(
@@ -59036,33 +59059,6 @@ export const ListDevicePosturesResponse =
                   state: "state",
                   version: "version",
                   versionOperator: "versionOperator",
-                }),
-              ),
-              Schema.Struct({
-                complianceStatus: Schema.Literals([
-                  "compliant",
-                  "noncompliant",
-                  "unknown",
-                  "notapplicable",
-                  "ingraceperiod",
-                  "error",
-                ]),
-                connectionId: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  complianceStatus: "compliance_status",
-                  connectionId: "connection_id",
-                }),
-              ),
-              Schema.Struct({
-                connectionId: Schema.String,
-                countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-                issueCount: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  connectionId: "connection_id",
-                  countOperator: "countOperator",
-                  issueCount: "issue_count",
                 }),
               ),
               Schema.Struct({
@@ -59155,15 +59151,19 @@ export const ListDevicePosturesResponse =
                 }),
               ),
               Schema.Struct({
-                connectionId: Schema.String,
-                operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-                score: Schema.Number,
+                checkDisks: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                requireAll: Schema.optional(
+                  Schema.Union([Schema.Boolean, Schema.Null]),
+                ),
+              }),
+              Schema.Struct({
+                updateWindowDays: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
               }).pipe(
-                Schema.encodeKeys({
-                  connectionId: "connection_id",
-                  operator: "operator",
-                  score: "score",
-                }),
+                Schema.encodeKeys({ updateWindowDays: "update_window_days" }),
               ),
             ]),
             Schema.Null,
@@ -59422,36 +59422,6 @@ export const CreateDevicePostureRequest =
     input: Schema.optional(
       Schema.Union([
         Schema.Struct({
-          operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-          path: Schema.String,
-          exists: Schema.optional(Schema.Boolean),
-          sha256: Schema.optional(Schema.String),
-          thumbprint: Schema.optional(Schema.String),
-        }).pipe(
-          Schema.encodeKeys({
-            operatingSystem: "operating_system",
-            path: "path",
-            exists: "exists",
-            sha256: "sha256",
-            thumbprint: "thumbprint",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
-        }).pipe(
-          Schema.encodeKeys({ id: "id", operatingSystem: "operating_system" }),
-        ),
-        Schema.Struct({
-          operatingSystem: Schema.Literal("windows"),
-          domain: Schema.optional(Schema.String),
-        }).pipe(
-          Schema.encodeKeys({
-            operatingSystem: "operating_system",
-            domain: "domain",
-          }),
-        ),
-        Schema.Struct({
           operatingSystem: Schema.Literal("windows"),
           operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
           version: Schema.String,
@@ -59467,41 +59437,6 @@ export const CreateDevicePostureRequest =
             osDistroRevision: "os_distro_revision",
             osVersionExtra: "os_version_extra",
           }),
-        ),
-        Schema.Struct({
-          enabled: Schema.Boolean,
-          operatingSystem: Schema.Literals(["windows", "mac"]),
-        }).pipe(
-          Schema.encodeKeys({
-            enabled: "enabled",
-            operatingSystem: "operating_system",
-          }),
-        ),
-        Schema.Struct({
-          operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-          path: Schema.String,
-          sha256: Schema.optional(Schema.String),
-          thumbprint: Schema.optional(Schema.String),
-        }).pipe(
-          Schema.encodeKeys({
-            operatingSystem: "operating_system",
-            path: "path",
-            sha256: "sha256",
-            thumbprint: "thumbprint",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-        }),
-        Schema.Struct({
-          checkDisks: Schema.optional(Schema.Array(Schema.String)),
-          requireAll: Schema.optional(Schema.Boolean),
-        }),
-        Schema.Struct({
-          certificateId: Schema.String,
-          cn: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
         ),
         Schema.Struct({
           certificateId: Schema.String,
@@ -59537,8 +59472,76 @@ export const CreateDevicePostureRequest =
           }),
         ),
         Schema.Struct({
-          updateWindowDays: Schema.optional(Schema.Number),
-        }).pipe(Schema.encodeKeys({ updateWindowDays: "update_window_days" })),
+          connectionId: Schema.String,
+          countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+          issueCount: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            connectionId: "connection_id",
+            countOperator: "countOperator",
+            issueCount: "issue_count",
+          }),
+        ),
+        Schema.Struct({
+          connectionId: Schema.String,
+          operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+          score: Schema.Number,
+        }).pipe(
+          Schema.encodeKeys({
+            connectionId: "connection_id",
+            operator: "operator",
+            score: "score",
+          }),
+        ),
+        Schema.Struct({
+          operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+          path: Schema.String,
+          exists: Schema.optional(Schema.Boolean),
+          sha256: Schema.optional(Schema.String),
+          thumbprint: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            operatingSystem: "operating_system",
+            path: "path",
+            exists: "exists",
+            sha256: "sha256",
+            thumbprint: "thumbprint",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
+        }).pipe(
+          Schema.encodeKeys({ id: "id", operatingSystem: "operating_system" }),
+        ),
+        Schema.Struct({
+          enabled: Schema.Boolean,
+          operatingSystem: Schema.Literals(["windows", "mac"]),
+        }).pipe(
+          Schema.encodeKeys({
+            enabled: "enabled",
+            operatingSystem: "operating_system",
+          }),
+        ),
+        Schema.Struct({
+          operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+          path: Schema.String,
+          sha256: Schema.optional(Schema.String),
+          thumbprint: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            operatingSystem: "operating_system",
+            path: "path",
+            sha256: "sha256",
+            thumbprint: "thumbprint",
+          }),
+        ),
+        Schema.Struct({
+          certificateId: Schema.String,
+          cn: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
+        ),
         Schema.Struct({
           complianceStatus: Schema.Literals([
             "compliant",
@@ -59552,6 +59555,34 @@ export const CreateDevicePostureRequest =
             connectionId: "connection_id",
           }),
         ),
+        Schema.Struct({
+          complianceStatus: Schema.Literals([
+            "compliant",
+            "noncompliant",
+            "unknown",
+            "notapplicable",
+            "ingraceperiod",
+            "error",
+          ]),
+          connectionId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            complianceStatus: "compliance_status",
+            connectionId: "connection_id",
+          }),
+        ),
+        Schema.Struct({
+          operatingSystem: Schema.Literal("windows"),
+          domain: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            operatingSystem: "operating_system",
+            domain: "domain",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+        }),
         Schema.Struct({
           connectionId: Schema.String,
           lastSeen: Schema.optional(Schema.String),
@@ -59579,33 +59610,6 @@ export const CreateDevicePostureRequest =
             state: "state",
             version: "version",
             versionOperator: "versionOperator",
-          }),
-        ),
-        Schema.Struct({
-          complianceStatus: Schema.Literals([
-            "compliant",
-            "noncompliant",
-            "unknown",
-            "notapplicable",
-            "ingraceperiod",
-            "error",
-          ]),
-          connectionId: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            complianceStatus: "compliance_status",
-            connectionId: "connection_id",
-          }),
-        ),
-        Schema.Struct({
-          connectionId: Schema.String,
-          countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-          issueCount: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            connectionId: "connection_id",
-            countOperator: "countOperator",
-            issueCount: "issue_count",
           }),
         ),
         Schema.Struct({
@@ -59670,16 +59674,12 @@ export const CreateDevicePostureRequest =
           }),
         ),
         Schema.Struct({
-          connectionId: Schema.String,
-          operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-          score: Schema.Number,
-        }).pipe(
-          Schema.encodeKeys({
-            connectionId: "connection_id",
-            operator: "operator",
-            score: "score",
-          }),
-        ),
+          checkDisks: Schema.optional(Schema.Array(Schema.String)),
+          requireAll: Schema.optional(Schema.Boolean),
+        }),
+        Schema.Struct({
+          updateWindowDays: Schema.optional(Schema.Number),
+        }).pipe(Schema.encodeKeys({ updateWindowDays: "update_window_days" })),
       ]),
     ),
     match: Schema.optional(
@@ -59872,43 +59872,6 @@ export const CreateDevicePostureResponse =
       Schema.Union([
         Schema.Union([
           Schema.Struct({
-            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-            path: Schema.String,
-            exists: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            thumbprint: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              path: "path",
-              exists: "exists",
-              sha256: "sha256",
-              thumbprint: "thumbprint",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              operatingSystem: "operating_system",
-            }),
-          ),
-          Schema.Struct({
-            operatingSystem: Schema.Literal("windows"),
-            domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              domain: "domain",
-            }),
-          ),
-          Schema.Struct({
             operatingSystem: Schema.Literal("windows"),
             operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
             version: Schema.String,
@@ -59930,47 +59893,6 @@ export const CreateDevicePostureResponse =
               osDistroRevision: "os_distro_revision",
               osVersionExtra: "os_version_extra",
             }),
-          ),
-          Schema.Struct({
-            enabled: Schema.Boolean,
-            operatingSystem: Schema.Literals(["windows", "mac"]),
-          }).pipe(
-            Schema.encodeKeys({
-              enabled: "enabled",
-              operatingSystem: "operating_system",
-            }),
-          ),
-          Schema.Struct({
-            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-            path: Schema.String,
-            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            thumbprint: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              path: "path",
-              sha256: "sha256",
-              thumbprint: "thumbprint",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-          }),
-          Schema.Struct({
-            checkDisks: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            requireAll: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-          }),
-          Schema.Struct({
-            certificateId: Schema.String,
-            cn: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
           ),
           Schema.Struct({
             certificateId: Schema.String,
@@ -60021,11 +59943,84 @@ export const CreateDevicePostureResponse =
             }),
           ),
           Schema.Struct({
-            updateWindowDays: Schema.optional(
-              Schema.Union([Schema.Number, Schema.Null]),
+            connectionId: Schema.String,
+            countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+            issueCount: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              connectionId: "connection_id",
+              countOperator: "countOperator",
+              issueCount: "issue_count",
+            }),
+          ),
+          Schema.Struct({
+            connectionId: Schema.String,
+            operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+            score: Schema.Number,
+          }).pipe(
+            Schema.encodeKeys({
+              connectionId: "connection_id",
+              operator: "operator",
+              score: "score",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+            path: Schema.String,
+            exists: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            thumbprint: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
             ),
           }).pipe(
-            Schema.encodeKeys({ updateWindowDays: "update_window_days" }),
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              path: "path",
+              exists: "exists",
+              sha256: "sha256",
+              thumbprint: "thumbprint",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              operatingSystem: "operating_system",
+            }),
+          ),
+          Schema.Struct({
+            enabled: Schema.Boolean,
+            operatingSystem: Schema.Literals(["windows", "mac"]),
+          }).pipe(
+            Schema.encodeKeys({
+              enabled: "enabled",
+              operatingSystem: "operating_system",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+            path: Schema.String,
+            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            thumbprint: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              path: "path",
+              sha256: "sha256",
+              thumbprint: "thumbprint",
+            }),
+          ),
+          Schema.Struct({
+            certificateId: Schema.String,
+            cn: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
           ),
           Schema.Struct({
             complianceStatus: Schema.Literals([
@@ -60040,6 +60035,34 @@ export const CreateDevicePostureResponse =
               connectionId: "connection_id",
             }),
           ),
+          Schema.Struct({
+            complianceStatus: Schema.Literals([
+              "compliant",
+              "noncompliant",
+              "unknown",
+              "notapplicable",
+              "ingraceperiod",
+              "error",
+            ]),
+            connectionId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              complianceStatus: "compliance_status",
+              connectionId: "connection_id",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literal("windows"),
+            domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          }).pipe(
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              domain: "domain",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+          }),
           Schema.Struct({
             connectionId: Schema.String,
             lastSeen: Schema.optional(
@@ -60084,33 +60107,6 @@ export const CreateDevicePostureResponse =
               state: "state",
               version: "version",
               versionOperator: "versionOperator",
-            }),
-          ),
-          Schema.Struct({
-            complianceStatus: Schema.Literals([
-              "compliant",
-              "noncompliant",
-              "unknown",
-              "notapplicable",
-              "ingraceperiod",
-              "error",
-            ]),
-            connectionId: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              complianceStatus: "compliance_status",
-              connectionId: "connection_id",
-            }),
-          ),
-          Schema.Struct({
-            connectionId: Schema.String,
-            countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-            issueCount: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              connectionId: "connection_id",
-              countOperator: "countOperator",
-              issueCount: "issue_count",
             }),
           ),
           Schema.Struct({
@@ -60203,15 +60199,19 @@ export const CreateDevicePostureResponse =
             }),
           ),
           Schema.Struct({
-            connectionId: Schema.String,
-            operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-            score: Schema.Number,
+            checkDisks: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            requireAll: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+          }),
+          Schema.Struct({
+            updateWindowDays: Schema.optional(
+              Schema.Union([Schema.Number, Schema.Null]),
+            ),
           }).pipe(
-            Schema.encodeKeys({
-              connectionId: "connection_id",
-              operator: "operator",
-              score: "score",
-            }),
+            Schema.encodeKeys({ updateWindowDays: "update_window_days" }),
           ),
         ]),
         Schema.Null,
@@ -60468,36 +60468,6 @@ export const UpdateDevicePostureRequest =
     input: Schema.optional(
       Schema.Union([
         Schema.Struct({
-          operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-          path: Schema.String,
-          exists: Schema.optional(Schema.Boolean),
-          sha256: Schema.optional(Schema.String),
-          thumbprint: Schema.optional(Schema.String),
-        }).pipe(
-          Schema.encodeKeys({
-            operatingSystem: "operating_system",
-            path: "path",
-            exists: "exists",
-            sha256: "sha256",
-            thumbprint: "thumbprint",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
-        }).pipe(
-          Schema.encodeKeys({ id: "id", operatingSystem: "operating_system" }),
-        ),
-        Schema.Struct({
-          operatingSystem: Schema.Literal("windows"),
-          domain: Schema.optional(Schema.String),
-        }).pipe(
-          Schema.encodeKeys({
-            operatingSystem: "operating_system",
-            domain: "domain",
-          }),
-        ),
-        Schema.Struct({
           operatingSystem: Schema.Literal("windows"),
           operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
           version: Schema.String,
@@ -60513,41 +60483,6 @@ export const UpdateDevicePostureRequest =
             osDistroRevision: "os_distro_revision",
             osVersionExtra: "os_version_extra",
           }),
-        ),
-        Schema.Struct({
-          enabled: Schema.Boolean,
-          operatingSystem: Schema.Literals(["windows", "mac"]),
-        }).pipe(
-          Schema.encodeKeys({
-            enabled: "enabled",
-            operatingSystem: "operating_system",
-          }),
-        ),
-        Schema.Struct({
-          operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-          path: Schema.String,
-          sha256: Schema.optional(Schema.String),
-          thumbprint: Schema.optional(Schema.String),
-        }).pipe(
-          Schema.encodeKeys({
-            operatingSystem: "operating_system",
-            path: "path",
-            sha256: "sha256",
-            thumbprint: "thumbprint",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-        }),
-        Schema.Struct({
-          checkDisks: Schema.optional(Schema.Array(Schema.String)),
-          requireAll: Schema.optional(Schema.Boolean),
-        }),
-        Schema.Struct({
-          certificateId: Schema.String,
-          cn: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
         ),
         Schema.Struct({
           certificateId: Schema.String,
@@ -60583,8 +60518,76 @@ export const UpdateDevicePostureRequest =
           }),
         ),
         Schema.Struct({
-          updateWindowDays: Schema.optional(Schema.Number),
-        }).pipe(Schema.encodeKeys({ updateWindowDays: "update_window_days" })),
+          connectionId: Schema.String,
+          countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+          issueCount: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            connectionId: "connection_id",
+            countOperator: "countOperator",
+            issueCount: "issue_count",
+          }),
+        ),
+        Schema.Struct({
+          connectionId: Schema.String,
+          operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+          score: Schema.Number,
+        }).pipe(
+          Schema.encodeKeys({
+            connectionId: "connection_id",
+            operator: "operator",
+            score: "score",
+          }),
+        ),
+        Schema.Struct({
+          operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+          path: Schema.String,
+          exists: Schema.optional(Schema.Boolean),
+          sha256: Schema.optional(Schema.String),
+          thumbprint: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            operatingSystem: "operating_system",
+            path: "path",
+            exists: "exists",
+            sha256: "sha256",
+            thumbprint: "thumbprint",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
+        }).pipe(
+          Schema.encodeKeys({ id: "id", operatingSystem: "operating_system" }),
+        ),
+        Schema.Struct({
+          enabled: Schema.Boolean,
+          operatingSystem: Schema.Literals(["windows", "mac"]),
+        }).pipe(
+          Schema.encodeKeys({
+            enabled: "enabled",
+            operatingSystem: "operating_system",
+          }),
+        ),
+        Schema.Struct({
+          operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+          path: Schema.String,
+          sha256: Schema.optional(Schema.String),
+          thumbprint: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            operatingSystem: "operating_system",
+            path: "path",
+            sha256: "sha256",
+            thumbprint: "thumbprint",
+          }),
+        ),
+        Schema.Struct({
+          certificateId: Schema.String,
+          cn: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
+        ),
         Schema.Struct({
           complianceStatus: Schema.Literals([
             "compliant",
@@ -60598,6 +60601,34 @@ export const UpdateDevicePostureRequest =
             connectionId: "connection_id",
           }),
         ),
+        Schema.Struct({
+          complianceStatus: Schema.Literals([
+            "compliant",
+            "noncompliant",
+            "unknown",
+            "notapplicable",
+            "ingraceperiod",
+            "error",
+          ]),
+          connectionId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            complianceStatus: "compliance_status",
+            connectionId: "connection_id",
+          }),
+        ),
+        Schema.Struct({
+          operatingSystem: Schema.Literal("windows"),
+          domain: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            operatingSystem: "operating_system",
+            domain: "domain",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+        }),
         Schema.Struct({
           connectionId: Schema.String,
           lastSeen: Schema.optional(Schema.String),
@@ -60625,33 +60656,6 @@ export const UpdateDevicePostureRequest =
             state: "state",
             version: "version",
             versionOperator: "versionOperator",
-          }),
-        ),
-        Schema.Struct({
-          complianceStatus: Schema.Literals([
-            "compliant",
-            "noncompliant",
-            "unknown",
-            "notapplicable",
-            "ingraceperiod",
-            "error",
-          ]),
-          connectionId: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            complianceStatus: "compliance_status",
-            connectionId: "connection_id",
-          }),
-        ),
-        Schema.Struct({
-          connectionId: Schema.String,
-          countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-          issueCount: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            connectionId: "connection_id",
-            countOperator: "countOperator",
-            issueCount: "issue_count",
           }),
         ),
         Schema.Struct({
@@ -60716,16 +60720,12 @@ export const UpdateDevicePostureRequest =
           }),
         ),
         Schema.Struct({
-          connectionId: Schema.String,
-          operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-          score: Schema.Number,
-        }).pipe(
-          Schema.encodeKeys({
-            connectionId: "connection_id",
-            operator: "operator",
-            score: "score",
-          }),
-        ),
+          checkDisks: Schema.optional(Schema.Array(Schema.String)),
+          requireAll: Schema.optional(Schema.Boolean),
+        }),
+        Schema.Struct({
+          updateWindowDays: Schema.optional(Schema.Number),
+        }).pipe(Schema.encodeKeys({ updateWindowDays: "update_window_days" })),
       ]),
     ),
     match: Schema.optional(
@@ -60921,43 +60921,6 @@ export const UpdateDevicePostureResponse =
       Schema.Union([
         Schema.Union([
           Schema.Struct({
-            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-            path: Schema.String,
-            exists: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            thumbprint: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              path: "path",
-              exists: "exists",
-              sha256: "sha256",
-              thumbprint: "thumbprint",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              operatingSystem: "operating_system",
-            }),
-          ),
-          Schema.Struct({
-            operatingSystem: Schema.Literal("windows"),
-            domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              domain: "domain",
-            }),
-          ),
-          Schema.Struct({
             operatingSystem: Schema.Literal("windows"),
             operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
             version: Schema.String,
@@ -60979,47 +60942,6 @@ export const UpdateDevicePostureResponse =
               osDistroRevision: "os_distro_revision",
               osVersionExtra: "os_version_extra",
             }),
-          ),
-          Schema.Struct({
-            enabled: Schema.Boolean,
-            operatingSystem: Schema.Literals(["windows", "mac"]),
-          }).pipe(
-            Schema.encodeKeys({
-              enabled: "enabled",
-              operatingSystem: "operating_system",
-            }),
-          ),
-          Schema.Struct({
-            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
-            path: Schema.String,
-            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            thumbprint: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              operatingSystem: "operating_system",
-              path: "path",
-              sha256: "sha256",
-              thumbprint: "thumbprint",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-          }),
-          Schema.Struct({
-            checkDisks: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            requireAll: Schema.optional(
-              Schema.Union([Schema.Boolean, Schema.Null]),
-            ),
-          }),
-          Schema.Struct({
-            certificateId: Schema.String,
-            cn: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
           ),
           Schema.Struct({
             certificateId: Schema.String,
@@ -61070,11 +60992,84 @@ export const UpdateDevicePostureResponse =
             }),
           ),
           Schema.Struct({
-            updateWindowDays: Schema.optional(
-              Schema.Union([Schema.Number, Schema.Null]),
+            connectionId: Schema.String,
+            countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+            issueCount: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              connectionId: "connection_id",
+              countOperator: "countOperator",
+              issueCount: "issue_count",
+            }),
+          ),
+          Schema.Struct({
+            connectionId: Schema.String,
+            operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
+            score: Schema.Number,
+          }).pipe(
+            Schema.encodeKeys({
+              connectionId: "connection_id",
+              operator: "operator",
+              score: "score",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+            path: Schema.String,
+            exists: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            thumbprint: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
             ),
           }).pipe(
-            Schema.encodeKeys({ updateWindowDays: "update_window_days" }),
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              path: "path",
+              exists: "exists",
+              sha256: "sha256",
+              thumbprint: "thumbprint",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            operatingSystem: Schema.Literals(["android", "ios", "chromeos"]),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              operatingSystem: "operating_system",
+            }),
+          ),
+          Schema.Struct({
+            enabled: Schema.Boolean,
+            operatingSystem: Schema.Literals(["windows", "mac"]),
+          }).pipe(
+            Schema.encodeKeys({
+              enabled: "enabled",
+              operatingSystem: "operating_system",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literals(["windows", "linux", "mac"]),
+            path: Schema.String,
+            sha256: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            thumbprint: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              path: "path",
+              sha256: "sha256",
+              thumbprint: "thumbprint",
+            }),
+          ),
+          Schema.Struct({
+            certificateId: Schema.String,
+            cn: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({ certificateId: "certificate_id", cn: "cn" }),
           ),
           Schema.Struct({
             complianceStatus: Schema.Literals([
@@ -61089,6 +61084,34 @@ export const UpdateDevicePostureResponse =
               connectionId: "connection_id",
             }),
           ),
+          Schema.Struct({
+            complianceStatus: Schema.Literals([
+              "compliant",
+              "noncompliant",
+              "unknown",
+              "notapplicable",
+              "ingraceperiod",
+              "error",
+            ]),
+            connectionId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              complianceStatus: "compliance_status",
+              connectionId: "connection_id",
+            }),
+          ),
+          Schema.Struct({
+            operatingSystem: Schema.Literal("windows"),
+            domain: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          }).pipe(
+            Schema.encodeKeys({
+              operatingSystem: "operating_system",
+              domain: "domain",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+          }),
           Schema.Struct({
             connectionId: Schema.String,
             lastSeen: Schema.optional(
@@ -61133,33 +61156,6 @@ export const UpdateDevicePostureResponse =
               state: "state",
               version: "version",
               versionOperator: "versionOperator",
-            }),
-          ),
-          Schema.Struct({
-            complianceStatus: Schema.Literals([
-              "compliant",
-              "noncompliant",
-              "unknown",
-              "notapplicable",
-              "ingraceperiod",
-              "error",
-            ]),
-            connectionId: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              complianceStatus: "compliance_status",
-              connectionId: "connection_id",
-            }),
-          ),
-          Schema.Struct({
-            connectionId: Schema.String,
-            countOperator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-            issueCount: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              connectionId: "connection_id",
-              countOperator: "countOperator",
-              issueCount: "issue_count",
             }),
           ),
           Schema.Struct({
@@ -61252,15 +61248,19 @@ export const UpdateDevicePostureResponse =
             }),
           ),
           Schema.Struct({
-            connectionId: Schema.String,
-            operator: Schema.Literals(["<", "<=", ">", ">=", "=="]),
-            score: Schema.Number,
+            checkDisks: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            requireAll: Schema.optional(
+              Schema.Union([Schema.Boolean, Schema.Null]),
+            ),
+          }),
+          Schema.Struct({
+            updateWindowDays: Schema.optional(
+              Schema.Union([Schema.Number, Schema.Null]),
+            ),
           }).pipe(
-            Schema.encodeKeys({
-              connectionId: "connection_id",
-              operator: "operator",
-              score: "score",
-            }),
+            Schema.encodeKeys({ updateWindowDays: "update_window_days" }),
           ),
         ]),
         Schema.Null,
@@ -61669,6 +61669,17 @@ export const CreateDevicePostureIntegrationRequest =
         }),
       ),
       Schema.Struct({
+        accessClientId: Schema.String,
+        accessClientSecret: SensitiveString,
+        apiUrl: Schema.String,
+      }).pipe(
+        Schema.encodeKeys({
+          accessClientId: "access_client_id",
+          accessClientSecret: "access_client_secret",
+          apiUrl: "api_url",
+        }),
+      ),
+      Schema.Struct({
         clientId: Schema.String,
         clientSecret: SensitiveString,
       }).pipe(
@@ -61695,17 +61706,6 @@ export const CreateDevicePostureIntegrationRequest =
         clientSecret: SensitiveString,
       }).pipe(
         Schema.encodeKeys({ apiUrl: "api_url", clientSecret: "client_secret" }),
-      ),
-      Schema.Struct({
-        accessClientId: Schema.String,
-        accessClientSecret: SensitiveString,
-        apiUrl: Schema.String,
-      }).pipe(
-        Schema.encodeKeys({
-          accessClientId: "access_client_id",
-          accessClientSecret: "access_client_secret",
-          apiUrl: "api_url",
-        }),
       ),
     ]),
     interval: Schema.String,
@@ -61909,6 +61909,17 @@ export const PatchDevicePostureIntegrationRequest =
           }),
         ),
         Schema.Struct({
+          accessClientId: Schema.String,
+          accessClientSecret: SensitiveString,
+          apiUrl: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            accessClientId: "access_client_id",
+            accessClientSecret: "access_client_secret",
+            apiUrl: "api_url",
+          }),
+        ),
+        Schema.Struct({
           clientId: Schema.String,
           clientSecret: SensitiveString,
         }).pipe(
@@ -61937,17 +61948,6 @@ export const PatchDevicePostureIntegrationRequest =
           Schema.encodeKeys({
             apiUrl: "api_url",
             clientSecret: "client_secret",
-          }),
-        ),
-        Schema.Struct({
-          accessClientId: Schema.String,
-          accessClientSecret: SensitiveString,
-          apiUrl: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            accessClientId: "access_client_id",
-            accessClientSecret: "access_client_secret",
-            apiUrl: "api_url",
           }),
         ),
       ]),
@@ -68142,6 +68142,53 @@ export type GetDlpEntryResponse =
 export const GetDlpEntryResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
   Schema.Struct({
     id: Schema.String,
+    caseSensitive: Schema.Boolean,
+    createdAt: Schema.String,
+    enabled: Schema.Boolean,
+    name: Schema.String,
+    secret: Schema.Boolean,
+    type: Schema.Literal("exact_data"),
+    updatedAt: Schema.String,
+    profiles: Schema.optional(
+      Schema.Union([
+        Schema.Array(
+          Schema.Struct({
+            id: Schema.String,
+            name: Schema.String,
+          }),
+        ),
+        Schema.Null,
+      ]),
+    ),
+    uploadStatus: Schema.optional(
+      Schema.Union([
+        Schema.Literals([
+          "empty",
+          "uploading",
+          "pending",
+          "processing",
+          "failed",
+          "complete",
+        ]),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      caseSensitive: "case_sensitive",
+      createdAt: "created_at",
+      enabled: "enabled",
+      name: "name",
+      secret: "secret",
+      type: "type",
+      updatedAt: "updated_at",
+      profiles: "profiles",
+      uploadStatus: "upload_status",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
     createdAt: Schema.String,
     enabled: Schema.Boolean,
     name: Schema.String,
@@ -68188,6 +68235,141 @@ export const GetDlpEntryResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       type: "type",
       updatedAt: "updated_at",
       profileId: "profile_id",
+      profiles: "profiles",
+      uploadStatus: "upload_status",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
+    createdAt: Schema.String,
+    enabled: Schema.Boolean,
+    name: Schema.String,
+    type: Schema.Literal("word_list"),
+    updatedAt: Schema.String,
+    wordList: Schema.Unknown,
+    profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    profiles: Schema.optional(
+      Schema.Union([
+        Schema.Array(
+          Schema.Struct({
+            id: Schema.String,
+            name: Schema.String,
+          }),
+        ),
+        Schema.Null,
+      ]),
+    ),
+    uploadStatus: Schema.optional(
+      Schema.Union([
+        Schema.Literals([
+          "empty",
+          "uploading",
+          "pending",
+          "processing",
+          "failed",
+          "complete",
+        ]),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      createdAt: "created_at",
+      enabled: "enabled",
+      name: "name",
+      type: "type",
+      updatedAt: "updated_at",
+      wordList: "word_list",
+      profileId: "profile_id",
+      profiles: "profiles",
+      uploadStatus: "upload_status",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
+    createdAt: Schema.String,
+    enabled: Schema.Boolean,
+    name: Schema.String,
+    type: Schema.Literal("integration"),
+    updatedAt: Schema.String,
+    profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    profiles: Schema.optional(
+      Schema.Union([
+        Schema.Array(
+          Schema.Struct({
+            id: Schema.String,
+            name: Schema.String,
+          }),
+        ),
+        Schema.Null,
+      ]),
+    ),
+    uploadStatus: Schema.optional(
+      Schema.Union([
+        Schema.Literals([
+          "empty",
+          "uploading",
+          "pending",
+          "processing",
+          "failed",
+          "complete",
+        ]),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      createdAt: "created_at",
+      enabled: "enabled",
+      name: "name",
+      type: "type",
+      updatedAt: "updated_at",
+      profileId: "profile_id",
+      profiles: "profiles",
+      uploadStatus: "upload_status",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
+    createdAt: Schema.String,
+    enabled: Schema.Boolean,
+    name: Schema.String,
+    type: Schema.Literal("document_fingerprint"),
+    updatedAt: Schema.String,
+    profiles: Schema.optional(
+      Schema.Union([
+        Schema.Array(
+          Schema.Struct({
+            id: Schema.String,
+            name: Schema.String,
+          }),
+        ),
+        Schema.Null,
+      ]),
+    ),
+    uploadStatus: Schema.optional(
+      Schema.Union([
+        Schema.Literals([
+          "empty",
+          "uploading",
+          "pending",
+          "processing",
+          "failed",
+          "complete",
+        ]),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      createdAt: "created_at",
+      enabled: "enabled",
+      name: "name",
+      type: "type",
+      updatedAt: "updated_at",
       profiles: "profiles",
       uploadStatus: "upload_status",
     }),
@@ -68260,188 +68442,6 @@ export const GetDlpEntryResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       profiles: "profiles",
       uploadStatus: "upload_status",
       variant: "variant",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    createdAt: Schema.String,
-    enabled: Schema.Boolean,
-    name: Schema.String,
-    type: Schema.Literal("integration"),
-    updatedAt: Schema.String,
-    profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    profiles: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            id: Schema.String,
-            name: Schema.String,
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-    uploadStatus: Schema.optional(
-      Schema.Union([
-        Schema.Literals([
-          "empty",
-          "uploading",
-          "pending",
-          "processing",
-          "failed",
-          "complete",
-        ]),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      createdAt: "created_at",
-      enabled: "enabled",
-      name: "name",
-      type: "type",
-      updatedAt: "updated_at",
-      profileId: "profile_id",
-      profiles: "profiles",
-      uploadStatus: "upload_status",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    caseSensitive: Schema.Boolean,
-    createdAt: Schema.String,
-    enabled: Schema.Boolean,
-    name: Schema.String,
-    secret: Schema.Boolean,
-    type: Schema.Literal("exact_data"),
-    updatedAt: Schema.String,
-    profiles: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            id: Schema.String,
-            name: Schema.String,
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-    uploadStatus: Schema.optional(
-      Schema.Union([
-        Schema.Literals([
-          "empty",
-          "uploading",
-          "pending",
-          "processing",
-          "failed",
-          "complete",
-        ]),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      caseSensitive: "case_sensitive",
-      createdAt: "created_at",
-      enabled: "enabled",
-      name: "name",
-      secret: "secret",
-      type: "type",
-      updatedAt: "updated_at",
-      profiles: "profiles",
-      uploadStatus: "upload_status",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    createdAt: Schema.String,
-    enabled: Schema.Boolean,
-    name: Schema.String,
-    type: Schema.Literal("document_fingerprint"),
-    updatedAt: Schema.String,
-    profiles: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            id: Schema.String,
-            name: Schema.String,
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-    uploadStatus: Schema.optional(
-      Schema.Union([
-        Schema.Literals([
-          "empty",
-          "uploading",
-          "pending",
-          "processing",
-          "failed",
-          "complete",
-        ]),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      createdAt: "created_at",
-      enabled: "enabled",
-      name: "name",
-      type: "type",
-      updatedAt: "updated_at",
-      profiles: "profiles",
-      uploadStatus: "upload_status",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    createdAt: Schema.String,
-    enabled: Schema.Boolean,
-    name: Schema.String,
-    type: Schema.Literal("word_list"),
-    updatedAt: Schema.String,
-    wordList: Schema.Unknown,
-    profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    profiles: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            id: Schema.String,
-            name: Schema.String,
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-    uploadStatus: Schema.optional(
-      Schema.Union([
-        Schema.Literals([
-          "empty",
-          "uploading",
-          "pending",
-          "processing",
-          "failed",
-          "complete",
-        ]),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      createdAt: "created_at",
-      enabled: "enabled",
-      name: "name",
-      type: "type",
-      updatedAt: "updated_at",
-      wordList: "word_list",
-      profileId: "profile_id",
-      profiles: "profiles",
-      uploadStatus: "upload_status",
     }),
   ),
 ]).pipe(
@@ -68590,6 +68590,41 @@ export const ListDlpEntriesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
       Schema.Union([
         Schema.Struct({
           id: Schema.String,
+          caseSensitive: Schema.Boolean,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          secret: Schema.Boolean,
+          type: Schema.Literal("exact_data"),
+          updatedAt: Schema.String,
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            caseSensitive: "case_sensitive",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            secret: "secret",
+            type: "type",
+            updatedAt: "updated_at",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
           createdAt: Schema.String,
           enabled: Schema.Boolean,
           name: Schema.String,
@@ -68627,6 +68662,109 @@ export const ListDlpEntriesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
             type: "type",
             updatedAt: "updated_at",
             profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("word_list"),
+          updatedAt: Schema.String,
+          wordList: Schema.Unknown,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            wordList: "word_list",
+            profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("document_fingerprint"),
+          updatedAt: Schema.String,
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
             uploadStatus: "upload_status",
           }),
         ),
@@ -68688,144 +68826,6 @@ export const ListDlpEntriesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
             profileId: "profile_id",
             uploadStatus: "upload_status",
             variant: "variant",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          caseSensitive: Schema.Boolean,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          secret: Schema.Boolean,
-          type: Schema.Literal("exact_data"),
-          updatedAt: Schema.String,
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            caseSensitive: "case_sensitive",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            secret: "secret",
-            type: "type",
-            updatedAt: "updated_at",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("document_fingerprint"),
-          updatedAt: Schema.String,
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("word_list"),
-          updatedAt: Schema.String,
-          wordList: Schema.Unknown,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            wordList: "word_list",
-            profileId: "profile_id",
-            uploadStatus: "upload_status",
           }),
         ),
       ]),
@@ -69032,6 +69032,27 @@ export type UpdateDlpEntryResponse =
 export const UpdateDlpEntryResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
   Schema.Struct({
     id: Schema.String,
+    caseSensitive: Schema.Boolean,
+    createdAt: Schema.String,
+    enabled: Schema.Boolean,
+    name: Schema.String,
+    secret: Schema.Boolean,
+    type: Schema.Literal("exact_data"),
+    updatedAt: Schema.String,
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      caseSensitive: "case_sensitive",
+      createdAt: "created_at",
+      enabled: "enabled",
+      name: "name",
+      secret: "secret",
+      type: "type",
+      updatedAt: "updated_at",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
     createdAt: Schema.String,
     enabled: Schema.Boolean,
     name: Schema.String,
@@ -69054,6 +69075,63 @@ export const UpdateDlpEntryResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       type: "type",
       updatedAt: "updated_at",
       profileId: "profile_id",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
+    createdAt: Schema.String,
+    enabled: Schema.Boolean,
+    name: Schema.String,
+    type: Schema.Literal("word_list"),
+    updatedAt: Schema.String,
+    wordList: Schema.Unknown,
+    profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      createdAt: "created_at",
+      enabled: "enabled",
+      name: "name",
+      type: "type",
+      updatedAt: "updated_at",
+      wordList: "word_list",
+      profileId: "profile_id",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
+    createdAt: Schema.String,
+    enabled: Schema.Boolean,
+    name: Schema.String,
+    type: Schema.Literal("integration"),
+    updatedAt: Schema.String,
+    profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      createdAt: "created_at",
+      enabled: "enabled",
+      name: "name",
+      type: "type",
+      updatedAt: "updated_at",
+      profileId: "profile_id",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
+    createdAt: Schema.String,
+    enabled: Schema.Boolean,
+    name: Schema.String,
+    type: Schema.Literal("document_fingerprint"),
+    updatedAt: Schema.String,
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      createdAt: "created_at",
+      enabled: "enabled",
+      name: "name",
+      type: "type",
+      updatedAt: "updated_at",
     }),
   ),
   Schema.Struct({
@@ -69098,84 +69176,6 @@ export const UpdateDlpEntryResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       type: "type",
       profileId: "profile_id",
       variant: "variant",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    createdAt: Schema.String,
-    enabled: Schema.Boolean,
-    name: Schema.String,
-    type: Schema.Literal("integration"),
-    updatedAt: Schema.String,
-    profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      createdAt: "created_at",
-      enabled: "enabled",
-      name: "name",
-      type: "type",
-      updatedAt: "updated_at",
-      profileId: "profile_id",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    caseSensitive: Schema.Boolean,
-    createdAt: Schema.String,
-    enabled: Schema.Boolean,
-    name: Schema.String,
-    secret: Schema.Boolean,
-    type: Schema.Literal("exact_data"),
-    updatedAt: Schema.String,
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      caseSensitive: "case_sensitive",
-      createdAt: "created_at",
-      enabled: "enabled",
-      name: "name",
-      secret: "secret",
-      type: "type",
-      updatedAt: "updated_at",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    createdAt: Schema.String,
-    enabled: Schema.Boolean,
-    name: Schema.String,
-    type: Schema.Literal("document_fingerprint"),
-    updatedAt: Schema.String,
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      createdAt: "created_at",
-      enabled: "enabled",
-      name: "name",
-      type: "type",
-      updatedAt: "updated_at",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    createdAt: Schema.String,
-    enabled: Schema.Boolean,
-    name: Schema.String,
-    type: Schema.Literal("word_list"),
-    updatedAt: Schema.String,
-    wordList: Schema.Unknown,
-    profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      createdAt: "created_at",
-      enabled: "enabled",
-      name: "name",
-      type: "type",
-      updatedAt: "updated_at",
-      wordList: "word_list",
-      profileId: "profile_id",
     }),
   ),
 ]).pipe(
@@ -69370,6 +69370,53 @@ export const GetDlpEntryCustomResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
       id: Schema.String,
+      caseSensitive: Schema.Boolean,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      secret: Schema.Boolean,
+      type: Schema.Literal("exact_data"),
+      updatedAt: Schema.String,
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        caseSensitive: "case_sensitive",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        secret: "secret",
+        type: "type",
+        updatedAt: "updated_at",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
       createdAt: Schema.String,
       enabled: Schema.Boolean,
       name: Schema.String,
@@ -69416,6 +69463,141 @@ export const GetDlpEntryCustomResponse =
         type: "type",
         updatedAt: "updated_at",
         profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("word_list"),
+      updatedAt: Schema.String,
+      wordList: Schema.Unknown,
+      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        wordList: "word_list",
+        profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("integration"),
+      updatedAt: Schema.String,
+      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("document_fingerprint"),
+      updatedAt: Schema.String,
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
         profiles: "profiles",
         uploadStatus: "upload_status",
       }),
@@ -69488,188 +69670,6 @@ export const GetDlpEntryCustomResponse =
         profiles: "profiles",
         uploadStatus: "upload_status",
         variant: "variant",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("integration"),
-      updatedAt: Schema.String,
-      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        profileId: "profile_id",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      caseSensitive: Schema.Boolean,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      secret: Schema.Boolean,
-      type: Schema.Literal("exact_data"),
-      updatedAt: Schema.String,
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        caseSensitive: "case_sensitive",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        secret: "secret",
-        type: "type",
-        updatedAt: "updated_at",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("document_fingerprint"),
-      updatedAt: Schema.String,
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("word_list"),
-      updatedAt: Schema.String,
-      wordList: Schema.Unknown,
-      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        wordList: "word_list",
-        profileId: "profile_id",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
       }),
     ),
   ]).pipe(
@@ -69819,6 +69819,41 @@ export const ListDlpEntryCustomsResponse =
       Schema.Union([
         Schema.Struct({
           id: Schema.String,
+          caseSensitive: Schema.Boolean,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          secret: Schema.Boolean,
+          type: Schema.Literal("exact_data"),
+          updatedAt: Schema.String,
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            caseSensitive: "case_sensitive",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            secret: "secret",
+            type: "type",
+            updatedAt: "updated_at",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
           createdAt: Schema.String,
           enabled: Schema.Boolean,
           name: Schema.String,
@@ -69856,6 +69891,109 @@ export const ListDlpEntryCustomsResponse =
             type: "type",
             updatedAt: "updated_at",
             profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("word_list"),
+          updatedAt: Schema.String,
+          wordList: Schema.Unknown,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            wordList: "word_list",
+            profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("document_fingerprint"),
+          updatedAt: Schema.String,
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
             uploadStatus: "upload_status",
           }),
         ),
@@ -69917,144 +70055,6 @@ export const ListDlpEntryCustomsResponse =
             profileId: "profile_id",
             uploadStatus: "upload_status",
             variant: "variant",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          caseSensitive: Schema.Boolean,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          secret: Schema.Boolean,
-          type: Schema.Literal("exact_data"),
-          updatedAt: Schema.String,
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            caseSensitive: "case_sensitive",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            secret: "secret",
-            type: "type",
-            updatedAt: "updated_at",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("document_fingerprint"),
-          updatedAt: Schema.String,
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("word_list"),
-          updatedAt: Schema.String,
-          wordList: Schema.Unknown,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            wordList: "word_list",
-            profileId: "profile_id",
-            uploadStatus: "upload_status",
           }),
         ),
       ]),
@@ -70422,6 +70422,53 @@ export const GetDlpEntryIntegrationResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
       id: Schema.String,
+      caseSensitive: Schema.Boolean,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      secret: Schema.Boolean,
+      type: Schema.Literal("exact_data"),
+      updatedAt: Schema.String,
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        caseSensitive: "case_sensitive",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        secret: "secret",
+        type: "type",
+        updatedAt: "updated_at",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
       createdAt: Schema.String,
       enabled: Schema.Boolean,
       name: Schema.String,
@@ -70468,6 +70515,141 @@ export const GetDlpEntryIntegrationResponse =
         type: "type",
         updatedAt: "updated_at",
         profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("word_list"),
+      updatedAt: Schema.String,
+      wordList: Schema.Unknown,
+      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        wordList: "word_list",
+        profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("integration"),
+      updatedAt: Schema.String,
+      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("document_fingerprint"),
+      updatedAt: Schema.String,
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
         profiles: "profiles",
         uploadStatus: "upload_status",
       }),
@@ -70540,188 +70722,6 @@ export const GetDlpEntryIntegrationResponse =
         profiles: "profiles",
         uploadStatus: "upload_status",
         variant: "variant",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("integration"),
-      updatedAt: Schema.String,
-      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        profileId: "profile_id",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      caseSensitive: Schema.Boolean,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      secret: Schema.Boolean,
-      type: Schema.Literal("exact_data"),
-      updatedAt: Schema.String,
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        caseSensitive: "case_sensitive",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        secret: "secret",
-        type: "type",
-        updatedAt: "updated_at",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("document_fingerprint"),
-      updatedAt: Schema.String,
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("word_list"),
-      updatedAt: Schema.String,
-      wordList: Schema.Unknown,
-      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        wordList: "word_list",
-        profileId: "profile_id",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
       }),
     ),
   ]).pipe(
@@ -70871,6 +70871,41 @@ export const ListDlpEntryIntegrationsResponse =
       Schema.Union([
         Schema.Struct({
           id: Schema.String,
+          caseSensitive: Schema.Boolean,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          secret: Schema.Boolean,
+          type: Schema.Literal("exact_data"),
+          updatedAt: Schema.String,
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            caseSensitive: "case_sensitive",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            secret: "secret",
+            type: "type",
+            updatedAt: "updated_at",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
           createdAt: Schema.String,
           enabled: Schema.Boolean,
           name: Schema.String,
@@ -70908,6 +70943,109 @@ export const ListDlpEntryIntegrationsResponse =
             type: "type",
             updatedAt: "updated_at",
             profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("word_list"),
+          updatedAt: Schema.String,
+          wordList: Schema.Unknown,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            wordList: "word_list",
+            profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("document_fingerprint"),
+          updatedAt: Schema.String,
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
             uploadStatus: "upload_status",
           }),
         ),
@@ -70969,144 +71107,6 @@ export const ListDlpEntryIntegrationsResponse =
             profileId: "profile_id",
             uploadStatus: "upload_status",
             variant: "variant",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          caseSensitive: Schema.Boolean,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          secret: Schema.Boolean,
-          type: Schema.Literal("exact_data"),
-          updatedAt: Schema.String,
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            caseSensitive: "case_sensitive",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            secret: "secret",
-            type: "type",
-            updatedAt: "updated_at",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("document_fingerprint"),
-          updatedAt: Schema.String,
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("word_list"),
-          updatedAt: Schema.String,
-          wordList: Schema.Unknown,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            wordList: "word_list",
-            profileId: "profile_id",
-            uploadStatus: "upload_status",
           }),
         ),
       ]),
@@ -71445,6 +71445,53 @@ export const GetDlpEntryPredefinedResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     Schema.Struct({
       id: Schema.String,
+      caseSensitive: Schema.Boolean,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      secret: Schema.Boolean,
+      type: Schema.Literal("exact_data"),
+      updatedAt: Schema.String,
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        caseSensitive: "case_sensitive",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        secret: "secret",
+        type: "type",
+        updatedAt: "updated_at",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
       createdAt: Schema.String,
       enabled: Schema.Boolean,
       name: Schema.String,
@@ -71491,6 +71538,141 @@ export const GetDlpEntryPredefinedResponse =
         type: "type",
         updatedAt: "updated_at",
         profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("word_list"),
+      updatedAt: Schema.String,
+      wordList: Schema.Unknown,
+      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        wordList: "word_list",
+        profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("integration"),
+      updatedAt: Schema.String,
+      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        profileId: "profile_id",
+        profiles: "profiles",
+        uploadStatus: "upload_status",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      createdAt: Schema.String,
+      enabled: Schema.Boolean,
+      name: Schema.String,
+      type: Schema.Literal("document_fingerprint"),
+      updatedAt: Schema.String,
+      profiles: Schema.optional(
+        Schema.Union([
+          Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              name: Schema.String,
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
+      uploadStatus: Schema.optional(
+        Schema.Union([
+          Schema.Literals([
+            "empty",
+            "uploading",
+            "pending",
+            "processing",
+            "failed",
+            "complete",
+          ]),
+          Schema.Null,
+        ]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        enabled: "enabled",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
         profiles: "profiles",
         uploadStatus: "upload_status",
       }),
@@ -71563,188 +71745,6 @@ export const GetDlpEntryPredefinedResponse =
         profiles: "profiles",
         uploadStatus: "upload_status",
         variant: "variant",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("integration"),
-      updatedAt: Schema.String,
-      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        profileId: "profile_id",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      caseSensitive: Schema.Boolean,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      secret: Schema.Boolean,
-      type: Schema.Literal("exact_data"),
-      updatedAt: Schema.String,
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        caseSensitive: "case_sensitive",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        secret: "secret",
-        type: "type",
-        updatedAt: "updated_at",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("document_fingerprint"),
-      updatedAt: Schema.String,
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      enabled: Schema.Boolean,
-      name: Schema.String,
-      type: Schema.Literal("word_list"),
-      updatedAt: Schema.String,
-      wordList: Schema.Unknown,
-      profileId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      profiles: Schema.optional(
-        Schema.Union([
-          Schema.Array(
-            Schema.Struct({
-              id: Schema.String,
-              name: Schema.String,
-            }),
-          ),
-          Schema.Null,
-        ]),
-      ),
-      uploadStatus: Schema.optional(
-        Schema.Union([
-          Schema.Literals([
-            "empty",
-            "uploading",
-            "pending",
-            "processing",
-            "failed",
-            "complete",
-          ]),
-          Schema.Null,
-        ]),
-      ),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        enabled: "enabled",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        wordList: "word_list",
-        profileId: "profile_id",
-        profiles: "profiles",
-        uploadStatus: "upload_status",
       }),
     ),
   ]).pipe(
@@ -71894,6 +71894,41 @@ export const ListDlpEntryPredefinedsResponse =
       Schema.Union([
         Schema.Struct({
           id: Schema.String,
+          caseSensitive: Schema.Boolean,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          secret: Schema.Boolean,
+          type: Schema.Literal("exact_data"),
+          updatedAt: Schema.String,
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            caseSensitive: "case_sensitive",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            secret: "secret",
+            type: "type",
+            updatedAt: "updated_at",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
           createdAt: Schema.String,
           enabled: Schema.Boolean,
           name: Schema.String,
@@ -71931,6 +71966,109 @@ export const ListDlpEntryPredefinedsResponse =
             type: "type",
             updatedAt: "updated_at",
             profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("word_list"),
+          updatedAt: Schema.String,
+          wordList: Schema.Unknown,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            wordList: "word_list",
+            profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            profileId: "profile_id",
+            uploadStatus: "upload_status",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("document_fingerprint"),
+          updatedAt: Schema.String,
+          uploadStatus: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "empty",
+                "uploading",
+                "pending",
+                "processing",
+                "failed",
+                "complete",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
             uploadStatus: "upload_status",
           }),
         ),
@@ -71992,144 +72130,6 @@ export const ListDlpEntryPredefinedsResponse =
             profileId: "profile_id",
             uploadStatus: "upload_status",
             variant: "variant",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          caseSensitive: Schema.Boolean,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          secret: Schema.Boolean,
-          type: Schema.Literal("exact_data"),
-          updatedAt: Schema.String,
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            caseSensitive: "case_sensitive",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            secret: "secret",
-            type: "type",
-            updatedAt: "updated_at",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("document_fingerprint"),
-          updatedAt: Schema.String,
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            uploadStatus: "upload_status",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("word_list"),
-          updatedAt: Schema.String,
-          wordList: Schema.Unknown,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          uploadStatus: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "empty",
-                "uploading",
-                "pending",
-                "processing",
-                "failed",
-                "complete",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            wordList: "word_list",
-            profileId: "profile_id",
-            uploadStatus: "upload_status",
           }),
         ),
       ]),
@@ -72843,6 +72843,27 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
           Schema.Union([
             Schema.Struct({
               id: Schema.String,
+              caseSensitive: Schema.Boolean,
+              createdAt: Schema.String,
+              enabled: Schema.Boolean,
+              name: Schema.String,
+              secret: Schema.Boolean,
+              type: Schema.Literal("exact_data"),
+              updatedAt: Schema.String,
+            }).pipe(
+              Schema.encodeKeys({
+                id: "id",
+                caseSensitive: "case_sensitive",
+                createdAt: "created_at",
+                enabled: "enabled",
+                name: "name",
+                secret: "secret",
+                type: "type",
+                updatedAt: "updated_at",
+              }),
+            ),
+            Schema.Struct({
+              id: Schema.String,
               createdAt: Schema.String,
               enabled: Schema.Boolean,
               name: Schema.String,
@@ -72867,6 +72888,67 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
                 type: "type",
                 updatedAt: "updated_at",
                 profileId: "profile_id",
+              }),
+            ),
+            Schema.Struct({
+              id: Schema.String,
+              createdAt: Schema.String,
+              enabled: Schema.Boolean,
+              name: Schema.String,
+              type: Schema.Literal("word_list"),
+              updatedAt: Schema.String,
+              wordList: Schema.Unknown,
+              profileId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                id: "id",
+                createdAt: "created_at",
+                enabled: "enabled",
+                name: "name",
+                type: "type",
+                updatedAt: "updated_at",
+                wordList: "word_list",
+                profileId: "profile_id",
+              }),
+            ),
+            Schema.Struct({
+              id: Schema.String,
+              createdAt: Schema.String,
+              enabled: Schema.Boolean,
+              name: Schema.String,
+              type: Schema.Literal("integration"),
+              updatedAt: Schema.String,
+              profileId: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                id: "id",
+                createdAt: "created_at",
+                enabled: "enabled",
+                name: "name",
+                type: "type",
+                updatedAt: "updated_at",
+                profileId: "profile_id",
+              }),
+            ),
+            Schema.Struct({
+              id: Schema.String,
+              createdAt: Schema.String,
+              enabled: Schema.Boolean,
+              name: Schema.String,
+              type: Schema.Literal("document_fingerprint"),
+              updatedAt: Schema.String,
+            }).pipe(
+              Schema.encodeKeys({
+                id: "id",
+                createdAt: "created_at",
+                enabled: "enabled",
+                name: "name",
+                type: "type",
+                updatedAt: "updated_at",
               }),
             ),
             Schema.Struct({
@@ -72915,88 +72997,6 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
                 variant: "variant",
               }),
             ),
-            Schema.Struct({
-              id: Schema.String,
-              createdAt: Schema.String,
-              enabled: Schema.Boolean,
-              name: Schema.String,
-              type: Schema.Literal("integration"),
-              updatedAt: Schema.String,
-              profileId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                createdAt: "created_at",
-                enabled: "enabled",
-                name: "name",
-                type: "type",
-                updatedAt: "updated_at",
-                profileId: "profile_id",
-              }),
-            ),
-            Schema.Struct({
-              id: Schema.String,
-              caseSensitive: Schema.Boolean,
-              createdAt: Schema.String,
-              enabled: Schema.Boolean,
-              name: Schema.String,
-              secret: Schema.Boolean,
-              type: Schema.Literal("exact_data"),
-              updatedAt: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                caseSensitive: "case_sensitive",
-                createdAt: "created_at",
-                enabled: "enabled",
-                name: "name",
-                secret: "secret",
-                type: "type",
-                updatedAt: "updated_at",
-              }),
-            ),
-            Schema.Struct({
-              id: Schema.String,
-              createdAt: Schema.String,
-              enabled: Schema.Boolean,
-              name: Schema.String,
-              type: Schema.Literal("document_fingerprint"),
-              updatedAt: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                createdAt: "created_at",
-                enabled: "enabled",
-                name: "name",
-                type: "type",
-                updatedAt: "updated_at",
-              }),
-            ),
-            Schema.Struct({
-              id: Schema.String,
-              createdAt: Schema.String,
-              enabled: Schema.Boolean,
-              name: Schema.String,
-              type: Schema.Literal("word_list"),
-              updatedAt: Schema.String,
-              wordList: Schema.Unknown,
-              profileId: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                createdAt: "created_at",
-                enabled: "enabled",
-                name: "name",
-                type: "type",
-                updatedAt: "updated_at",
-                wordList: "word_list",
-                profileId: "profile_id",
-              }),
-            ),
           ]),
         ),
         Schema.Null,
@@ -73020,9 +73020,30 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
   ),
   Schema.Struct({
     id: Schema.String,
-    allowedMatchCount: Schema.Number,
+    createdAt: Schema.String,
     entries: Schema.Array(
       Schema.Union([
+        Schema.Struct({
+          id: Schema.String,
+          caseSensitive: Schema.Boolean,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          secret: Schema.Boolean,
+          type: Schema.Literal("exact_data"),
+          updatedAt: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            caseSensitive: "case_sensitive",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            secret: "secret",
+            type: "type",
+            updatedAt: "updated_at",
+          }),
+        ),
         Schema.Struct({
           id: Schema.String,
           createdAt: Schema.String,
@@ -73049,6 +73070,67 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
             type: "type",
             updatedAt: "updated_at",
             profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("word_list"),
+          updatedAt: Schema.String,
+          wordList: Schema.Unknown,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            wordList: "word_list",
+            profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("document_fingerprint"),
+          updatedAt: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
           }),
         ),
         Schema.Struct({
@@ -73097,27 +73179,28 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
             variant: "variant",
           }),
         ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-          }),
-        ),
+      ]),
+    ),
+    name: Schema.String,
+    type: Schema.Literal("integration"),
+    updatedAt: Schema.String,
+    description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      createdAt: "created_at",
+      entries: "entries",
+      name: "name",
+      type: "type",
+      updatedAt: "updated_at",
+      description: "description",
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.String,
+    allowedMatchCount: Schema.Number,
+    entries: Schema.Array(
+      Schema.Union([
         Schema.Struct({
           id: Schema.String,
           caseSensitive: Schema.Boolean,
@@ -73144,16 +73227,27 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
           createdAt: Schema.String,
           enabled: Schema.Boolean,
           name: Schema.String,
-          type: Schema.Literal("document_fingerprint"),
+          pattern: Schema.Struct({
+            regex: Schema.String,
+            validation: Schema.optional(
+              Schema.Union([Schema.Literal("luhn"), Schema.Null]),
+            ),
+          }),
+          type: Schema.Literal("custom"),
           updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
         }).pipe(
           Schema.encodeKeys({
             id: "id",
             createdAt: "created_at",
             enabled: "enabled",
             name: "name",
+            pattern: "pattern",
             type: "type",
             updatedAt: "updated_at",
+            profileId: "profile_id",
           }),
         ),
         Schema.Struct({
@@ -73177,6 +73271,90 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
             updatedAt: "updated_at",
             wordList: "word_list",
             profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("document_fingerprint"),
+          updatedAt: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          confidence: Schema.Struct({
+            aiContextAvailable: Schema.Boolean,
+            available: Schema.Boolean,
+          }).pipe(
+            Schema.encodeKeys({
+              aiContextAvailable: "ai_context_available",
+              available: "available",
+            }),
+          ),
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("predefined"),
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          variant: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                topicType: Schema.Literals(["Intent", "Content"]),
+                type: Schema.Literal("PromptTopic"),
+                description: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  topicType: "topic_type",
+                  type: "type",
+                  description: "description",
+                }),
+              ),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            confidence: "confidence",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            profileId: "profile_id",
+            variant: "variant",
           }),
         ),
       ]),
@@ -73217,184 +73395,6 @@ export const GetDlpProfileResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       contextAwareness: "context_awareness",
       ocrEnabled: "ocr_enabled",
       openAccess: "open_access",
-    }),
-  ),
-  Schema.Struct({
-    id: Schema.String,
-    createdAt: Schema.String,
-    entries: Schema.Array(
-      Schema.Union([
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          pattern: Schema.Struct({
-            regex: Schema.String,
-            validation: Schema.optional(
-              Schema.Union([Schema.Literal("luhn"), Schema.Null]),
-            ),
-          }),
-          type: Schema.Literal("custom"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            pattern: "pattern",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          confidence: Schema.Struct({
-            aiContextAvailable: Schema.Boolean,
-            available: Schema.Boolean,
-          }).pipe(
-            Schema.encodeKeys({
-              aiContextAvailable: "ai_context_available",
-              available: "available",
-            }),
-          ),
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("predefined"),
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          variant: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                topicType: Schema.Literals(["Intent", "Content"]),
-                type: Schema.Literal("PromptTopic"),
-                description: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  topicType: "topic_type",
-                  type: "type",
-                  description: "description",
-                }),
-              ),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            confidence: "confidence",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            profileId: "profile_id",
-            variant: "variant",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          caseSensitive: Schema.Boolean,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          secret: Schema.Boolean,
-          type: Schema.Literal("exact_data"),
-          updatedAt: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            caseSensitive: "case_sensitive",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            secret: "secret",
-            type: "type",
-            updatedAt: "updated_at",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("document_fingerprint"),
-          updatedAt: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("word_list"),
-          updatedAt: Schema.String,
-          wordList: Schema.Unknown,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            wordList: "word_list",
-            profileId: "profile_id",
-          }),
-        ),
-      ]),
-    ),
-    name: Schema.String,
-    type: Schema.Literal("integration"),
-    updatedAt: Schema.String,
-    description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      id: "id",
-      createdAt: "created_at",
-      entries: "entries",
-      name: "name",
-      type: "type",
-      updatedAt: "updated_at",
-      description: "description",
     }),
   ),
 ]).pipe(
@@ -73705,6 +73705,27 @@ export const ListDlpProfilesResponse =
                 Schema.Union([
                   Schema.Struct({
                     id: Schema.String,
+                    caseSensitive: Schema.Boolean,
+                    createdAt: Schema.String,
+                    enabled: Schema.Boolean,
+                    name: Schema.String,
+                    secret: Schema.Boolean,
+                    type: Schema.Literal("exact_data"),
+                    updatedAt: Schema.String,
+                  }).pipe(
+                    Schema.encodeKeys({
+                      id: "id",
+                      caseSensitive: "case_sensitive",
+                      createdAt: "created_at",
+                      enabled: "enabled",
+                      name: "name",
+                      secret: "secret",
+                      type: "type",
+                      updatedAt: "updated_at",
+                    }),
+                  ),
+                  Schema.Struct({
+                    id: Schema.String,
                     createdAt: Schema.String,
                     enabled: Schema.Boolean,
                     name: Schema.String,
@@ -73729,6 +73750,67 @@ export const ListDlpProfilesResponse =
                       type: "type",
                       updatedAt: "updated_at",
                       profileId: "profile_id",
+                    }),
+                  ),
+                  Schema.Struct({
+                    id: Schema.String,
+                    createdAt: Schema.String,
+                    enabled: Schema.Boolean,
+                    name: Schema.String,
+                    type: Schema.Literal("word_list"),
+                    updatedAt: Schema.String,
+                    wordList: Schema.Unknown,
+                    profileId: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      id: "id",
+                      createdAt: "created_at",
+                      enabled: "enabled",
+                      name: "name",
+                      type: "type",
+                      updatedAt: "updated_at",
+                      wordList: "word_list",
+                      profileId: "profile_id",
+                    }),
+                  ),
+                  Schema.Struct({
+                    id: Schema.String,
+                    createdAt: Schema.String,
+                    enabled: Schema.Boolean,
+                    name: Schema.String,
+                    type: Schema.Literal("integration"),
+                    updatedAt: Schema.String,
+                    profileId: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                  }).pipe(
+                    Schema.encodeKeys({
+                      id: "id",
+                      createdAt: "created_at",
+                      enabled: "enabled",
+                      name: "name",
+                      type: "type",
+                      updatedAt: "updated_at",
+                      profileId: "profile_id",
+                    }),
+                  ),
+                  Schema.Struct({
+                    id: Schema.String,
+                    createdAt: Schema.String,
+                    enabled: Schema.Boolean,
+                    name: Schema.String,
+                    type: Schema.Literal("document_fingerprint"),
+                    updatedAt: Schema.String,
+                  }).pipe(
+                    Schema.encodeKeys({
+                      id: "id",
+                      createdAt: "created_at",
+                      enabled: "enabled",
+                      name: "name",
+                      type: "type",
+                      updatedAt: "updated_at",
                     }),
                   ),
                   Schema.Struct({
@@ -73777,88 +73859,6 @@ export const ListDlpProfilesResponse =
                       variant: "variant",
                     }),
                   ),
-                  Schema.Struct({
-                    id: Schema.String,
-                    createdAt: Schema.String,
-                    enabled: Schema.Boolean,
-                    name: Schema.String,
-                    type: Schema.Literal("integration"),
-                    updatedAt: Schema.String,
-                    profileId: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      id: "id",
-                      createdAt: "created_at",
-                      enabled: "enabled",
-                      name: "name",
-                      type: "type",
-                      updatedAt: "updated_at",
-                      profileId: "profile_id",
-                    }),
-                  ),
-                  Schema.Struct({
-                    id: Schema.String,
-                    caseSensitive: Schema.Boolean,
-                    createdAt: Schema.String,
-                    enabled: Schema.Boolean,
-                    name: Schema.String,
-                    secret: Schema.Boolean,
-                    type: Schema.Literal("exact_data"),
-                    updatedAt: Schema.String,
-                  }).pipe(
-                    Schema.encodeKeys({
-                      id: "id",
-                      caseSensitive: "case_sensitive",
-                      createdAt: "created_at",
-                      enabled: "enabled",
-                      name: "name",
-                      secret: "secret",
-                      type: "type",
-                      updatedAt: "updated_at",
-                    }),
-                  ),
-                  Schema.Struct({
-                    id: Schema.String,
-                    createdAt: Schema.String,
-                    enabled: Schema.Boolean,
-                    name: Schema.String,
-                    type: Schema.Literal("document_fingerprint"),
-                    updatedAt: Schema.String,
-                  }).pipe(
-                    Schema.encodeKeys({
-                      id: "id",
-                      createdAt: "created_at",
-                      enabled: "enabled",
-                      name: "name",
-                      type: "type",
-                      updatedAt: "updated_at",
-                    }),
-                  ),
-                  Schema.Struct({
-                    id: Schema.String,
-                    createdAt: Schema.String,
-                    enabled: Schema.Boolean,
-                    name: Schema.String,
-                    type: Schema.Literal("word_list"),
-                    updatedAt: Schema.String,
-                    wordList: Schema.Unknown,
-                    profileId: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }).pipe(
-                    Schema.encodeKeys({
-                      id: "id",
-                      createdAt: "created_at",
-                      enabled: "enabled",
-                      name: "name",
-                      type: "type",
-                      updatedAt: "updated_at",
-                      wordList: "word_list",
-                      profileId: "profile_id",
-                    }),
-                  ),
                 ]),
               ),
               Schema.Null,
@@ -73882,9 +73882,30 @@ export const ListDlpProfilesResponse =
         ),
         Schema.Struct({
           id: Schema.String,
-          allowedMatchCount: Schema.Number,
+          createdAt: Schema.String,
           entries: Schema.Array(
             Schema.Union([
+              Schema.Struct({
+                id: Schema.String,
+                caseSensitive: Schema.Boolean,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                secret: Schema.Boolean,
+                type: Schema.Literal("exact_data"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  caseSensitive: "case_sensitive",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  secret: "secret",
+                  type: "type",
+                  updatedAt: "updated_at",
+                }),
+              ),
               Schema.Struct({
                 id: Schema.String,
                 createdAt: Schema.String,
@@ -73911,6 +73932,67 @@ export const ListDlpProfilesResponse =
                   type: "type",
                   updatedAt: "updated_at",
                   profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("word_list"),
+                updatedAt: Schema.String,
+                wordList: Schema.Unknown,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  wordList: "word_list",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("integration"),
+                updatedAt: Schema.String,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("document_fingerprint"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
                 }),
               ),
               Schema.Struct({
@@ -73959,27 +74041,30 @@ export const ListDlpProfilesResponse =
                   variant: "variant",
                 }),
               ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("integration"),
-                updatedAt: Schema.String,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  profileId: "profile_id",
-                }),
-              ),
+            ]),
+          ),
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          description: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            entries: "entries",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            description: "description",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          allowedMatchCount: Schema.Number,
+          entries: Schema.Array(
+            Schema.Union([
               Schema.Struct({
                 id: Schema.String,
                 caseSensitive: Schema.Boolean,
@@ -74006,16 +74091,27 @@ export const ListDlpProfilesResponse =
                 createdAt: Schema.String,
                 enabled: Schema.Boolean,
                 name: Schema.String,
-                type: Schema.Literal("document_fingerprint"),
+                pattern: Schema.Struct({
+                  regex: Schema.String,
+                  validation: Schema.optional(
+                    Schema.Union([Schema.Literal("luhn"), Schema.Null]),
+                  ),
+                }),
+                type: Schema.Literal("custom"),
                 updatedAt: Schema.String,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
               }).pipe(
                 Schema.encodeKeys({
                   id: "id",
                   createdAt: "created_at",
                   enabled: "enabled",
                   name: "name",
+                  pattern: "pattern",
                   type: "type",
                   updatedAt: "updated_at",
+                  profileId: "profile_id",
                 }),
               ),
               Schema.Struct({
@@ -74039,6 +74135,90 @@ export const ListDlpProfilesResponse =
                   updatedAt: "updated_at",
                   wordList: "word_list",
                   profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("integration"),
+                updatedAt: Schema.String,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("document_fingerprint"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                confidence: Schema.Struct({
+                  aiContextAvailable: Schema.Boolean,
+                  available: Schema.Boolean,
+                }).pipe(
+                  Schema.encodeKeys({
+                    aiContextAvailable: "ai_context_available",
+                    available: "available",
+                  }),
+                ),
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("predefined"),
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                variant: Schema.optional(
+                  Schema.Union([
+                    Schema.Struct({
+                      topicType: Schema.Literals(["Intent", "Content"]),
+                      type: Schema.Literal("PromptTopic"),
+                      description: Schema.optional(
+                        Schema.Union([Schema.String, Schema.Null]),
+                      ),
+                    }).pipe(
+                      Schema.encodeKeys({
+                        topicType: "topic_type",
+                        type: "type",
+                        description: "description",
+                      }),
+                    ),
+                    Schema.Null,
+                  ]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  confidence: "confidence",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  profileId: "profile_id",
+                  variant: "variant",
                 }),
               ),
             ]),
@@ -74083,186 +74263,6 @@ export const ListDlpProfilesResponse =
             contextAwareness: "context_awareness",
             ocrEnabled: "ocr_enabled",
             openAccess: "open_access",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          entries: Schema.Array(
-            Schema.Union([
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                pattern: Schema.Struct({
-                  regex: Schema.String,
-                  validation: Schema.optional(
-                    Schema.Union([Schema.Literal("luhn"), Schema.Null]),
-                  ),
-                }),
-                type: Schema.Literal("custom"),
-                updatedAt: Schema.String,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  pattern: "pattern",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  profileId: "profile_id",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                confidence: Schema.Struct({
-                  aiContextAvailable: Schema.Boolean,
-                  available: Schema.Boolean,
-                }).pipe(
-                  Schema.encodeKeys({
-                    aiContextAvailable: "ai_context_available",
-                    available: "available",
-                  }),
-                ),
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("predefined"),
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                variant: Schema.optional(
-                  Schema.Union([
-                    Schema.Struct({
-                      topicType: Schema.Literals(["Intent", "Content"]),
-                      type: Schema.Literal("PromptTopic"),
-                      description: Schema.optional(
-                        Schema.Union([Schema.String, Schema.Null]),
-                      ),
-                    }).pipe(
-                      Schema.encodeKeys({
-                        topicType: "topic_type",
-                        type: "type",
-                        description: "description",
-                      }),
-                    ),
-                    Schema.Null,
-                  ]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  confidence: "confidence",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  profileId: "profile_id",
-                  variant: "variant",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("integration"),
-                updatedAt: Schema.String,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  profileId: "profile_id",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                caseSensitive: Schema.Boolean,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                secret: Schema.Boolean,
-                type: Schema.Literal("exact_data"),
-                updatedAt: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  caseSensitive: "case_sensitive",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  secret: "secret",
-                  type: "type",
-                  updatedAt: "updated_at",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("document_fingerprint"),
-                updatedAt: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("word_list"),
-                updatedAt: Schema.String,
-                wordList: Schema.Unknown,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  wordList: "word_list",
-                  profileId: "profile_id",
-                }),
-              ),
-            ]),
-          ),
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          description: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            entries: "entries",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            description: "description",
           }),
         ),
       ]),
@@ -74565,6 +74565,27 @@ export const GetDlpProfileCustomResponse =
             Schema.Union([
               Schema.Struct({
                 id: Schema.String,
+                caseSensitive: Schema.Boolean,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                secret: Schema.Boolean,
+                type: Schema.Literal("exact_data"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  caseSensitive: "case_sensitive",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  secret: "secret",
+                  type: "type",
+                  updatedAt: "updated_at",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
                 createdAt: Schema.String,
                 enabled: Schema.Boolean,
                 name: Schema.String,
@@ -74589,6 +74610,67 @@ export const GetDlpProfileCustomResponse =
                   type: "type",
                   updatedAt: "updated_at",
                   profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("word_list"),
+                updatedAt: Schema.String,
+                wordList: Schema.Unknown,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  wordList: "word_list",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("integration"),
+                updatedAt: Schema.String,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("document_fingerprint"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
                 }),
               ),
               Schema.Struct({
@@ -74637,88 +74719,6 @@ export const GetDlpProfileCustomResponse =
                   variant: "variant",
                 }),
               ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("integration"),
-                updatedAt: Schema.String,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  profileId: "profile_id",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                caseSensitive: Schema.Boolean,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                secret: Schema.Boolean,
-                type: Schema.Literal("exact_data"),
-                updatedAt: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  caseSensitive: "case_sensitive",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  secret: "secret",
-                  type: "type",
-                  updatedAt: "updated_at",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("document_fingerprint"),
-                updatedAt: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("word_list"),
-                updatedAt: Schema.String,
-                wordList: Schema.Unknown,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  wordList: "word_list",
-                  profileId: "profile_id",
-                }),
-              ),
             ]),
           ),
           Schema.Null,
@@ -74742,9 +74742,30 @@ export const GetDlpProfileCustomResponse =
     ),
     Schema.Struct({
       id: Schema.String,
-      allowedMatchCount: Schema.Number,
+      createdAt: Schema.String,
       entries: Schema.Array(
         Schema.Union([
+          Schema.Struct({
+            id: Schema.String,
+            caseSensitive: Schema.Boolean,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            secret: Schema.Boolean,
+            type: Schema.Literal("exact_data"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              caseSensitive: "case_sensitive",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              secret: "secret",
+              type: "type",
+              updatedAt: "updated_at",
+            }),
+          ),
           Schema.Struct({
             id: Schema.String,
             createdAt: Schema.String,
@@ -74771,6 +74792,67 @@ export const GetDlpProfileCustomResponse =
               type: "type",
               updatedAt: "updated_at",
               profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("word_list"),
+            updatedAt: Schema.String,
+            wordList: Schema.Unknown,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              wordList: "word_list",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("integration"),
+            updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("document_fingerprint"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
             }),
           ),
           Schema.Struct({
@@ -74819,27 +74901,28 @@ export const GetDlpProfileCustomResponse =
               variant: "variant",
             }),
           ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("integration"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
+        ]),
+      ),
+      name: Schema.String,
+      type: Schema.Literal("integration"),
+      updatedAt: Schema.String,
+      description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        entries: "entries",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        description: "description",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      allowedMatchCount: Schema.Number,
+      entries: Schema.Array(
+        Schema.Union([
           Schema.Struct({
             id: Schema.String,
             caseSensitive: Schema.Boolean,
@@ -74866,16 +74949,27 @@ export const GetDlpProfileCustomResponse =
             createdAt: Schema.String,
             enabled: Schema.Boolean,
             name: Schema.String,
-            type: Schema.Literal("document_fingerprint"),
+            pattern: Schema.Struct({
+              regex: Schema.String,
+              validation: Schema.optional(
+                Schema.Union([Schema.Literal("luhn"), Schema.Null]),
+              ),
+            }),
+            type: Schema.Literal("custom"),
             updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
           }).pipe(
             Schema.encodeKeys({
               id: "id",
               createdAt: "created_at",
               enabled: "enabled",
               name: "name",
+              pattern: "pattern",
               type: "type",
               updatedAt: "updated_at",
+              profileId: "profile_id",
             }),
           ),
           Schema.Struct({
@@ -74899,6 +74993,90 @@ export const GetDlpProfileCustomResponse =
               updatedAt: "updated_at",
               wordList: "word_list",
               profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("integration"),
+            updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("document_fingerprint"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            confidence: Schema.Struct({
+              aiContextAvailable: Schema.Boolean,
+              available: Schema.Boolean,
+            }).pipe(
+              Schema.encodeKeys({
+                aiContextAvailable: "ai_context_available",
+                available: "available",
+              }),
+            ),
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("predefined"),
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            variant: Schema.optional(
+              Schema.Union([
+                Schema.Struct({
+                  topicType: Schema.Literals(["Intent", "Content"]),
+                  type: Schema.Literal("PromptTopic"),
+                  description: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    topicType: "topic_type",
+                    type: "type",
+                    description: "description",
+                  }),
+                ),
+                Schema.Null,
+              ]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              confidence: "confidence",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              profileId: "profile_id",
+              variant: "variant",
             }),
           ),
         ]),
@@ -74939,184 +75117,6 @@ export const GetDlpProfileCustomResponse =
         contextAwareness: "context_awareness",
         ocrEnabled: "ocr_enabled",
         openAccess: "open_access",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      entries: Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            pattern: Schema.Struct({
-              regex: Schema.String,
-              validation: Schema.optional(
-                Schema.Union([Schema.Literal("luhn"), Schema.Null]),
-              ),
-            }),
-            type: Schema.Literal("custom"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              pattern: "pattern",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            confidence: Schema.Struct({
-              aiContextAvailable: Schema.Boolean,
-              available: Schema.Boolean,
-            }).pipe(
-              Schema.encodeKeys({
-                aiContextAvailable: "ai_context_available",
-                available: "available",
-              }),
-            ),
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("predefined"),
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            variant: Schema.optional(
-              Schema.Union([
-                Schema.Struct({
-                  topicType: Schema.Literals(["Intent", "Content"]),
-                  type: Schema.Literal("PromptTopic"),
-                  description: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    topicType: "topic_type",
-                    type: "type",
-                    description: "description",
-                  }),
-                ),
-                Schema.Null,
-              ]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              confidence: "confidence",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              profileId: "profile_id",
-              variant: "variant",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("integration"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            caseSensitive: Schema.Boolean,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            secret: Schema.Boolean,
-            type: Schema.Literal("exact_data"),
-            updatedAt: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              caseSensitive: "case_sensitive",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              secret: "secret",
-              type: "type",
-              updatedAt: "updated_at",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("document_fingerprint"),
-            updatedAt: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("word_list"),
-            updatedAt: Schema.String,
-            wordList: Schema.Unknown,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              wordList: "word_list",
-              profileId: "profile_id",
-            }),
-          ),
-        ]),
-      ),
-      name: Schema.String,
-      type: Schema.Literal("integration"),
-      updatedAt: Schema.String,
-      description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        entries: "entries",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        description: "description",
       }),
     ),
   ]).pipe(
@@ -75489,6 +75489,27 @@ export const CreateDlpProfileCustomResponse =
             Schema.Union([
               Schema.Struct({
                 id: Schema.String,
+                caseSensitive: Schema.Boolean,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                secret: Schema.Boolean,
+                type: Schema.Literal("exact_data"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  caseSensitive: "case_sensitive",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  secret: "secret",
+                  type: "type",
+                  updatedAt: "updated_at",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
                 createdAt: Schema.String,
                 enabled: Schema.Boolean,
                 name: Schema.String,
@@ -75513,6 +75534,67 @@ export const CreateDlpProfileCustomResponse =
                   type: "type",
                   updatedAt: "updated_at",
                   profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("word_list"),
+                updatedAt: Schema.String,
+                wordList: Schema.Unknown,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  wordList: "word_list",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("integration"),
+                updatedAt: Schema.String,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("document_fingerprint"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
                 }),
               ),
               Schema.Struct({
@@ -75561,88 +75643,6 @@ export const CreateDlpProfileCustomResponse =
                   variant: "variant",
                 }),
               ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("integration"),
-                updatedAt: Schema.String,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  profileId: "profile_id",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                caseSensitive: Schema.Boolean,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                secret: Schema.Boolean,
-                type: Schema.Literal("exact_data"),
-                updatedAt: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  caseSensitive: "case_sensitive",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  secret: "secret",
-                  type: "type",
-                  updatedAt: "updated_at",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("document_fingerprint"),
-                updatedAt: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("word_list"),
-                updatedAt: Schema.String,
-                wordList: Schema.Unknown,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  wordList: "word_list",
-                  profileId: "profile_id",
-                }),
-              ),
             ]),
           ),
           Schema.Null,
@@ -75666,9 +75666,30 @@ export const CreateDlpProfileCustomResponse =
     ),
     Schema.Struct({
       id: Schema.String,
-      allowedMatchCount: Schema.Number,
+      createdAt: Schema.String,
       entries: Schema.Array(
         Schema.Union([
+          Schema.Struct({
+            id: Schema.String,
+            caseSensitive: Schema.Boolean,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            secret: Schema.Boolean,
+            type: Schema.Literal("exact_data"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              caseSensitive: "case_sensitive",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              secret: "secret",
+              type: "type",
+              updatedAt: "updated_at",
+            }),
+          ),
           Schema.Struct({
             id: Schema.String,
             createdAt: Schema.String,
@@ -75695,6 +75716,67 @@ export const CreateDlpProfileCustomResponse =
               type: "type",
               updatedAt: "updated_at",
               profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("word_list"),
+            updatedAt: Schema.String,
+            wordList: Schema.Unknown,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              wordList: "word_list",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("integration"),
+            updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("document_fingerprint"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
             }),
           ),
           Schema.Struct({
@@ -75743,27 +75825,28 @@ export const CreateDlpProfileCustomResponse =
               variant: "variant",
             }),
           ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("integration"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
+        ]),
+      ),
+      name: Schema.String,
+      type: Schema.Literal("integration"),
+      updatedAt: Schema.String,
+      description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        entries: "entries",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        description: "description",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      allowedMatchCount: Schema.Number,
+      entries: Schema.Array(
+        Schema.Union([
           Schema.Struct({
             id: Schema.String,
             caseSensitive: Schema.Boolean,
@@ -75790,16 +75873,27 @@ export const CreateDlpProfileCustomResponse =
             createdAt: Schema.String,
             enabled: Schema.Boolean,
             name: Schema.String,
-            type: Schema.Literal("document_fingerprint"),
+            pattern: Schema.Struct({
+              regex: Schema.String,
+              validation: Schema.optional(
+                Schema.Union([Schema.Literal("luhn"), Schema.Null]),
+              ),
+            }),
+            type: Schema.Literal("custom"),
             updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
           }).pipe(
             Schema.encodeKeys({
               id: "id",
               createdAt: "created_at",
               enabled: "enabled",
               name: "name",
+              pattern: "pattern",
               type: "type",
               updatedAt: "updated_at",
+              profileId: "profile_id",
             }),
           ),
           Schema.Struct({
@@ -75823,6 +75917,90 @@ export const CreateDlpProfileCustomResponse =
               updatedAt: "updated_at",
               wordList: "word_list",
               profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("integration"),
+            updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("document_fingerprint"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            confidence: Schema.Struct({
+              aiContextAvailable: Schema.Boolean,
+              available: Schema.Boolean,
+            }).pipe(
+              Schema.encodeKeys({
+                aiContextAvailable: "ai_context_available",
+                available: "available",
+              }),
+            ),
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("predefined"),
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            variant: Schema.optional(
+              Schema.Union([
+                Schema.Struct({
+                  topicType: Schema.Literals(["Intent", "Content"]),
+                  type: Schema.Literal("PromptTopic"),
+                  description: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    topicType: "topic_type",
+                    type: "type",
+                    description: "description",
+                  }),
+                ),
+                Schema.Null,
+              ]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              confidence: "confidence",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              profileId: "profile_id",
+              variant: "variant",
             }),
           ),
         ]),
@@ -75863,184 +76041,6 @@ export const CreateDlpProfileCustomResponse =
         contextAwareness: "context_awareness",
         ocrEnabled: "ocr_enabled",
         openAccess: "open_access",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      entries: Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            pattern: Schema.Struct({
-              regex: Schema.String,
-              validation: Schema.optional(
-                Schema.Union([Schema.Literal("luhn"), Schema.Null]),
-              ),
-            }),
-            type: Schema.Literal("custom"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              pattern: "pattern",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            confidence: Schema.Struct({
-              aiContextAvailable: Schema.Boolean,
-              available: Schema.Boolean,
-            }).pipe(
-              Schema.encodeKeys({
-                aiContextAvailable: "ai_context_available",
-                available: "available",
-              }),
-            ),
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("predefined"),
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            variant: Schema.optional(
-              Schema.Union([
-                Schema.Struct({
-                  topicType: Schema.Literals(["Intent", "Content"]),
-                  type: Schema.Literal("PromptTopic"),
-                  description: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    topicType: "topic_type",
-                    type: "type",
-                    description: "description",
-                  }),
-                ),
-                Schema.Null,
-              ]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              confidence: "confidence",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              profileId: "profile_id",
-              variant: "variant",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("integration"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            caseSensitive: Schema.Boolean,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            secret: Schema.Boolean,
-            type: Schema.Literal("exact_data"),
-            updatedAt: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              caseSensitive: "case_sensitive",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              secret: "secret",
-              type: "type",
-              updatedAt: "updated_at",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("document_fingerprint"),
-            updatedAt: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("word_list"),
-            updatedAt: Schema.String,
-            wordList: Schema.Unknown,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              wordList: "word_list",
-              profileId: "profile_id",
-            }),
-          ),
-        ]),
-      ),
-      name: Schema.String,
-      type: Schema.Literal("integration"),
-      updatedAt: Schema.String,
-      description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        entries: "entries",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        description: "description",
       }),
     ),
   ]).pipe(
@@ -76438,6 +76438,27 @@ export const UpdateDlpProfileCustomResponse =
             Schema.Union([
               Schema.Struct({
                 id: Schema.String,
+                caseSensitive: Schema.Boolean,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                secret: Schema.Boolean,
+                type: Schema.Literal("exact_data"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  caseSensitive: "case_sensitive",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  secret: "secret",
+                  type: "type",
+                  updatedAt: "updated_at",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
                 createdAt: Schema.String,
                 enabled: Schema.Boolean,
                 name: Schema.String,
@@ -76462,6 +76483,67 @@ export const UpdateDlpProfileCustomResponse =
                   type: "type",
                   updatedAt: "updated_at",
                   profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("word_list"),
+                updatedAt: Schema.String,
+                wordList: Schema.Unknown,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  wordList: "word_list",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("integration"),
+                updatedAt: Schema.String,
+                profileId: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
+                  profileId: "profile_id",
+                }),
+              ),
+              Schema.Struct({
+                id: Schema.String,
+                createdAt: Schema.String,
+                enabled: Schema.Boolean,
+                name: Schema.String,
+                type: Schema.Literal("document_fingerprint"),
+                updatedAt: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  id: "id",
+                  createdAt: "created_at",
+                  enabled: "enabled",
+                  name: "name",
+                  type: "type",
+                  updatedAt: "updated_at",
                 }),
               ),
               Schema.Struct({
@@ -76510,88 +76592,6 @@ export const UpdateDlpProfileCustomResponse =
                   variant: "variant",
                 }),
               ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("integration"),
-                updatedAt: Schema.String,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  profileId: "profile_id",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                caseSensitive: Schema.Boolean,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                secret: Schema.Boolean,
-                type: Schema.Literal("exact_data"),
-                updatedAt: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  caseSensitive: "case_sensitive",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  secret: "secret",
-                  type: "type",
-                  updatedAt: "updated_at",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("document_fingerprint"),
-                updatedAt: Schema.String,
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                }),
-              ),
-              Schema.Struct({
-                id: Schema.String,
-                createdAt: Schema.String,
-                enabled: Schema.Boolean,
-                name: Schema.String,
-                type: Schema.Literal("word_list"),
-                updatedAt: Schema.String,
-                wordList: Schema.Unknown,
-                profileId: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }).pipe(
-                Schema.encodeKeys({
-                  id: "id",
-                  createdAt: "created_at",
-                  enabled: "enabled",
-                  name: "name",
-                  type: "type",
-                  updatedAt: "updated_at",
-                  wordList: "word_list",
-                  profileId: "profile_id",
-                }),
-              ),
             ]),
           ),
           Schema.Null,
@@ -76615,9 +76615,30 @@ export const UpdateDlpProfileCustomResponse =
     ),
     Schema.Struct({
       id: Schema.String,
-      allowedMatchCount: Schema.Number,
+      createdAt: Schema.String,
       entries: Schema.Array(
         Schema.Union([
+          Schema.Struct({
+            id: Schema.String,
+            caseSensitive: Schema.Boolean,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            secret: Schema.Boolean,
+            type: Schema.Literal("exact_data"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              caseSensitive: "case_sensitive",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              secret: "secret",
+              type: "type",
+              updatedAt: "updated_at",
+            }),
+          ),
           Schema.Struct({
             id: Schema.String,
             createdAt: Schema.String,
@@ -76644,6 +76665,67 @@ export const UpdateDlpProfileCustomResponse =
               type: "type",
               updatedAt: "updated_at",
               profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("word_list"),
+            updatedAt: Schema.String,
+            wordList: Schema.Unknown,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              wordList: "word_list",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("integration"),
+            updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("document_fingerprint"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
             }),
           ),
           Schema.Struct({
@@ -76692,27 +76774,28 @@ export const UpdateDlpProfileCustomResponse =
               variant: "variant",
             }),
           ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("integration"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
+        ]),
+      ),
+      name: Schema.String,
+      type: Schema.Literal("integration"),
+      updatedAt: Schema.String,
+      description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    }).pipe(
+      Schema.encodeKeys({
+        id: "id",
+        createdAt: "created_at",
+        entries: "entries",
+        name: "name",
+        type: "type",
+        updatedAt: "updated_at",
+        description: "description",
+      }),
+    ),
+    Schema.Struct({
+      id: Schema.String,
+      allowedMatchCount: Schema.Number,
+      entries: Schema.Array(
+        Schema.Union([
           Schema.Struct({
             id: Schema.String,
             caseSensitive: Schema.Boolean,
@@ -76739,16 +76822,27 @@ export const UpdateDlpProfileCustomResponse =
             createdAt: Schema.String,
             enabled: Schema.Boolean,
             name: Schema.String,
-            type: Schema.Literal("document_fingerprint"),
+            pattern: Schema.Struct({
+              regex: Schema.String,
+              validation: Schema.optional(
+                Schema.Union([Schema.Literal("luhn"), Schema.Null]),
+              ),
+            }),
+            type: Schema.Literal("custom"),
             updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
           }).pipe(
             Schema.encodeKeys({
               id: "id",
               createdAt: "created_at",
               enabled: "enabled",
               name: "name",
+              pattern: "pattern",
               type: "type",
               updatedAt: "updated_at",
+              profileId: "profile_id",
             }),
           ),
           Schema.Struct({
@@ -76772,6 +76866,90 @@ export const UpdateDlpProfileCustomResponse =
               updatedAt: "updated_at",
               wordList: "word_list",
               profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("integration"),
+            updatedAt: Schema.String,
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+              profileId: "profile_id",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            createdAt: Schema.String,
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("document_fingerprint"),
+            updatedAt: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              createdAt: "created_at",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              updatedAt: "updated_at",
+            }),
+          ),
+          Schema.Struct({
+            id: Schema.String,
+            confidence: Schema.Struct({
+              aiContextAvailable: Schema.Boolean,
+              available: Schema.Boolean,
+            }).pipe(
+              Schema.encodeKeys({
+                aiContextAvailable: "ai_context_available",
+                available: "available",
+              }),
+            ),
+            enabled: Schema.Boolean,
+            name: Schema.String,
+            type: Schema.Literal("predefined"),
+            profileId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            variant: Schema.optional(
+              Schema.Union([
+                Schema.Struct({
+                  topicType: Schema.Literals(["Intent", "Content"]),
+                  type: Schema.Literal("PromptTopic"),
+                  description: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }).pipe(
+                  Schema.encodeKeys({
+                    topicType: "topic_type",
+                    type: "type",
+                    description: "description",
+                  }),
+                ),
+                Schema.Null,
+              ]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              id: "id",
+              confidence: "confidence",
+              enabled: "enabled",
+              name: "name",
+              type: "type",
+              profileId: "profile_id",
+              variant: "variant",
             }),
           ),
         ]),
@@ -76812,184 +76990,6 @@ export const UpdateDlpProfileCustomResponse =
         contextAwareness: "context_awareness",
         ocrEnabled: "ocr_enabled",
         openAccess: "open_access",
-      }),
-    ),
-    Schema.Struct({
-      id: Schema.String,
-      createdAt: Schema.String,
-      entries: Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            pattern: Schema.Struct({
-              regex: Schema.String,
-              validation: Schema.optional(
-                Schema.Union([Schema.Literal("luhn"), Schema.Null]),
-              ),
-            }),
-            type: Schema.Literal("custom"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              pattern: "pattern",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            confidence: Schema.Struct({
-              aiContextAvailable: Schema.Boolean,
-              available: Schema.Boolean,
-            }).pipe(
-              Schema.encodeKeys({
-                aiContextAvailable: "ai_context_available",
-                available: "available",
-              }),
-            ),
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("predefined"),
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            variant: Schema.optional(
-              Schema.Union([
-                Schema.Struct({
-                  topicType: Schema.Literals(["Intent", "Content"]),
-                  type: Schema.Literal("PromptTopic"),
-                  description: Schema.optional(
-                    Schema.Union([Schema.String, Schema.Null]),
-                  ),
-                }).pipe(
-                  Schema.encodeKeys({
-                    topicType: "topic_type",
-                    type: "type",
-                    description: "description",
-                  }),
-                ),
-                Schema.Null,
-              ]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              confidence: "confidence",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              profileId: "profile_id",
-              variant: "variant",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("integration"),
-            updatedAt: Schema.String,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              profileId: "profile_id",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            caseSensitive: Schema.Boolean,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            secret: Schema.Boolean,
-            type: Schema.Literal("exact_data"),
-            updatedAt: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              caseSensitive: "case_sensitive",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              secret: "secret",
-              type: "type",
-              updatedAt: "updated_at",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("document_fingerprint"),
-            updatedAt: Schema.String,
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-            }),
-          ),
-          Schema.Struct({
-            id: Schema.String,
-            createdAt: Schema.String,
-            enabled: Schema.Boolean,
-            name: Schema.String,
-            type: Schema.Literal("word_list"),
-            updatedAt: Schema.String,
-            wordList: Schema.Unknown,
-            profileId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              createdAt: "created_at",
-              enabled: "enabled",
-              name: "name",
-              type: "type",
-              updatedAt: "updated_at",
-              wordList: "word_list",
-              profileId: "profile_id",
-            }),
-          ),
-        ]),
-      ),
-      name: Schema.String,
-      type: Schema.Literal("integration"),
-      updatedAt: Schema.String,
-      description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        id: "id",
-        createdAt: "created_at",
-        entries: "entries",
-        name: "name",
-        type: "type",
-        updatedAt: "updated_at",
-        description: "description",
       }),
     ),
   ]).pipe(
@@ -77152,6 +77152,27 @@ export const GetDlpProfilePredefinedResponse =
       Schema.Union([
         Schema.Struct({
           id: Schema.String,
+          caseSensitive: Schema.Boolean,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          secret: Schema.Boolean,
+          type: Schema.Literal("exact_data"),
+          updatedAt: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            caseSensitive: "case_sensitive",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            secret: "secret",
+            type: "type",
+            updatedAt: "updated_at",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
           createdAt: Schema.String,
           enabled: Schema.Boolean,
           name: Schema.String,
@@ -77176,6 +77197,67 @@ export const GetDlpProfilePredefinedResponse =
             type: "type",
             updatedAt: "updated_at",
             profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("word_list"),
+          updatedAt: Schema.String,
+          wordList: Schema.Unknown,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            wordList: "word_list",
+            profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("document_fingerprint"),
+          updatedAt: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
           }),
         ),
         Schema.Struct({
@@ -77222,88 +77304,6 @@ export const GetDlpProfilePredefinedResponse =
             type: "type",
             profileId: "profile_id",
             variant: "variant",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          caseSensitive: Schema.Boolean,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          secret: Schema.Boolean,
-          type: Schema.Literal("exact_data"),
-          updatedAt: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            caseSensitive: "case_sensitive",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            secret: "secret",
-            type: "type",
-            updatedAt: "updated_at",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("document_fingerprint"),
-          updatedAt: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("word_list"),
-          updatedAt: Schema.String,
-          wordList: Schema.Unknown,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            wordList: "word_list",
-            profileId: "profile_id",
           }),
         ),
       ]),
@@ -77488,6 +77488,27 @@ export const PutDlpProfilePredefinedResponse =
       Schema.Union([
         Schema.Struct({
           id: Schema.String,
+          caseSensitive: Schema.Boolean,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          secret: Schema.Boolean,
+          type: Schema.Literal("exact_data"),
+          updatedAt: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            caseSensitive: "case_sensitive",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            secret: "secret",
+            type: "type",
+            updatedAt: "updated_at",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
           createdAt: Schema.String,
           enabled: Schema.Boolean,
           name: Schema.String,
@@ -77512,6 +77533,67 @@ export const PutDlpProfilePredefinedResponse =
             type: "type",
             updatedAt: "updated_at",
             profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("word_list"),
+          updatedAt: Schema.String,
+          wordList: Schema.Unknown,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            wordList: "word_list",
+            profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("integration"),
+          updatedAt: Schema.String,
+          profileId: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
+            profileId: "profile_id",
+          }),
+        ),
+        Schema.Struct({
+          id: Schema.String,
+          createdAt: Schema.String,
+          enabled: Schema.Boolean,
+          name: Schema.String,
+          type: Schema.Literal("document_fingerprint"),
+          updatedAt: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            createdAt: "created_at",
+            enabled: "enabled",
+            name: "name",
+            type: "type",
+            updatedAt: "updated_at",
           }),
         ),
         Schema.Struct({
@@ -77558,88 +77640,6 @@ export const PutDlpProfilePredefinedResponse =
             type: "type",
             profileId: "profile_id",
             variant: "variant",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("integration"),
-          updatedAt: Schema.String,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            profileId: "profile_id",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          caseSensitive: Schema.Boolean,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          secret: Schema.Boolean,
-          type: Schema.Literal("exact_data"),
-          updatedAt: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            caseSensitive: "case_sensitive",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            secret: "secret",
-            type: "type",
-            updatedAt: "updated_at",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("document_fingerprint"),
-          updatedAt: Schema.String,
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-          }),
-        ),
-        Schema.Struct({
-          id: Schema.String,
-          createdAt: Schema.String,
-          enabled: Schema.Boolean,
-          name: Schema.String,
-          type: Schema.Literal("word_list"),
-          updatedAt: Schema.String,
-          wordList: Schema.Unknown,
-          profileId: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            id: "id",
-            createdAt: "created_at",
-            enabled: "enabled",
-            name: "name",
-            type: "type",
-            updatedAt: "updated_at",
-            wordList: "word_list",
-            profileId: "profile_id",
           }),
         ),
       ]),

--- a/packages/cloudflare/src/services/zones.ts
+++ b/packages/cloudflare/src/services/zones.ts
@@ -1212,21 +1212,6 @@ export const GetSettingResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     }),
   ),
   Schema.Struct({
-    id: Schema.Literal("aegis"),
-    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    value: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-          poolId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }).pipe(Schema.encodeKeys({ enabled: "enabled", poolId: "pool_id" })),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
-  ),
-  Schema.Struct({
     id: Schema.Literal("always_online"),
     value: Schema.Literals(["on", "off"]),
     editable: Schema.optional(
@@ -1737,22 +1722,6 @@ export const GetSettingResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     }),
   ),
   Schema.Struct({
-    id: Schema.Literal("origin_h2_max_streams"),
-    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    value: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
-  ),
-  Schema.Struct({
-    id: Schema.Literal("origin_max_http_version"),
-    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    value: Schema.optional(
-      Schema.Union([Schema.Literals(["2", "1"]), Schema.Null]),
-    ),
-  }).pipe(
-    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
-  ),
-  Schema.Struct({
     id: Schema.Literal("polish"),
     value: Schema.Literals(["off", "lossless", "lossy"]),
     editable: Schema.optional(
@@ -2034,12 +2003,6 @@ export const GetSettingResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     }),
   ),
   Schema.Struct({
-    id: Schema.optional(
-      Schema.Union([Schema.Literal("ssl_recommender"), Schema.Null]),
-    ),
-    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  }),
-  Schema.Struct({
     id: Schema.Literal("tls_1_2_only"),
     value: Schema.Literals(["off", "on"]),
     editable: Schema.optional(
@@ -2174,6 +2137,43 @@ export const GetSettingResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       modifiedOn: "modified_on",
     }),
   ),
+  Schema.Struct({
+    id: Schema.Literal("aegis"),
+    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    value: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+          poolId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        }).pipe(Schema.encodeKeys({ enabled: "enabled", poolId: "pool_id" })),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
+  ),
+  Schema.Struct({
+    id: Schema.Literal("origin_h2_max_streams"),
+    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    value: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
+  ),
+  Schema.Struct({
+    id: Schema.Literal("origin_max_http_version"),
+    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    value: Schema.optional(
+      Schema.Union([Schema.Literals(["2", "1"]), Schema.Null]),
+    ),
+  }).pipe(
+    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
+  ),
+  Schema.Struct({
+    id: Schema.optional(
+      Schema.Union([Schema.Literal("ssl_recommender"), Schema.Null]),
+    ),
+    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  }),
 ]).pipe(
   T.ResponsePath("result"),
 ) as unknown as Schema.Schema<GetSettingResponse>;
@@ -2668,21 +2668,6 @@ export const PatchSettingResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     }),
   ),
   Schema.Struct({
-    id: Schema.Literal("aegis"),
-    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    value: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-          poolId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }).pipe(Schema.encodeKeys({ enabled: "enabled", poolId: "pool_id" })),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
-  ),
-  Schema.Struct({
     id: Schema.Literal("always_online"),
     value: Schema.Literals(["on", "off"]),
     editable: Schema.optional(
@@ -3193,22 +3178,6 @@ export const PatchSettingResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     }),
   ),
   Schema.Struct({
-    id: Schema.Literal("origin_h2_max_streams"),
-    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    value: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
-  ),
-  Schema.Struct({
-    id: Schema.Literal("origin_max_http_version"),
-    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    value: Schema.optional(
-      Schema.Union([Schema.Literals(["2", "1"]), Schema.Null]),
-    ),
-  }).pipe(
-    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
-  ),
-  Schema.Struct({
     id: Schema.Literal("polish"),
     value: Schema.Literals(["off", "lossless", "lossy"]),
     editable: Schema.optional(
@@ -3490,12 +3459,6 @@ export const PatchSettingResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
     }),
   ),
   Schema.Struct({
-    id: Schema.optional(
-      Schema.Union([Schema.Literal("ssl_recommender"), Schema.Null]),
-    ),
-    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  }),
-  Schema.Struct({
     id: Schema.Literal("tls_1_2_only"),
     value: Schema.Literals(["off", "on"]),
     editable: Schema.optional(
@@ -3630,6 +3593,43 @@ export const PatchSettingResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
       modifiedOn: "modified_on",
     }),
   ),
+  Schema.Struct({
+    id: Schema.Literal("aegis"),
+    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    value: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+          poolId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        }).pipe(Schema.encodeKeys({ enabled: "enabled", poolId: "pool_id" })),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
+  ),
+  Schema.Struct({
+    id: Schema.Literal("origin_h2_max_streams"),
+    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    value: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
+  ),
+  Schema.Struct({
+    id: Schema.Literal("origin_max_http_version"),
+    modifiedOn: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    value: Schema.optional(
+      Schema.Union([Schema.Literals(["2", "1"]), Schema.Null]),
+    ),
+  }).pipe(
+    Schema.encodeKeys({ id: "id", modifiedOn: "modified_on", value: "value" }),
+  ),
+  Schema.Struct({
+    id: Schema.optional(
+      Schema.Union([Schema.Literal("ssl_recommender"), Schema.Null]),
+    ),
+    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  }),
 ]).pipe(
   T.ResponsePath("result"),
 ) as unknown as Schema.Schema<PatchSettingResponse>;


### PR DESCRIPTION
`Schema.Union` is first-match-wins on encode. When the spec emits overlapping object variants in less-specific-first order — e.g. `{ipv4, network}` before `{ipv4, ipv6, network}` — dual-stack inputs match the wider variant first and the encoder strips the extra fields (e.g. `ipv6`) before the request hits the wire.

```ts
// before — dual-stack input loses `ipv6` on encode:
host: Schema.Union([
  Schema.Struct({ ipv4: Schema.String, network: ... }),                       // matches first
  Schema.Struct({ ipv6: Schema.String, network: ... }),
  Schema.Struct({ ipv4: Schema.String, ipv6: Schema.String, network: ... }),  // never reached
  Schema.Struct({ hostname: ..., resolverNetwork: ... }),
])

// after — most-specific first:
host: Schema.Union([
  Schema.Struct({ ipv4: Schema.String, ipv6: Schema.String, network: ... }),
  Schema.Struct({ ipv4: Schema.String, network: ... }),
  Schema.Struct({ ipv6: Schema.String, network: ... }),
  Schema.Struct({ hostname: ..., resolverNetwork: ... }),
])
```

Sort variants by required-property count descending in the generator's union emission. Stable sort preserves the relative order of non-object variants, so `[Literal, Null]` and similar unions are unaffected.

Repro that motivated the fix: `createDirectoryService({ host: { ipv4, ipv6, network } })` silently dropped `ipv6`. Verified end-to-end against alchemy-effect's `Cloudflare.VpcService` dual-stack test, which now passes.

Regenerated all affected services. The diff is mechanical reordering of union variants across 19 service files.
