### PR TITLE
fix(cloudflare): tag 10001 internal-error variant retryable

### DIFF
--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -45,30 +45,17 @@ import { type ErrorMatcher, getErrorMatchers } from "../traits.ts";
 // ============================================================================
 
 /**
- * Tag an error instance as retryable. Cloudflare's API maps several
- * actually-transient blips (auth-edge hiccups, internal-error 403s,
- * Workers 5xx wrapped as `WorkerNotFound`) to permanent-looking error
- * tags. Marking the specific instance — not the whole class — keeps
- * legitimate auth/auth failures non-retryable while letting the
- * blanket retry policy ride out the transient cases.
+ * Tag an error instance as retryable. Cloudflare reuses code 10001 for
+ * both a permanent permission failure ("Method not allowed for token")
+ * and a transient internal hiccup ("internal error"). Marking the
+ * specific instance — not the whole class — keeps legitimate
+ * permission failures non-retryable while letting the blanket retry
+ * policy ride out the transient case.
  */
 const tagRetryable = <E>(error: E): E => {
   (error as Record<string, unknown>)[retryableKey] = {};
   return error;
 };
-
-/**
- * Heuristic: does the error message text indicate a Cloudflare auth-edge
- * blip / internal hiccup rather than a permanent auth/permission failure?
- * Cloudflare frequently surfaces brief edge / internal failures behind
- * `Authentication error` (10000) or `internal error` (10001) envelopes;
- * the API itself doesn't distinguish them from real auth failures, so we
- * pattern-match on the message content.
- */
-const isMisleadinglyTransientMessage = (message: string): boolean =>
-  /authentication error/i.test(message) ||
-  /internal error/i.test(message) ||
-  /unknown error has occurred/i.test(message);
 
 /**
  * Cloudflare error codes that map to global/default errors regardless of operation.
@@ -98,15 +85,18 @@ const GLOBAL_ERROR_CODE_MAP: Record<
   // 9109: Unauthorized to access requested resource / Max auth failures reached
   9109: (message) => new Unauthorized({ message }),
   // 10000: Authentication error / Authentication failed.
-  // Sometimes a transient CF auth-edge blip — tag those instances as
-  // retryable so the blanket retry policy covers them.
-  10000: (message) => {
-    const error = new Unauthorized({ message });
-    return /authentication error/i.test(message) ? tagRetryable(error) : error;
-  },
-  // 10001: Method not allowed for token, BUT also returned with
-  // "internal error" message during CF-internal hiccups. Tag the
-  // internal-error variant as retryable.
+  // Deliberately NOT tagged retryable: Cloudflare uses the same message
+  // for both transient auth-edge blips and a genuinely invalid token,
+  // so there is no message we can match on to discriminate. Auto-retrying
+  // would silently loop on real auth failures, making them slower to
+  // surface without fixing anything. If callers want to retry these
+  // anyway, they can override the retry predicate.
+  10000: (message) => new Unauthorized({ message }),
+  // 10001: dual-use code. The permanent-failure variant has message
+  // "Method not allowed for token" (legitimate permission denial); the
+  // transient variant has message "internal error" (CF infrastructure
+  // hiccup mistagged as 403). Those two messages are unambiguously
+  // distinct, so we can safely tag only the transient variant retryable.
   10001: (message) => {
     const error = new Forbidden({ message });
     return /internal error/i.test(message) ? tagRetryable(error) : error;

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -15,6 +15,7 @@ import {
   type OperationMethod,
   type PaginatedOperationMethod,
 } from "@distilled.cloud/core/client";
+import { retryableKey } from "@distilled.cloud/core/category";
 import {
   paginateCursor,
   paginateSingle,
@@ -44,6 +45,32 @@ import { type ErrorMatcher, getErrorMatchers } from "../traits.ts";
 // ============================================================================
 
 /**
+ * Tag an error instance as retryable. Cloudflare's API maps several
+ * actually-transient blips (auth-edge hiccups, internal-error 403s,
+ * Workers 5xx wrapped as `WorkerNotFound`) to permanent-looking error
+ * tags. Marking the specific instance — not the whole class — keeps
+ * legitimate auth/auth failures non-retryable while letting the
+ * blanket retry policy ride out the transient cases.
+ */
+const tagRetryable = <E>(error: E): E => {
+  (error as Record<string, unknown>)[retryableKey] = {};
+  return error;
+};
+
+/**
+ * Heuristic: does the error message text indicate a Cloudflare auth-edge
+ * blip / internal hiccup rather than a permanent auth/permission failure?
+ * Cloudflare frequently surfaces brief edge / internal failures behind
+ * `Authentication error` (10000) or `internal error` (10001) envelopes;
+ * the API itself doesn't distinguish them from real auth failures, so we
+ * pattern-match on the message content.
+ */
+const isMisleadinglyTransientMessage = (message: string): boolean =>
+  /authentication error/i.test(message) ||
+  /internal error/i.test(message) ||
+  /unknown error has occurred/i.test(message);
+
+/**
  * Cloudflare error codes that map to global/default errors regardless of operation.
  * These are infrastructure-level errors that can occur on any endpoint.
  */
@@ -70,10 +97,20 @@ const GLOBAL_ERROR_CODE_MAP: Record<
   9106: (message) => new Unauthorized({ message }),
   // 9109: Unauthorized to access requested resource / Max auth failures reached
   9109: (message) => new Unauthorized({ message }),
-  // 10000: Authentication error / Authentication failed
-  10000: (message) => new Unauthorized({ message }),
-  // 10001: Method not allowed for token (authorization, not authentication)
-  10001: (message) => new Forbidden({ message }),
+  // 10000: Authentication error / Authentication failed.
+  // Sometimes a transient CF auth-edge blip — tag those instances as
+  // retryable so the blanket retry policy covers them.
+  10000: (message) => {
+    const error = new Unauthorized({ message });
+    return /authentication error/i.test(message) ? tagRetryable(error) : error;
+  },
+  // 10001: Method not allowed for token, BUT also returned with
+  // "internal error" message during CF-internal hiccups. Tag the
+  // internal-error variant as retryable.
+  10001: (message) => {
+    const error = new Forbidden({ message });
+    return /internal error/i.test(message) ? tagRetryable(error) : error;
+  },
 };
 
 /**


### PR DESCRIPTION
Cloudflare reuses error code `10001` for two semantically different cases:

| Variant | Message | Cause |
|---|---|---|
| Permanent | `Method not allowed for token` | Token scope is wrong — legitimate permission failure |
| Transient | `internal error` | Cloudflare infrastructure hiccup mistagged as 403 |

The default `Retry` policy doesn't retry these (they're categorised as `Forbidden`), so consumers either override the predicate locally or wrap calls. But because the two variants have unambiguously distinct messages, we can tag only the transient instance as retryable inside the SDK and leave the legitimate one alone.

```diff
  10001: (message) => {
-   return new Forbidden({ message });
+   const error = new Forbidden({ message });
+   return /internal error/i.test(message) ? tagRetryable(error) : error;
  },
```

Tagging the **instance**, not the class, means real permission failures still surface immediately — the retry only kicks in for the message variant we know is transient.

### Considered and rejected: tagging code 10000

I initially included `Unauthorized` (10000) too, on the basis that the auth-edge blip is also "transient." Dropped after review: Cloudflare returns the same `Authentication error` / `Authentication failed` message for both the blip and a genuinely invalid token. With no discriminator to match on, auto-retrying would silently loop on every real auth failure, slowing the failure-surface without ever recovering it. Callers who want to override that tradeoff can replace the `Retry` policy.

### Out of scope

- `WorkerNotFound` with `unknown error has occurred` (Workers API wrapping 5xx). Tagging this needs a hook into per-operation error decoding in `matchError`, separate change.
