### PR TITLE
fix(aws/spec): allow NotFound/AlreadyExists/DependencyViolation/Locked/Configuration categories

### DIFF
--- a/packages/aws/scripts/spec-schema.ts
+++ b/packages/aws/scripts/spec-schema.ts
@@ -21,6 +21,11 @@ export const ConflictError = "ConflictError" as const;
 export const QuotaError = "QuotaError" as const;
 export const NetworkError = "NetworkError" as const;
 export const AbortedError = "AbortedError" as const;
+export const NotFoundError = "NotFoundError" as const;
+export const AlreadyExistsError = "AlreadyExistsError" as const;
+export const DependencyViolationError = "DependencyViolationError" as const;
+export const LockedError = "LockedError" as const;
+export const ConfigurationError = "ConfigurationError" as const;
 
 /**
  * Schema for error category strings.
@@ -36,6 +41,11 @@ export const CategorySchema = S.Literals([
   QuotaError,
   NetworkError,
   AbortedError,
+  NotFoundError,
+  AlreadyExistsError,
+  DependencyViolationError,
+  LockedError,
+  ConfigurationError,
 ]);
 export type CategorySchema = typeof CategorySchema.Type;
 


### PR DESCRIPTION
The patch schema's `CategorySchema` only allowed 10 of the 15 categories defined in `@distilled.cloud/sdk-core/category`. Patches that try to set `NotFoundError` (or any of the others) on a specific error fail `S.decodeUnknownSync(ServiceSpec)` at generation time.

```diff
 export const CategorySchema = S.Literals([
   ThrottlingError, RetryableError, ServerError,
   AuthError, BadRequestError, TimeoutError,
   ConflictError, QuotaError, NetworkError, AbortedError,
+  NotFoundError, AlreadyExistsError, DependencyViolationError,
+  LockedError, ConfigurationError,
 ]);
```

These categories already have decorators (`C.withNotFoundError`, etc.) in core and the generator already emits them from inferred name patterns. They just couldn't be set explicitly via a patch.

Surfaced while categorizing SNS `NotFound`, `ResourceNotFound`, and `KMSNotFound` for a downstream alchemy-effect hardening pass — those names don't match the existing inference heuristics, so they need to be set explicitly.
