### PR TITLE
fix(aws): wrap SSO cache JSON.parse in Effect.try

### DIFF
--- a/packages/aws/src/auth.ts
+++ b/packages/aws/src/auth.ts
@@ -155,8 +155,19 @@ export const makeAuthService = () =>
           `${cacheName}.credentials.json`,
         );
 
+        // `Effect.try` so a `JSON.parse` throw on an empty/partial file
+        // (a brief race window when another process is rewriting the
+        // SSO cache) becomes a typed error and is caught below — without
+        // the wrap it surfaces as a fiber defect that blows past
+        // `Effect.catch`.
         const cachedCreds = yield* fs.readFileString(cachedCredsFilePath).pipe(
-          Effect.map((text) => JSON.parse(text)),
+          Effect.flatMap((text) =>
+            Effect.try({
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              try: (): any => JSON.parse(text),
+              catch: (cause) => cause,
+            }),
+          ),
           Effect.catch(() => Effect.void),
         );
 
@@ -179,7 +190,16 @@ export const makeAuthService = () =>
         }
 
         const ssoToken = yield* fs.readFileString(ssoTokenFilepath).pipe(
-          Effect.map((text) => JSON.parse(text) as SSOToken),
+          // `Effect.try` so a `JSON.parse` throw on an empty/partial
+          // token file (a brief race window when another process is
+          // refreshing the cache) becomes a typed error and is caught
+          // below — without the wrap it surfaces as a fiber defect.
+          Effect.flatMap((text) =>
+            Effect.try({
+              try: () => JSON.parse(text) as SSOToken,
+              catch: (cause) => cause,
+            }),
+          ),
           Effect.catch(() =>
             new InvalidSSOToken({
               message: `The SSO session token associated with profile=${profileName} was not found or is invalid. ${REFRESH_MESSAGE}`,


### PR DESCRIPTION
`Effect.map((text) => JSON.parse(text))` runs the parse synchronously inside the map. If `JSON.parse` throws — e.g. when another process is mid-rewrite of the SSO cache file and we read a zero-byte / partial snapshot — the throw becomes a fiber defect, which blows past the surrounding `Effect.catch(() => Effect.void)` (catch only sees the typed error channel).

In practice this surfaces as a `SyntaxError: Unexpected end of JSON input` crashing auth resolution for the FIRST test of every AWS suite running in parallel — they all hit `~/.aws/sso/cache/<hash>.json` at the same time and race the SSO token refresh.

Wrap the parse in `Effect.try` so the throw becomes a typed error that the existing `Effect.catch` handles cleanly:

- For the credentials cache: fall back to refreshing via the SSO token.
- For the SSO token cache: surface the typed `InvalidSSOToken` error with the existing user-facing "run aws sso login" message.

```diff
- Effect.map((text) => JSON.parse(text)),
+ Effect.flatMap((text) =>
+   Effect.try({
+     try: () => JSON.parse(text),
+     catch: (cause) => cause,
+   }),
+ ),
```

Verified against `alchemy-effect`'s parallel test suite — the three "first test in suite" failures (`DynamoDB.Table > create…`, `S3.Bucket > create and delete…`, `SQS.Queue > create and delete…`) that previously crashed mid-auth now wait through the typed error and proceed cleanly once the cache settles.
