### PR TITLE
chore(ci): force JS actions onto Node 24

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -7,6 +7,9 @@ concurrency:
   group: deploy-website
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/nuke.yml
+++ b/.github/workflows/nuke.yml
@@ -71,6 +71,9 @@ on:
         type: boolean
         default: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # ── Gate: decide whether to proceed ──
   gate:

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -20,6 +20,7 @@ permissions:
 env:
   PR_PACKAGE_HOST: pkg.ing
   NODE_VERSION: "24"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # ── Detect which packages changed (same filters as test.yml). ─────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   # Files produced by the bump job and consumed by the commit-and-tag and
   # publish jobs. Listed once here so additions stay in sync.
   BUMP_ARTIFACT_PATHS: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ci-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
@@ -401,7 +404,7 @@ jobs:
     if: needs.detect-changes.outputs.axiom == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -421,7 +424,7 @@ jobs:
     if: needs.detect-changes.outputs.posthog == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -441,7 +444,7 @@ jobs:
     if: needs.detect-changes.outputs.typesense == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -456,7 +459,7 @@ jobs:
     if: needs.detect-changes.outputs.workos == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -475,7 +478,7 @@ jobs:
     if: needs.detect-changes.outputs.expo-eas == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest


### PR DESCRIPTION
Opt JavaScript-based actions onto Node 24 ahead of GitHub's June 2026 default flip, silencing the Node 20 deprecation warnings on every CI run.

Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at the workflow level on all five workflows. Also normalized lingering `actions/checkout@v4` references in `test.yml` to `@v6`.

### Why the env var instead of bumping action versions

The flagged actions (`actions/cache@v4`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`, `actions/create-github-app-token@v1`) are already on their latest major. None of them have shipped a release whose `action.yml` declares `runs.using: node24` yet — that is precisely why GitHub introduced this opt-in env var. Once upstream cuts node24-runtime releases (likely `v5` of cache/artifact), we can drop the env var and bump the pins.
