### PR TITLE
fix(cloudflare/rulesets): support phase entrypoint paths

### DIFF
--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -476,9 +476,7 @@ function applyPatchToTypeInfo(typeInfo: TypeInfo, patch: PropertyPatch): void {
     typeInfo.values
   ) {
     for (const variant of patch.appendUnion) {
-      typeInfo.values.push(
-        JSON.parse(JSON.stringify(variant)) as TypeInfo,
-      );
+      typeInfo.values.push(JSON.parse(JSON.stringify(variant)) as TypeInfo);
     }
   }
 
@@ -534,14 +532,40 @@ interface ResolvedOperationModel {
   errors: OperationErrorInfo[];
 }
 
+const ACCOUNT_OR_ZONE_SCOPE_PATH_PARAMS = new Set([
+  "accountOrZone",
+  "accountOrZoneId",
+]);
+
+const withMissingUrlPathParams = (op: ParsedOperation): ParamInfo[] => {
+  const existing = new Set(op.pathParams.map((param) => param.name));
+  const missing = op.urlPathParams.filter(
+    (name) =>
+      !existing.has(name) && !ACCOUNT_OR_ZONE_SCOPE_PATH_PARAMS.has(name),
+  );
+  if (missing.length === 0) return op.pathParams;
+  return [
+    ...op.pathParams,
+    ...missing.map(
+      (name): ParamInfo => ({
+        name,
+        type: { kind: "primitive", value: "string" },
+        location: "path",
+        required: true,
+      }),
+    ),
+  ];
+};
+
 function resolveOperationModel(
   op: ParsedOperation,
   patch?: OperationPatch,
 ): ResolvedOperationModel {
   const syntheticHeaderParams = getSyntheticHeaderParams(op);
+  const pathParams = withMissingUrlPathParams(op);
 
   const nonBodyParamNames = new Set([
-    ...op.pathParams.map((p) => toCamelCase(p.name)),
+    ...pathParams.map((p) => toCamelCase(p.name)),
     ...op.queryParams.map((p) => toCamelCase(p.name)),
     ...op.headerParams.map((p) => toCamelCase(p.name)),
     ...syntheticHeaderParams.map((p) => toCamelCase(p.name)),
@@ -552,7 +576,7 @@ function resolveOperationModel(
   );
 
   const allParams = [
-    ...op.pathParams,
+    ...pathParams,
     ...op.queryParams,
     ...op.headerParams,
     ...syntheticHeaderParams,
@@ -562,7 +586,7 @@ function resolveOperationModel(
     type: resolveOperationTypeInfo(op, param.type),
   }));
 
-  const resolvedPathParams = op.pathParams.map((p) => ({
+  const resolvedPathParams = pathParams.map((p) => ({
     ...p,
     type: resolveOperationTypeInfo(op, p.type),
   }));
@@ -1233,9 +1257,10 @@ function generateOperationSchemaAst(
   }
 
   const syntheticHeaderParams = getSyntheticHeaderParams(op);
+  const pathParams = withMissingUrlPathParams(op);
 
   const nonBodyParamNames = new Set([
-    ...op.pathParams.map((p) => toCamelCase(p.name)),
+    ...pathParams.map((p) => toCamelCase(p.name)),
     ...op.queryParams.map((p) => toCamelCase(p.name)),
     ...op.headerParams.map((p) => toCamelCase(p.name)),
     ...syntheticHeaderParams.map((p) => toCamelCase(p.name)),
@@ -1246,7 +1271,7 @@ function generateOperationSchemaAst(
   );
 
   const allParams = [
-    ...op.pathParams,
+    ...pathParams,
     ...op.queryParams,
     ...op.headerParams,
     ...syntheticHeaderParams,
@@ -1256,7 +1281,7 @@ function generateOperationSchemaAst(
     type: resolveTypeInfoDeep(param.type, op.registry!),
   }));
 
-  const resolvedPathParams = op.pathParams.map((p) => ({
+  const resolvedPathParams = pathParams.map((p) => ({
     ...p,
     type: resolveTypeInfoDeep(p.type, op.registry!),
   }));
@@ -1336,7 +1361,10 @@ function generateOperationSchemaAst(
   for (const param of resolvedPathParams) {
     const propName = toCamelCase(param.name);
     const wireName = param.name;
-    const schema = typeInfoToSchema(param.type);
+    let schema = typeInfoToSchema(param.type);
+    if (!param.required) {
+      schema = `Schema.optional(${schema})`;
+    }
     requestProps.push(
       `  ${quotePropKey(propName)}: ${schema}.pipe(T.HttpPath("${wireName}"))`,
     );
@@ -1684,7 +1712,10 @@ function generateOperationSchema(
   for (const param of resolvedPathParams) {
     const propName = toCamelCase(param.name);
     const wireName = param.name;
-    const schema = typeInfoToSchema(param.type);
+    let schema = typeInfoToSchema(param.type);
+    if (!param.required) {
+      schema = `Schema.optional(${schema})`;
+    }
     requestProps.push(
       `  ${quotePropKey(propName)}: ${schema}.pipe(T.HttpPath("${wireName}"))`,
     );

--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -537,6 +537,10 @@ const ACCOUNT_OR_ZONE_SCOPE_PATH_PARAMS = new Set([
   "accountOrZoneId",
 ]);
 
+const isAccountOrZoneScoped = (op: ParsedOperation): boolean =>
+  op.urlPathParams.includes("accountOrZone") &&
+  op.urlPathParams.includes("accountOrZoneId");
+
 const withMissingUrlPathParams = (op: ParsedOperation): ParamInfo[] => {
   const existing = new Set(op.pathParams.map((param) => param.name));
   const missing = op.urlPathParams.filter(
@@ -1442,6 +1446,9 @@ function generateOperationSchemaAst(
       .join(", ");
     pipes.push(`Schema.encodeKeys({ ${encodeKeysEntries} })`);
   }
+  if (isAccountOrZoneScoped(op)) {
+    pipes.push("T.AccountOrZoneScope()");
+  }
   // Add contentType: "multipart" when operation has file uploads or uses multipartFormRequestOptions
   const hasFiles = operationHasFiles(op);
   const isMultipart = hasFiles || op.isMultipart;
@@ -1780,6 +1787,9 @@ function generateOperationSchema(
       .map(([k, v]) => `${quotePropKey(k)}: "${v}"`)
       .join(", ");
     pipes.push(`Schema.encodeKeys({ ${encodeKeysEntries} })`);
+  }
+  if (isAccountOrZoneScoped(op)) {
+    pipes.push("T.AccountOrZoneScope()");
   }
   const hasFiles = operationHasFiles(op);
   const isMultipart = hasFiles || op.isMultipart;

--- a/packages/cloudflare/specs/cloudflare/rulesets.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/rulesets.openapi.yml
@@ -9,6 +9,12 @@ paths:
   /{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint:
     get:
       operationId: getPhas
+      parameters:
+        - name: rulesetPhase
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -2721,6 +2727,11 @@ paths:
           required: true
           description: "Path param: The Zone ID to use for this endpoint. Mutually
             exclusive with the Account ID."
+          schema:
+            type: string
+        - name: rulesetPhase
+          in: path
+          required: true
           schema:
             type: string
       requestBody:
@@ -7803,6 +7814,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: rulesetPhase
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -10499,6 +10515,12 @@ paths:
   /{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint/versions:
     get:
       operationId: listPhasVersions
+      parameters:
+        - name: rulesetPhase
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -38,7 +38,12 @@ import {
 } from "../errors.ts";
 import { Credentials, formatHeaders } from "../credentials.ts";
 import { Retry } from "../retry.ts";
-import { type ErrorMatcher, getErrorMatchers } from "../traits.ts";
+import {
+  type AccountOrZoneScopeTrait,
+  type ErrorMatcher,
+  getAccountOrZoneScope,
+  getErrorMatchers,
+} from "../traits.ts";
 
 // ============================================================================
 // Global Cloudflare error codes
@@ -403,40 +408,22 @@ const ASSET_UPLOAD_PATH = "/accounts/{account_id}/workers/assets/upload";
 
 export const transformCloudflareRequestParts = ({
   input,
+  inputSchema,
   pathTemplate,
   parts,
 }: {
   input?: Record<string, unknown>;
+  inputSchema?: Schema.Top;
   pathTemplate: string;
   parts: RequestParts;
 }): RequestParts => {
   let next = parts;
+  const accountOrZoneScope = inputSchema
+    ? getAccountOrZoneScope(inputSchema.ast)
+    : undefined;
 
-  if (
-    pathTemplate.includes("/{accountOrZone}/{accountOrZoneId}/") &&
-    next.path.includes("{accountOrZone}") &&
-    next.path.includes("{accountOrZoneId}")
-  ) {
-    const accountId = input?.accountId;
-    const zoneId = input?.zoneId;
-    const hasAccountId = accountId !== undefined && accountId !== null;
-    const hasZoneId = zoneId !== undefined && zoneId !== null;
-
-    if (hasAccountId === hasZoneId) {
-      throw new Error(
-        "Cloudflare account-or-zone scoped requests require exactly one of accountId or zoneId",
-      );
-    }
-
-    next = {
-      ...next,
-      path: next.path
-        .replace("{accountOrZone}", hasAccountId ? "accounts" : "zones")
-        .replace(
-          "{accountOrZoneId}",
-          encodeURIComponent(String(hasAccountId ? accountId : zoneId)),
-        ),
-    };
+  if (accountOrZoneScope) {
+    next = applyAccountOrZoneScope(next, input, accountOrZoneScope);
   }
 
   if (pathTemplate !== ASSET_UPLOAD_PATH) {
@@ -457,14 +444,50 @@ export const transformCloudflareRequestParts = ({
   };
 };
 
+const applyAccountOrZoneScope = (
+  parts: RequestParts,
+  input: Record<string, unknown> | undefined,
+  scope: AccountOrZoneScopeTrait,
+): RequestParts => {
+  const accountIdParam = scope.accountIdParam ?? "accountId";
+  const zoneIdParam = scope.zoneIdParam ?? "zoneId";
+  const scopePathParam = scope.scopePathParam ?? "accountOrZone";
+  const scopeIdPathParam = scope.scopeIdPathParam ?? "accountOrZoneId";
+  const accountId = input?.[accountIdParam];
+  const zoneId = input?.[zoneIdParam];
+  const hasAccountId = accountId !== undefined && accountId !== null;
+  const hasZoneId = zoneId !== undefined && zoneId !== null;
+
+  if (hasAccountId === hasZoneId) {
+    throw new Error(
+      "Cloudflare account-or-zone scoped requests require exactly one of accountId or zoneId",
+    );
+  }
+
+  return {
+    ...parts,
+    path: parts.path
+      .replace(`{${scopePathParam}}`, hasAccountId ? "accounts" : "zones")
+      .replace(
+        `{${scopeIdPathParam}}`,
+        encodeURIComponent(String(hasAccountId ? accountId : zoneId)),
+      ),
+  };
+};
+
 const _API = makeAPI<Credentials>({
   credentials: Credentials as any,
   getBaseUrl: (creds: any) => creds.apiBaseUrl,
   getAuthHeaders: formatHeaders as any,
   matchError,
   ParseError: CloudflareDecodeError as any,
-  transformRequestParts: ({ input, pathTemplate, parts }) =>
-    transformCloudflareRequestParts({ input, pathTemplate, parts }),
+  transformRequestParts: ({ input, inputSchema, pathTemplate, parts }) =>
+    transformCloudflareRequestParts({
+      input,
+      inputSchema,
+      pathTemplate,
+      parts,
+    }),
   retry: Retry as any,
 });
 

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -402,25 +402,56 @@ class CloudflareDecodeError extends CloudflareHttpError {
 const ASSET_UPLOAD_PATH = "/accounts/{account_id}/workers/assets/upload";
 
 export const transformCloudflareRequestParts = ({
+  input,
   pathTemplate,
   parts,
 }: {
+  input?: Record<string, unknown>;
   pathTemplate: string;
   parts: RequestParts;
 }): RequestParts => {
-  if (pathTemplate !== ASSET_UPLOAD_PATH) {
-    return parts;
+  let next = parts;
+
+  if (
+    pathTemplate.includes("/{accountOrZone}/{accountOrZoneId}/") &&
+    next.path.includes("{accountOrZone}") &&
+    next.path.includes("{accountOrZoneId}")
+  ) {
+    const accountId = input?.accountId;
+    const zoneId = input?.zoneId;
+    const hasAccountId = accountId !== undefined && accountId !== null;
+    const hasZoneId = zoneId !== undefined && zoneId !== null;
+
+    if (hasAccountId === hasZoneId) {
+      throw new Error(
+        "Cloudflare account-or-zone scoped requests require exactly one of accountId or zoneId",
+      );
+    }
+
+    next = {
+      ...next,
+      path: next.path
+        .replace("{accountOrZone}", hasAccountId ? "accounts" : "zones")
+        .replace(
+          "{accountOrZoneId}",
+          encodeURIComponent(String(hasAccountId ? accountId : zoneId)),
+        ),
+    };
   }
 
-  const authorization = parts.headers.Authorization;
+  if (pathTemplate !== ASSET_UPLOAD_PATH) {
+    return next;
+  }
+
+  const authorization = next.headers.Authorization;
   if (!authorization || authorization.startsWith("Bearer ")) {
-    return parts;
+    return next;
   }
 
   return {
-    ...parts,
+    ...next,
     headers: {
-      ...parts.headers,
+      ...next.headers,
       Authorization: `Bearer ${authorization}`,
     },
   };
@@ -432,8 +463,8 @@ const _API = makeAPI<Credentials>({
   getAuthHeaders: formatHeaders as any,
   matchError,
   ParseError: CloudflareDecodeError as any,
-  transformRequestParts: ({ pathTemplate, parts }) =>
-    transformCloudflareRequestParts({ pathTemplate, parts }),
+  transformRequestParts: ({ input, pathTemplate, parts }) =>
+    transformCloudflareRequestParts({ input, pathTemplate, parts }),
   retry: Retry as any,
 });
 

--- a/packages/cloudflare/src/services/rulesets.ts
+++ b/packages/cloudflare/src/services/rulesets.ts
@@ -24,6 +24,7 @@ export interface GetPhasRequest {
 export const GetPhasRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "GET",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint",
@@ -5849,6 +5850,7 @@ export const PutPhasRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ),
   ),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "PUT",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint",
@@ -9351,6 +9353,7 @@ export const GetPhasVersionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
   rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "GET",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint/versions/{rulesetVersion}",
@@ -12902,6 +12905,7 @@ export const ListPhasVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
   }).pipe(
+    T.AccountOrZoneScope(),
     T.Http({
       method: "GET",
       path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint/versions",
@@ -13152,6 +13156,7 @@ export const CreateRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ratelimit: "ratelimit",
     ref: "ref",
   }),
+  T.AccountOrZoneScope(),
   T.Http({
     method: "POST",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/rules",
@@ -16782,6 +16787,7 @@ export const PatchRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ratelimit: "ratelimit",
     ref: "ref",
   }),
+  T.AccountOrZoneScope(),
   T.Http({
     method: "PATCH",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/rules/{ruleId}",
@@ -20282,6 +20288,7 @@ export const DeleteRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "DELETE",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/rules/{ruleId}",
@@ -23784,6 +23791,7 @@ export interface GetRulesetRequest {
 export const GetRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "GET",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}",
@@ -27280,6 +27288,7 @@ export interface ListRulesetsRequest {}
 export const ListRulesetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
   {},
 ).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "GET",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets",
@@ -29794,6 +29803,7 @@ export const CreateRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ),
   ),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "POST",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets",
@@ -35676,6 +35686,7 @@ export const UpdateRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ),
   ),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "PUT",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}",
@@ -39174,6 +39185,7 @@ export interface DeleteRulesetRequest {
 export const DeleteRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "DELETE",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}",
@@ -39211,6 +39223,7 @@ export const GetVersionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "GET",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/versions/{rulesetVersion}",
@@ -42709,6 +42722,7 @@ export interface ListVersionsRequest {
 export const ListVersionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "GET",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/versions",
@@ -42824,6 +42838,7 @@ export const DeleteVersionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
 }).pipe(
+  T.AccountOrZoneScope(),
   T.Http({
     method: "DELETE",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/versions/{rulesetVersion}",

--- a/packages/cloudflare/src/services/rulesets.ts
+++ b/packages/cloudflare/src/services/rulesets.ts
@@ -17,11 +17,13 @@ import { SensitiveString } from "../sensitive.ts";
 // Pha
 // =============================================================================
 
-export interface GetPhasRequest {}
+export interface GetPhasRequest {
+  rulesetPhase: string;
+}
 
-export const GetPhasRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).pipe(
+export const GetPhasRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
+}).pipe(
   T.Http({
     method: "GET",
     path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint",
@@ -3516,6 +3518,7 @@ export interface PutPhasRequest {
   accountId?: string;
   /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
   zoneId?: string;
+  rulesetPhase: string;
   /** Body param: An informative description of the ruleset. */
   description?: string;
   /** Body param: The human-readable name of the ruleset. */
@@ -4141,8 +4144,9 @@ export interface PutPhasRequest {
 }
 
 export const PutPhasRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+  accountId: Schema.optional(Schema.String).pipe(T.HttpPath("account_id")),
+  zoneId: Schema.optional(Schema.String).pipe(T.HttpPath("zone_id")),
+  rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
   description: Schema.optional(Schema.String),
   name: Schema.optional(Schema.String),
   rules: Schema.optional(
@@ -9340,10 +9344,12 @@ export const putPhas: API.OperationMethod<
 
 export interface GetPhasVersionRequest {
   rulesetVersion: string;
+  rulesetPhase: string;
 }
 
 export const GetPhasVersionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
+  rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
 }).pipe(
   T.Http({
     method: "GET",
@@ -12888,10 +12894,14 @@ export const getPhasVersion: API.OperationMethod<
   errors: [],
 }));
 
-export interface ListPhasVersionsRequest {}
+export interface ListPhasVersionsRequest {
+  rulesetPhase: string;
+}
 
 export const ListPhasVersionsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
+  }).pipe(
     T.Http({
       method: "GET",
       path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint/versions",
@@ -13051,8 +13061,8 @@ export interface CreateRuleRequest {
 
 export const CreateRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+  accountId: Schema.optional(Schema.String).pipe(T.HttpPath("account_id")),
+  zoneId: Schema.optional(Schema.String).pipe(T.HttpPath("zone_id")),
   id: Schema.optional(Schema.String),
   action: Schema.optional(Schema.Literal("block")),
   actionParameters: Schema.optional(
@@ -16681,8 +16691,8 @@ export interface PatchRuleRequest {
 export const PatchRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+  accountId: Schema.optional(Schema.String).pipe(T.HttpPath("account_id")),
+  zoneId: Schema.optional(Schema.String).pipe(T.HttpPath("zone_id")),
   id: Schema.optional(Schema.String),
   action: Schema.optional(Schema.Literal("block")),
   actionParameters: Schema.optional(
@@ -28054,8 +28064,8 @@ export interface CreateRulesetRequest {
 }
 
 export const CreateRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+  accountId: Schema.optional(Schema.String).pipe(T.HttpPath("account_id")),
+  zoneId: Schema.optional(Schema.String).pipe(T.HttpPath("zone_id")),
   kind: Schema.Literals(["managed", "custom", "root", "zone"]),
   name: Schema.String,
   phase: Schema.Literals([
@@ -33934,8 +33944,8 @@ export interface UpdateRulesetRequest {
 
 export const UpdateRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+  accountId: Schema.optional(Schema.String).pipe(T.HttpPath("account_id")),
+  zoneId: Schema.optional(Schema.String).pipe(T.HttpPath("zone_id")),
   description: Schema.optional(Schema.String),
   kind: Schema.optional(Schema.Literals(["managed", "custom", "root", "zone"])),
   name: Schema.optional(Schema.String),

--- a/packages/cloudflare/src/traits.ts
+++ b/packages/cloudflare/src/traits.ts
@@ -37,6 +37,24 @@ export const applyErrorMatchers = (
 export const getErrorMatchers = (ast: AST.AST) =>
   getAnnotation<ErrorMatcher[]>(ast, errorMatchersSymbol);
 
+/** Symbol for operations scoped by either a Cloudflare account or zone. */
+export const accountOrZoneScopeSymbol = Symbol.for(
+  "@distilled.cloud/cf/account-or-zone-scope",
+);
+
+export interface AccountOrZoneScopeTrait {
+  accountIdParam?: string;
+  zoneIdParam?: string;
+  scopePathParam?: string;
+  scopeIdPathParam?: string;
+}
+
+export const AccountOrZoneScope = (trait: AccountOrZoneScopeTrait = {}) =>
+  makeAnnotation(accountOrZoneScopeSymbol, trait);
+
+export const getAccountOrZoneScope = (ast: AST.AST) =>
+  getAnnotation<AccountOrZoneScopeTrait>(ast, accountOrZoneScopeSymbol);
+
 /** Symbol for content type override (e.g., multipart) */
 export const contentTypeSymbol = Symbol.for("@distilled.cloud/cf/content-type");
 

--- a/packages/cloudflare/test/client-api.test.ts
+++ b/packages/cloudflare/test/client-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildRequestParts, getHttpTrait } from "@distilled.cloud/core/traits";
 import { transformCloudflareRequestParts } from "~/client/api";
+import { PutPhasRequest } from "~/services/rulesets";
 import { CreateAssetUploadRequest, PutScriptRequest } from "~/services/workers";
 
 describe("client api", () => {
@@ -26,6 +27,12 @@ describe("client api", () => {
     expect(parts.body).toEqual({ asset: "ZGF0YQ==" });
 
     const transformed = transformCloudflareRequestParts({
+      input: {
+        accountId: "account-123",
+        base64: true,
+        jwtToken: "upload-session-jwt",
+        body: { asset: "ZGF0YQ==" },
+      },
       pathTemplate: httpTrait!.path,
       parts,
     });
@@ -38,6 +45,7 @@ describe("client api", () => {
 
   it("does not double-prefix an existing bearer header", () => {
     const transformed = transformCloudflareRequestParts({
+      input: {},
       pathTemplate: "/accounts/{account_id}/workers/assets/upload",
       parts: {
         path: "/accounts/account-123/workers/assets/upload",
@@ -104,5 +112,52 @@ describe("client api", () => {
         ],
       },
     });
+  });
+
+  it("maps account-or-zone scoped ruleset paths to zones", () => {
+    const httpTrait = getHttpTrait(PutPhasRequest.ast);
+    expect(httpTrait).toBeDefined();
+
+    const input = {
+      zoneId: "zone-123",
+      rulesetPhase: "http_request_firewall_custom",
+      rules: [
+        {
+          action: "block" as const,
+          expression: "true",
+          description: "Block everything",
+        },
+      ],
+    };
+
+    const parts = buildRequestParts(
+      PutPhasRequest.ast,
+      httpTrait!,
+      input,
+      PutPhasRequest,
+    );
+
+    expect(parts.path).toEqual(
+      "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/http_request_firewall_custom/entrypoint",
+    );
+    expect(parts.body).toEqual({
+      rules: [
+        {
+          action: "block",
+          expression: "true",
+          description: "Block everything",
+        },
+      ],
+    });
+
+    const transformed = transformCloudflareRequestParts({
+      input,
+      pathTemplate: httpTrait!.path,
+      parts,
+    });
+
+    expect(transformed.path).toEqual(
+      "/zones/zone-123/rulesets/phases/http_request_firewall_custom/entrypoint",
+    );
   });
 });

--- a/packages/cloudflare/test/client-api.test.ts
+++ b/packages/cloudflare/test/client-api.test.ts
@@ -152,6 +152,7 @@ describe("client api", () => {
 
     const transformed = transformCloudflareRequestParts({
       input,
+      inputSchema: PutPhasRequest,
       pathTemplate: httpTrait!.path,
       parts,
     });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -177,6 +177,7 @@ export interface ClientConfig<Creds> {
    */
   transformRequestParts?: (input: {
     input: Record<string, unknown>;
+    inputSchema: Schema.Top;
     method: string;
     pathTemplate: string;
     parts: Traits.RequestParts;
@@ -472,6 +473,7 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           if (config.transformRequestParts) {
             parts = config.transformRequestParts({
               input: input as Record<string, unknown>,
+              inputSchema,
               method,
               pathTemplate: httpTrait.path,
               parts,


### PR DESCRIPTION
Fixes generated Cloudflare Rulesets phase-entrypoint requests so the SDK can call endpoints such as `/zones/{zone_id}/rulesets/phases/{rulesetPhase}/entrypoint`.

- synthesizes missing URL path params such as `rulesetPhase` during generation
- keeps optional generated path params optional in request schemas
- maps Cloudflare `{accountOrZone}/{accountOrZoneId}` paths from exactly one of `accountId` or `zoneId`
- adds request-building coverage for zone-scoped Rulesets entrypoint updates

Verification run:

- `bun --filter '@distilled.cloud/cloudflare' test --run test/client-api.test.ts`
- `bun --filter '@distilled.cloud/cloudflare' typecheck`
- `bun --filter '@distilled.cloud/cloudflare' check`
- `git diff --check`
