### PR TITLE
fix(gcp): apply error matchers via AST + typed 4xx errors for cloudresourcemanager v3

### DIFF
--- a/packages/gcp/patches/cloudresourcemanager/createProjects.json
+++ b/packages/gcp/patches/cloudresourcemanager/createProjects.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/cloudresourcemanager/deleteProjects.json
+++ b/packages/gcp/patches/cloudresourcemanager/deleteProjects.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "NotFound": [{ "httpStatus": 404 }]
+  }
+}

--- a/packages/gcp/patches/cloudresourcemanager/getOperations.json
+++ b/packages/gcp/patches/cloudresourcemanager/getOperations.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "Forbidden": [{ "httpStatus": 403 }],
+    "NotFound": [{ "httpStatus": 404 }]
+  }
+}

--- a/packages/gcp/patches/cloudresourcemanager/getProjects.json
+++ b/packages/gcp/patches/cloudresourcemanager/getProjects.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/cloudresourcemanager/patchProjects.json
+++ b/packages/gcp/patches/cloudresourcemanager/patchProjects.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "NotFound": [{ "httpStatus": 404 }]
+  }
+}

--- a/packages/gcp/src/services/cloudresourcemanager-v3.ts
+++ b/packages/gcp/src/services/cloudresourcemanager-v3.ts
@@ -940,6 +940,52 @@ export const TestIamPermissionsRequest =
   }).annotate({ identifier: "TestIamPermissionsRequest" });
 
 // ==========================================================================
+// Errors
+// ==========================================================================
+
+export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
+  "BadRequest",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
+
+export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
+  "Forbidden",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
+
+export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+  code: Schema.optional(Schema.Number),
+  message: Schema.String,
+  status: Schema.optional(Schema.String),
+  reason: Schema.optional(Schema.String),
+  domain: Schema.optional(Schema.String),
+}) {}
+T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
+
+export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
+  code: Schema.optional(Schema.Number),
+  message: Schema.String,
+  status: Schema.optional(Schema.String),
+  reason: Schema.optional(Schema.String),
+  domain: Schema.optional(Schema.String),
+}) {}
+T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
+
+// ==========================================================================
 // Operations
 // ==========================================================================
 
@@ -1702,7 +1748,7 @@ export const GetProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 export type GetProjectsResponse = Project;
 export const GetProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Project;
 
-export type GetProjectsError = DefaultErrors;
+export type GetProjectsError = DefaultErrors | NotFound | Forbidden;
 
 /** Retrieves the project identified by the specified `name` (for example, `projects/415104041262`). The caller must have `resourcemanager.projects.get` permission for this project. */
 export const getProjects: API.OperationMethod<
@@ -1713,7 +1759,7 @@ export const getProjects: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetProjectsRequest,
   output: GetProjectsResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface DeleteProjectsRequest {
@@ -1731,7 +1777,11 @@ export const DeleteProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 export type DeleteProjectsResponse = Operation;
 export const DeleteProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type DeleteProjectsError = DefaultErrors;
+export type DeleteProjectsError =
+  | DefaultErrors
+  | BadRequest
+  | Forbidden
+  | NotFound;
 
 /** Marks the project identified by the specified `name` (for example, `projects/415104041262`) for deletion. This method will only affect the project if it has a lifecycle state of ACTIVE. This method changes the Project's lifecycle state from ACTIVE to DELETE_REQUESTED. The deletion starts at an unspecified time, at which point the Project is no longer accessible. Until the deletion completes, you can check the lifecycle state checked by retrieving the project with GetProject, and the project remains visible to ListProjects. However, you cannot update the project. After the deletion completes, the project is not retrievable by the GetProject, ListProjects, and SearchProjects methods. The caller must have `resourcemanager.projects.delete` permissions for this project. */
 export const deleteProjects: API.OperationMethod<
@@ -1742,7 +1792,7 @@ export const deleteProjects: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteProjectsRequest,
   output: DeleteProjectsResponse,
-  errors: [],
+  errors: [BadRequest, Forbidden, NotFound],
 }));
 
 export interface PatchProjectsRequest {
@@ -1766,7 +1816,11 @@ export const PatchProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 export type PatchProjectsResponse = Operation;
 export const PatchProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type PatchProjectsError = DefaultErrors;
+export type PatchProjectsError =
+  | DefaultErrors
+  | BadRequest
+  | Forbidden
+  | NotFound;
 
 /** Updates the `display_name` and labels of the project identified by the specified `name` (for example, `projects/415104041262`). Deleting all labels requires an update mask for labels field. The caller must have `resourcemanager.projects.update` permission for this project. */
 export const patchProjects: API.OperationMethod<
@@ -1777,7 +1831,7 @@ export const patchProjects: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: PatchProjectsRequest,
   output: PatchProjectsResponse,
-  errors: [],
+  errors: [BadRequest, Forbidden, NotFound],
 }));
 
 export interface SetIamPolicyProjectsRequest {
@@ -2063,7 +2117,11 @@ export const CreateProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 export type CreateProjectsResponse = Operation;
 export const CreateProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type CreateProjectsError = DefaultErrors;
+export type CreateProjectsError =
+  | DefaultErrors
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Request that a new project be created. The result is an `Operation` which can be used to track the creation process. This process usually takes a few seconds, but can sometimes take much longer. The tracking `Operation` is automatically deleted after a few hours, so there is no need to call `DeleteOperation`. */
 export const createProjects: API.OperationMethod<
@@ -2074,7 +2132,7 @@ export const createProjects: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateProjectsRequest,
   output: CreateProjectsResponse,
-  errors: [],
+  errors: [BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetIamPolicyOrganizationsRequest {
@@ -2601,7 +2659,7 @@ export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 export type GetOperationsResponse = Operation;
 export const GetOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type GetOperationsError = DefaultErrors;
+export type GetOperationsError = DefaultErrors | Forbidden | NotFound;
 
 /** Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service. */
 export const getOperations: API.OperationMethod<
@@ -2612,7 +2670,7 @@ export const getOperations: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetOperationsRequest,
   output: GetOperationsResponse,
-  errors: [],
+  errors: [Forbidden, NotFound],
 }));
 
 export interface ListTagValuesRequest {

--- a/packages/gcp/src/traits.ts
+++ b/packages/gcp/src/traits.ts
@@ -3,7 +3,8 @@
  */
 export * from "@distilled.cloud/core/traits";
 
-import { makeAnnotation } from "@distilled.cloud/core/traits";
+import { getAnnotation } from "@distilled.cloud/core/traits";
+import * as AST from "effect/SchemaAST";
 
 // =============================================================================
 // GCP-specific Error Matcher Traits
@@ -23,16 +24,17 @@ export interface ErrorMatcher {
 }
 
 /**
- * Apply error matchers to an error class.
- * Mutates the class's schema AST to annotate it with error matchers.
+ * Apply error matchers directly to a class's AST annotations.
+ * Used for TaggedErrorClass where .pipe() on a class returns a schema
+ * (not a class), breaking `extends ... .pipe(...)`.
  */
 export const applyErrorMatchers = (
-  cls: any,
+  cls: { ast: AST.AST },
   matchers: ErrorMatcher[],
 ): void => {
-  const annotation = makeAnnotation(errorMatchersSymbol, matchers);
-  // Apply annotation to the class's AST if possible
-  if (cls && typeof cls === "function" && cls.ast) {
-    annotation(cls.ast);
-  }
+  const annotations = cls.ast.annotations as Record<symbol, unknown>;
+  annotations[errorMatchersSymbol] = matchers;
 };
+
+export const getErrorMatchers = (ast: AST.AST) =>
+  getAnnotation<ErrorMatcher[]>(ast, errorMatchersSymbol);


### PR DESCRIPTION
Two related GCP fixes:

### `applyErrorMatchers` was broken

Any operation patch that declared `errors` triggered:

```
TypeError: schema.annotate is not a function.
    at applyErrorMatchers (packages/gcp/src/traits.ts:36)
```

The implementation routed through `makeAnnotation(...)` which calls `.annotate(...)` on its argument — that only works for full Schemas, not the raw AST nodes a `TaggedErrorClass` exposes via `cls.ast`. Because no GCP service had patches in-tree, the broken codepath was unexercised.

Mirror the working `@distilled.cloud/cloudflare/traits.ts` approach: mutate `cls.ast.annotations[errorMatchersSymbol] = matchers` directly.

```diff
-import { makeAnnotation } from "@distilled.cloud/core/traits";
+import { getAnnotation } from "@distilled.cloud/core/traits";
+import * as AST from "effect/SchemaAST";

 export const applyErrorMatchers = (
-  cls: any,
+  cls: { ast: AST.AST },
   matchers: ErrorMatcher[],
 ): void => {
-  const annotation = makeAnnotation(errorMatchersSymbol, matchers);
-  if (cls && typeof cls === "function" && cls.ast) {
-    annotation(cls.ast);
-  }
+  const annotations = cls.ast.annotations as Record<symbol, unknown>;
+  annotations[errorMatchersSymbol] = matchers;
 };
```

### Typed 4xx errors for cloudresourcemanager v3

Add per-operation patches for `getProjects`, `createProjects`, `patchProjects`, `deleteProjects`, `getOperations` declaring the 4xx tags `matchError` already emits at runtime via `HTTP_STATUS_MAP`.

```ts
// before
export type GetProjectsError = DefaultErrors;
export type CreateProjectsError = DefaultErrors;

// after
export type GetProjectsError    = DefaultErrors | NotFound | Forbidden;
export type CreateProjectsError = DefaultErrors | BadRequest | Forbidden | Conflict;
export type PatchProjectsError  = DefaultErrors | BadRequest | Forbidden | NotFound;
export type DeleteProjectsError = DefaultErrors | BadRequest | Forbidden | NotFound;
export type GetOperationsError  = DefaultErrors | Forbidden | NotFound;
```

Without these, callers have to ad-hoc match `(e as any)?._tag === "NotFound"` because `Effect.catchTag("NotFound", ...)` won't narrow against `DefaultErrors`.

Regenerated with `bun run scripts/generate.ts --service cloudresourcemanager --version v3`.
