### PR TITLE
fix(cloudflare/workers): support ratelimit upload bindings

### DIFF
--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -11,7 +11,9 @@
     "DuplicateMigrationTarget": [
       {
         "code": 10074,
-        "message": { "includes": "cannot be the target of more than one migration" }
+        "message": {
+          "includes": "cannot be the target of more than one migration"
+        }
       }
     ],
     "ScriptStartupError": [{ "code": 10021 }],
@@ -58,6 +60,45 @@
                 "name": "namespace",
                 "required": true,
                 "type": { "kind": "primitive", "value": "string" }
+              }
+            ]
+          },
+          {
+            "kind": "object",
+            "properties": [
+              {
+                "name": "name",
+                "required": true,
+                "type": { "kind": "primitive", "value": "string" }
+              },
+              {
+                "name": "type",
+                "required": true,
+                "type": { "kind": "literal", "value": "ratelimit" }
+              },
+              {
+                "name": "namespace_id",
+                "required": true,
+                "type": { "kind": "primitive", "value": "string" }
+              },
+              {
+                "name": "simple",
+                "required": true,
+                "type": {
+                  "kind": "object",
+                  "properties": [
+                    {
+                      "name": "limit",
+                      "required": true,
+                      "type": { "kind": "primitive", "value": "number" }
+                    },
+                    {
+                      "name": "period",
+                      "required": true,
+                      "type": { "kind": "primitive", "value": "number" }
+                    }
+                  ]
+                }
               }
             ]
           }

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -6715,6 +6715,31 @@ paths:
                               - name
                               - type
                               - namespace
+                          - type: object
+                            properties:
+                              name:
+                                type: string
+                              type:
+                                type: string
+                                enum:
+                                  - ratelimit
+                              namespace_id:
+                                type: string
+                              simple:
+                                type: object
+                                properties:
+                                  limit:
+                                    type: number
+                                  period:
+                                    type: number
+                                required:
+                                  - limit
+                                  - period
+                            required:
+                              - name
+                              - type
+                              - namespace_id
+                              - simple
                       description: "List of bindings attached to a Worker. You can find more about
                         bindings on our docs:
                         https://developers.cloudflare.com/workers/configuration\

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -6611,6 +6611,12 @@ export interface PutScriptRequest {
       | { name: string; part: string; type: "wasm_module" }
       | { name: string; type: "worker_loader" }
       | { name: string; type: "artifacts"; namespace: string }
+      | {
+          name: string;
+          type: "ratelimit";
+          namespaceId: string;
+          simple: { limit: number; period: number };
+        }
     )[];
     bodyPart?: string;
     compatibilityDate?: string;
@@ -6759,6 +6765,22 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
               secretName: "secret_name",
               storeId: "store_id",
               type: "type",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("ratelimit"),
+            namespaceId: Schema.String,
+            simple: Schema.Struct({
+              limit: Schema.Number,
+              period: Schema.Number,
+            }),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              namespaceId: "namespace_id",
+              simple: "simple",
             }),
           ),
           Schema.Struct({

--- a/packages/cloudflare/test/client-api.test.ts
+++ b/packages/cloudflare/test/client-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildRequestParts, getHttpTrait } from "@distilled.cloud/core/traits";
 import { transformCloudflareRequestParts } from "~/client/api";
-import { CreateAssetUploadRequest } from "~/services/workers";
+import { CreateAssetUploadRequest, PutScriptRequest } from "~/services/workers";
 
 describe("client api", () => {
   it("maps createAssetUpload jwtToken to a bearer authorization header", () => {
@@ -50,6 +50,59 @@ describe("client api", () => {
 
     expect(transformed.headers).toEqual({
       Authorization: "Bearer upload-session-jwt",
+    });
+  });
+
+  it("encodes Worker script uploads with ratelimit bindings", () => {
+    const httpTrait = getHttpTrait(PutScriptRequest.ast);
+    expect(httpTrait).toBeDefined();
+
+    const parts = buildRequestParts(
+      PutScriptRequest.ast,
+      httpTrait!,
+      {
+        accountId: "account-123",
+        scriptName: "rate-limited-worker",
+        metadata: {
+          mainModule: "index.mjs",
+          compatibilityDate: "2026-03-17",
+          bindings: [
+            {
+              type: "ratelimit",
+              name: "PUBLIC_SIGNUP_THROTTLE",
+              namespaceId: "10005",
+              simple: {
+                limit: 1,
+                period: 60,
+              },
+            },
+          ],
+        },
+        files: [
+          new File(["export default {}"], "index.mjs", {
+            type: "application/javascript+module",
+          }),
+        ],
+      },
+      PutScriptRequest,
+    );
+
+    expect(parts.body).toMatchObject({
+      metadata: {
+        main_module: "index.mjs",
+        compatibility_date: "2026-03-17",
+        bindings: [
+          {
+            type: "ratelimit",
+            name: "PUBLIC_SIGNUP_THROTTLE",
+            namespace_id: "10005",
+            simple: {
+              limit: 1,
+              period: 60,
+            },
+          },
+        ],
+      },
     });
   });
 });


### PR DESCRIPTION
Adds the missing `ratelimit` Worker script upload binding variant to the generated Cloudflare Workers SDK.

- Patches `putScript` request metadata bindings through the existing Cloudflare patch system
- Regenerates the Workers service and emitted OpenAPI spec
- Covers request encoding so `namespaceId` is sent as `namespace_id`
