### PR TITLE
fix(gcp): emit ReadonlyArray<T> in struct interfaces to match Schema.Array

### DIFF
--- a/packages/gcp/scripts/generate.ts
+++ b/packages/gcp/scripts/generate.ts
@@ -591,10 +591,18 @@ function propertyToTsType(
       return "boolean";
 
     case "array":
+      // Emit `ReadonlyArray<T>` (not `Array<T>`) so the interface matches
+      // what `Schema.Type<typeof Schema.Array(...)>` produces. Without
+      // this, the schema-derived value type is `readonly T[]` while the
+      // hand-emitted interface declares mutable `T[]`, and TS rejects
+      // `readonly T[]` → `T[]` in operation method signatures (see e.g.
+      // cloudresourcemanager-v3 `getOperations` / `listTagBindings`).
+      // `ReadonlyArray<T>` is a supertype of `T[]`, so callers building
+      // requests with array literals stay compatible.
       if (prop.items) {
-        return `Array<${propertyToTsType(prop.items, allSchemas, renames)}>`;
+        return `ReadonlyArray<${propertyToTsType(prop.items, allSchemas, renames)}>`;
       }
-      return "Array<unknown>";
+      return "ReadonlyArray<unknown>";
 
     case "object":
       if (prop.additionalProperties) {

--- a/packages/gcp/src/services/cloudresourcemanager-v3.ts
+++ b/packages/gcp/src/services/cloudresourcemanager-v3.ts
@@ -67,7 +67,7 @@ export const TagKey = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface ListTagKeysResponse {
   /** List of TagKeys that live under the specified parent in the request. */
-  tagKeys?: Array<TagKey>;
+  tagKeys?: ReadonlyArray<TagKey>;
   /** A pagination token returned from a previous call to `ListTagKeys` that indicates from where listing should continue. */
   nextPageToken?: string;
 }
@@ -109,7 +109,7 @@ export const TagValue = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface ListTagValuesResponse {
   /** A possibly paginated list of TagValues that are direct descendants of the specified parent TagKey. */
-  tagValues?: Array<TagValue>;
+  tagValues?: ReadonlyArray<TagValue>;
   /** A pagination token returned from a previous call to `ListTagValues` that indicates from where listing should continue. */
   nextPageToken?: string;
 }
@@ -151,7 +151,7 @@ export const Organization = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface TestIamPermissionsResponse {
   /** A subset of `TestPermissionsRequest.permissions` that the caller is allowed. */
-  permissions?: Array<string>;
+  permissions?: ReadonlyArray<string>;
 }
 
 export const TestIamPermissionsResponse =
@@ -197,7 +197,7 @@ export interface Project {
   /** Immutable. The unique, user-assigned id of the project. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: `tokyo-rain-123` */
   projectId?: string;
   /** Output only. If this project is a Management Project, list of capabilities configured on the parent folder. Note, presence of any capability implies that this is a Management Project. Example: `folders/123/capabilities/app-management`. OUTPUT ONLY. */
-  configuredCapabilities?: Array<string>;
+  configuredCapabilities?: ReadonlyArray<string>;
   /** Optional. A reference to a parent Resource. eg., `organizations/123` or `folders/876`. */
   parent?: string;
   /** Optional. A user-assigned display name of the project. When present it must be between 4 to 30 characters. Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point. Example: `My Project` */
@@ -253,7 +253,7 @@ export interface ListEffectiveTagsResponse {
   /** Pagination token. If the result set is too large to fit in a single response, this token is returned. It encodes the position of the current result cursor. Feeding this value into a new list request with the `page_token` parameter gives the next page of the results. When `next_page_token` is not filled in, there is no next page and the list returned is the last page in the result set. Pagination tokens have a limited lifetime. */
   nextPageToken?: string;
   /** A possibly paginated list of effective tags for the specified resource. */
-  effectiveTags?: Array<EffectiveTag>;
+  effectiveTags?: ReadonlyArray<EffectiveTag>;
 }
 
 export const ListEffectiveTagsResponse =
@@ -284,7 +284,7 @@ export interface Lien {
   /** A reference to the resource this Lien is attached to. The server will validate the parent against those for which Liens are supported. Example: `projects/1234` */
   parent?: string;
   /** The types of operations which should be blocked as a result of this Lien. Each value should correspond to an IAM permission. The server will validate the permissions against those for which Liens are supported. An empty list is meaningless and will be rejected. Example: ['resourcemanager.projects.delete'] */
-  restrictions?: Array<string>;
+  restrictions?: ReadonlyArray<string>;
   /** Concise user-visible strings indicating why an action cannot be performed on a resource. Maximum length of 200 characters. Example: 'Holds production API key' */
   reason?: string;
   /** A system-generated unique identifier for this Lien. Example: `liens/1234abcd` */
@@ -306,7 +306,7 @@ export const Lien = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface ListLiensResponse {
   /** A list of Liens. */
-  liens?: Array<Lien>;
+  liens?: ReadonlyArray<Lien>;
   /** Token to retrieve the next page of results, or empty if there are no more results in the list. */
   nextPageToken?: string;
 }
@@ -342,7 +342,7 @@ export const TagBinding = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface ListTagBindingsResponse {
   /** A possibly paginated list of TagBindings for the specified resource. */
-  tagBindings?: Array<TagBinding>;
+  tagBindings?: ReadonlyArray<TagBinding>;
   /** Pagination token. If the result set is too large to fit in a single response, this token is returned. It encodes the position of the current result cursor. Feeding this value into a new list request with the `page_token` parameter gives the next page of the results. When `next_page_token` is not filled in, there is no next page and the list returned is the last page in the result set. Pagination tokens have a limited lifetime. */
   nextPageToken?: string;
 }
@@ -397,7 +397,7 @@ export interface Status {
   /** A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client. */
   message?: string;
   /** A list of messages that carry the error details. There is a common set of message types for APIs to use. */
-  details?: Array<Record<string, unknown>>;
+  details?: ReadonlyArray<Record<string, unknown>>;
 }
 
 export const Status = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -449,7 +449,7 @@ export const Expr = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface Binding {
   /** Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`. */
-  members?: Array<string>;
+  members?: ReadonlyArray<string>;
   /** The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). */
   condition?: Expr;
   /** Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles). */
@@ -464,7 +464,7 @@ export const Binding = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface AuditLogConfig {
   /** Specifies the identities that do not cause logging for this type of permission. Follows the same format of Binding.members. */
-  exemptedMembers?: Array<string>;
+  exemptedMembers?: ReadonlyArray<string>;
   /** The log type that this config enables. */
   logType?:
     | "LOG_TYPE_UNSPECIFIED"
@@ -481,7 +481,7 @@ export const AuditLogConfig = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface AuditConfig {
   /** The configuration for logging of each type of permission. */
-  auditLogConfigs?: Array<AuditLogConfig>;
+  auditLogConfigs?: ReadonlyArray<AuditLogConfig>;
   /** Specifies a service that will be enabled for audit logging. For example, `storage.googleapis.com`, `cloudsql.googleapis.com`. `allServices` is a special value that covers all services. */
   service?: string;
 }
@@ -497,9 +497,9 @@ export interface Policy {
   /** Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). */
   version?: number;
   /** Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`. */
-  bindings?: Array<Binding>;
+  bindings?: ReadonlyArray<Binding>;
   /** Specifies cloud audit logging configuration for this policy. */
-  auditConfigs?: Array<AuditConfig>;
+  auditConfigs?: ReadonlyArray<AuditConfig>;
 }
 
 export const Policy = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -525,7 +525,7 @@ export interface SearchProjectsResponse {
   /** Pagination token. If the result set is too large to fit in a single response, this token is returned. It encodes the position of the current result cursor. Feeding this value into a new list request with the `page_token` parameter gives the next page of the results. When `next_page_token` is not filled in, there is no next page and the list returned is the last page in the result set. Pagination tokens have a limited lifetime. */
   nextPageToken?: string;
   /** The list of Projects that matched the list filter query. This list can be paginated. */
-  projects?: Array<Project>;
+  projects?: ReadonlyArray<Project>;
 }
 
 export const SearchProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -551,7 +551,7 @@ export interface Folder {
   /** Output only. Timestamp when the folder was requested to be deleted. */
   deleteTime?: string;
   /** Output only. Optional capabilities configured for this folder (via UpdateCapability API). Example: `folders/123/capabilities/app-management`. */
-  configuredCapabilities?: Array<string>;
+  configuredCapabilities?: ReadonlyArray<string>;
   /** Output only. The lifecycle state of the folder. Updates to the state must be performed using DeleteFolder and UndeleteFolder. */
   state?: "STATE_UNSPECIFIED" | "ACTIVE" | "DELETE_REQUESTED" | (string & {});
   /** Output only. A checksum computed by the server based on the current value of the folder resource. This may be sent on update and delete requests to ensure the client has an up-to-date value before proceeding. */
@@ -578,7 +578,7 @@ export interface ListFoldersResponse {
   /** A pagination token returned from a previous call to `ListFolders` that indicates from where listing should continue. */
   nextPageToken?: string;
   /** A possibly paginated list of folders that are direct descendants of the specified parent resource. */
-  folders?: Array<Folder>;
+  folders?: ReadonlyArray<Folder>;
 }
 
 export const ListFoldersResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -734,7 +734,7 @@ export const CreateTagKeyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 
 export interface SearchOrganizationsResponse {
   /** The list of Organizations that matched the search query, possibly paginated. */
-  organizations?: Array<Organization>;
+  organizations?: ReadonlyArray<Organization>;
   /** A pagination token to be used to retrieve the next page of results. If the result is too large to fit within the page size specified in the request, this field will be set with a token that can be used to fetch the next page of results. If this field is empty, it indicates that this response contains the last page of results. */
   nextPageToken?: string;
 }
@@ -792,7 +792,7 @@ export interface ListProjectsResponse {
   /** Pagination token. If the result set is too large to fit in a single response, this token is returned. It encodes the position of the current result cursor. Feeding this value into a new list request with the `page_token` parameter gives the next page of the results. When `next_page_token` is not filled in, there is no next page and the list returned is the last page in the result set. Pagination tokens have a limited lifetime. */
   nextPageToken?: string;
   /** The list of Projects under the parent. This list can be paginated. */
-  projects?: Array<Project>;
+  projects?: ReadonlyArray<Project>;
 }
 
 export const ListProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -851,7 +851,7 @@ export interface ListTagHoldsResponse {
   /** Pagination token. If the result set is too large to fit in a single response, this token is returned. It encodes the position of the current result cursor. Feeding this value into a new list request with the `page_token` parameter gives the next page of the results. When `next_page_token` is not filled in, there is no next page and the list returned is the last page in the result set. Pagination tokens have a limited lifetime. */
   nextPageToken?: string;
   /** A possibly paginated list of TagHolds. */
-  tagHolds?: Array<TagHold>;
+  tagHolds?: ReadonlyArray<TagHold>;
 }
 
 export const ListTagHoldsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -883,7 +883,7 @@ export const FolderOperation = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface SearchFoldersResponse {
   /** A possibly paginated folder search results. the specified parent resource. */
-  folders?: Array<Folder>;
+  folders?: ReadonlyArray<Folder>;
   /** A pagination token returned from a previous call to `SearchFolders` that indicates from where searching should continue. */
   nextPageToken?: string;
 }
@@ -931,7 +931,7 @@ export const CreateProjectMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface TestIamPermissionsRequest {
   /** The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions). */
-  permissions?: Array<string>;
+  permissions?: ReadonlyArray<string>;
 }
 
 export const TestIamPermissionsRequest =


### PR DESCRIPTION
The GCP codegen emits two parallel artifacts per schema — a TS `interface` and an Effect `Schema.Struct` — and they currently disagree on array variance.

```ts
// before — interface and schema disagree:
export interface ListTagBindingsResponse {
  tagBindings?: Array<TagBinding>;                                 // mutable
}
export const ListTagBindingsResponse = Schema.Struct({
  tagBindings: Schema.optional(Schema.Array(TagBinding)),          // → readonly
});
```

`Schema.Type<typeof Schema.Array(...)>` is `readonly T[]`. When `API.make` infers the operation's response type from the schema and the declared return type is the interface, TS rejects `readonly T[]` → `T[]`. In a downstream consumer (`vendor/alchemy-v2-gcp`) this surfaces as ~50 errors in `cloudresourcemanager-v3.ts`, all the same shape — at `getOperations`, `listTagBindings`, `createTagBindings`, `deleteTagBindings`, `searchProjects`, etc. Both `tsc` and `@typescript/native-preview` flag them.

```diff
   case "array":
     if (prop.items) {
-      return `Array<${propertyToTsType(prop.items, allSchemas, renames)}>`;
+      return `ReadonlyArray<${propertyToTsType(prop.items, allSchemas, renames)}>`;
     }
-    return "Array<unknown>";
+    return "ReadonlyArray<unknown>";
```

`ReadonlyArray<T>` is a supertype of `T[]`, so callers building requests with array literals stay compatible:

```ts
// still typechecks
const req: SomeRequest = { tagValues: ["a", "b"] };
```

Only explicit post-construction mutation (`req.tagValues.push(...)`) breaks, which is uncommon in SDK request building. Response code that mutated results was already lying — the schema-derived type was already readonly.

### Scope

Regenerated `cloudresourcemanager-v3.ts` only — that's the file currently exercised by my downstream caller, and it matches the scoping pattern of #258. A full regen via `cd packages/gcp && bun run generate` produces a much larger but mechanical diff (~509 files, all `Array<T>` → `ReadonlyArray<T>` plus oxfmt drift); happy to push that on top if preferred.

### Verification

```
$ cd vendor/alchemy-v2-gcp && bunx tsc --noEmit 2>&1 | grep cloudresourcemanager | wc -l
0
$ bunx --bun @typescript/native-preview --noEmit 2>&1 | grep cloudresourcemanager | wc -l
0
```
